### PR TITLE
feat: improve error handling experience

### DIFF
--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -13,15 +13,38 @@ from pydynox import pydynox_core  # noqa: F401
 # Import Python wrappers
 from .batch_operations import BatchWriter
 from .client import DynamoClient
+from .exceptions import (
+    AccessDeniedError,
+    ConditionCheckFailedError,
+    CredentialsError,
+    PydynoxError,
+    SerializationError,
+    TableNotFoundError,
+    ThrottlingError,
+    TransactionCanceledError,
+    ValidationError,
+)
 from .query import QueryResult
 from .transaction import Transaction
 
 __version__ = "0.1.0"
 
 __all__ = [
+    # Client
     "BatchWriter",
     "DynamoClient",
     "QueryResult",
     "Transaction",
+    # Exceptions
+    "AccessDeniedError",
+    "ConditionCheckFailedError",
+    "CredentialsError",
+    "PydynoxError",
+    "SerializationError",
+    "TableNotFoundError",
+    "ThrottlingError",
+    "TransactionCanceledError",
+    "ValidationError",
+    # Version
     "__version__",
 ]

--- a/python/pydynox/exceptions.py
+++ b/python/pydynox/exceptions.py
@@ -1,0 +1,41 @@
+"""Custom exceptions for pydynox.
+
+These exceptions mirror the error structure from botocore's ClientError,
+making it easy for users familiar with boto3 to handle errors.
+
+Example:
+    >>> from pydynox import DynamoClient
+    >>> from pydynox.exceptions import TableNotFoundError, ValidationError
+    >>>
+    >>> client = DynamoClient()
+    >>> try:
+    ...     client.get_item("nonexistent-table", {"pk": "123"})
+    ... except TableNotFoundError as e:
+    ...     print(f"Table not found: {e}")
+"""
+
+# Re-export exceptions from Rust core
+from pydynox import pydynox_core
+
+# These are the actual exception classes from Rust
+PydynoxError = pydynox_core.PydynoxError
+TableNotFoundError = pydynox_core.TableNotFoundError
+ValidationError = pydynox_core.ValidationError
+ConditionCheckFailedError = pydynox_core.ConditionCheckFailedError
+TransactionCanceledError = pydynox_core.TransactionCanceledError
+ThrottlingError = pydynox_core.ThrottlingError
+AccessDeniedError = pydynox_core.AccessDeniedError
+CredentialsError = pydynox_core.CredentialsError
+SerializationError = pydynox_core.SerializationError
+
+__all__ = [
+    "PydynoxError",
+    "TableNotFoundError",
+    "ValidationError",
+    "ConditionCheckFailedError",
+    "TransactionCanceledError",
+    "ThrottlingError",
+    "AccessDeniedError",
+    "CredentialsError",
+    "SerializationError",
+]

--- a/src/basic_operations.rs
+++ b/src/basic_operations.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
+use crate::errors::map_sdk_error;
 use crate::serialization::{dynamo_to_py, py_to_dynamo};
 
 /// Convert a Python dict to a HashMap of DynamoDB AttributeValues.
@@ -294,25 +295,7 @@ pub fn put_item(
 
     match result {
         Ok(_) => Ok(()),
-        Err(e) => {
-            let err_msg = e.to_string();
-            if err_msg.contains("ResourceNotFoundException") {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Table not found: {}",
-                    table
-                )))
-            } else if err_msg.contains("ValidationException") {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Validation error: {}",
-                    err_msg
-                )))
-            } else {
-                Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Failed to put item: {}",
-                    err_msg
-                )))
-            }
-        }
+        Err(e) => Err(map_sdk_error(e, Some(table))),
     }
 }
 
@@ -347,20 +330,7 @@ pub fn get_item(
                 Ok(None)
             }
         }
-        Err(e) => {
-            let err_msg = e.to_string();
-            if err_msg.contains("ResourceNotFoundException") {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Table not found: {}",
-                    table
-                )))
-            } else {
-                Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Failed to get item: {}",
-                    err_msg
-                )))
-            }
-        }
+        Err(e) => Err(map_sdk_error(e, Some(table))),
     }
 }
 
@@ -409,34 +379,7 @@ pub fn delete_item(
 
     match result {
         Ok(_) => Ok(()),
-        Err(e) => {
-            let err_msg = e.to_string();
-            if err_msg.contains("ConditionalCheckFailedException")
-                || err_msg.contains("ConditionalCheckFailed")
-                || err_msg.contains("conditional request failed")
-            {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "Condition check failed: the condition expression evaluated to false",
-                ))
-            } else if err_msg.contains("ResourceNotFoundException")
-                || err_msg.contains("resource not found")
-            {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Table not found: {}",
-                    table
-                )))
-            } else if err_msg.contains("ValidationException") {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Validation error: {}",
-                    err_msg
-                )))
-            } else {
-                Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Failed to delete item: {}",
-                    err_msg
-                )))
-            }
-        }
+        Err(e) => Err(map_sdk_error(e, Some(table))),
     }
 }
 
@@ -505,34 +448,7 @@ pub fn update_item(
 
     match result {
         Ok(_) => Ok(()),
-        Err(e) => {
-            let err_msg = e.to_string();
-            if err_msg.contains("ConditionalCheckFailedException")
-                || err_msg.contains("ConditionalCheckFailed")
-                || err_msg.contains("conditional request failed")
-            {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                    "Condition check failed: the condition expression evaluated to false",
-                ))
-            } else if err_msg.contains("ResourceNotFoundException")
-                || err_msg.contains("resource not found")
-            {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Table not found: {}",
-                    table
-                )))
-            } else if err_msg.contains("ValidationException") {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Validation error: {}",
-                    err_msg
-                )))
-            } else {
-                Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Failed to update item: {}",
-                    err_msg
-                )))
-            }
-        }
+        Err(e) => Err(map_sdk_error(e, Some(table))),
     }
 }
 
@@ -677,26 +593,6 @@ pub fn query(
                 last_evaluated_key: last_key,
             })
         }
-        Err(e) => {
-            let err_msg = e.to_string();
-            if err_msg.contains("ResourceNotFoundException")
-                || err_msg.contains("resource not found")
-            {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Table not found: {}",
-                    table
-                )))
-            } else if err_msg.contains("ValidationException") {
-                Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Validation error: {}",
-                    err_msg
-                )))
-            } else {
-                Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Failed to query: {}",
-                    err_msg
-                )))
-            }
-        }
+        Err(e) => Err(map_sdk_error(e, Some(table))),
     }
 }

--- a/src/batch_operations.rs
+++ b/src/batch_operations.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 
 use crate::basic_operations::{attribute_values_to_py_dict, py_dict_to_attribute_values};
+use crate::errors::map_sdk_error;
 
 /// Maximum items per batch write request (DynamoDB limit).
 const BATCH_WRITE_MAX_ITEMS: usize = 25;
@@ -135,25 +136,7 @@ pub fn batch_write(
                     pending.clear();
                 }
                 Err(e) => {
-                    let err_msg = e.to_string();
-                    if err_msg.contains("ResourceNotFoundException")
-                        || err_msg.contains("resource not found")
-                    {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                            "Table not found: {}",
-                            table
-                        )));
-                    } else if err_msg.contains("ValidationException") {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                            "Validation error: {}",
-                            err_msg
-                        )));
-                    } else {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "Failed to batch write: {}",
-                            err_msg
-                        )));
-                    }
+                    return Err(map_sdk_error(e, Some(table)));
                 }
             }
         }
@@ -271,25 +254,7 @@ pub fn batch_get(
                     pending.clear();
                 }
                 Err(e) => {
-                    let err_msg = e.to_string();
-                    if err_msg.contains("ResourceNotFoundException")
-                        || err_msg.contains("resource not found")
-                    {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                            "Table not found: {}",
-                            table
-                        )));
-                    } else if err_msg.contains("ValidationException") {
-                        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                            "Validation error: {}",
-                            err_msg
-                        )));
-                    } else {
-                        return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "Failed to batch get: {}",
-                            err_msg
-                        )));
-                    }
+                    return Err(map_sdk_error(e, Some(table)));
                 }
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,61 +1,219 @@
-//! Error types for pydyno.
+//! Error types for pydynox.
 //!
-//! This module defines the error types used throughout pydyno.
-//! All errors are converted to Python exceptions via PyO3.
+//! This module maps AWS SDK errors to Python exceptions.
+//! Uses a single mapping function to avoid code duplication.
 
+use aws_sdk_dynamodb::error::SdkError;
+use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
-use thiserror::Error;
 
-/// Error types for pydyno operations.
-///
-/// These errors are automatically converted to Python exceptions
-/// when returned from PyO3 functions.
-#[derive(Error, Debug)]
-pub enum PydynoError {
-    /// General DynamoDB error from the AWS SDK.
-    #[error("DynamoDB error: {0}")]
-    DynamoDb(String),
+// Create Python exception classes
+create_exception!(pydynox, PydynoxError, PyException);
+create_exception!(pydynox, TableNotFoundError, PydynoxError);
+create_exception!(pydynox, ValidationError, PydynoxError);
+create_exception!(pydynox, ConditionCheckFailedError, PydynoxError);
+create_exception!(pydynox, TransactionCanceledError, PydynoxError);
+create_exception!(pydynox, ThrottlingError, PydynoxError);
+create_exception!(pydynox, AccessDeniedError, PydynoxError);
+create_exception!(pydynox, CredentialsError, PydynoxError);
+create_exception!(pydynox, SerializationError, PydynoxError);
 
-    /// Condition check failed (e.g., optimistic locking failure).
-    ///
-    /// Raised when a conditional write/delete fails because
-    /// the condition expression evaluated to false.
-    #[error("Condition check failed: {0}")]
-    ConditionCheckFailed(String),
-
-    /// Validation error for a specific field.
-    ///
-    /// Raised when model validation fails before sending to DynamoDB.
-    #[error("Validation error on field '{field}': {message}")]
-    Validation {
-        /// The field that failed validation.
-        field: String,
-        /// Description of the validation error.
-        message: String,
-    },
-
-    /// Table not found in DynamoDB.
-    #[error("Table not found: {0}")]
-    TableNotFound(String),
-
-    /// Transaction failed.
-    ///
-    /// Raised when a TransactWriteItems operation fails.
-    /// All operations in the transaction are rolled back.
-    #[error("Transaction failed: {0}")]
-    Transaction(String),
-
-    /// Serialization/deserialization error.
-    ///
-    /// Raised when converting between Python and DynamoDB types fails.
-    #[error("Serialization error: {0}")]
-    Serialization(String),
+/// Register exception classes with the Python module.
+pub fn register_exceptions(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("PydynoxError", m.py().get_type::<PydynoxError>())?;
+    m.add(
+        "TableNotFoundError",
+        m.py().get_type::<TableNotFoundError>(),
+    )?;
+    m.add("ValidationError", m.py().get_type::<ValidationError>())?;
+    m.add(
+        "ConditionCheckFailedError",
+        m.py().get_type::<ConditionCheckFailedError>(),
+    )?;
+    m.add(
+        "TransactionCanceledError",
+        m.py().get_type::<TransactionCanceledError>(),
+    )?;
+    m.add("ThrottlingError", m.py().get_type::<ThrottlingError>())?;
+    m.add("AccessDeniedError", m.py().get_type::<AccessDeniedError>())?;
+    m.add("CredentialsError", m.py().get_type::<CredentialsError>())?;
+    m.add(
+        "SerializationError",
+        m.py().get_type::<SerializationError>(),
+    )?;
+    Ok(())
 }
 
-impl From<PydynoError> for PyErr {
-    /// Convert a PydynoError to a Python exception.
-    fn from(err: PydynoError) -> PyErr {
-        PyException::new_err(err.to_string())
+/// Map any AWS SDK error to the appropriate Python exception.
+///
+/// This is the single entry point for error handling. All operations
+/// should use this function to convert SDK errors to Python exceptions.
+pub fn map_sdk_error<E, R>(err: SdkError<E, R>, table: Option<&str>) -> PyErr
+where
+    E: std::fmt::Debug + std::fmt::Display,
+    R: std::fmt::Debug,
+{
+    // Get both display and debug representations
+    let err_display = err.to_string();
+    let err_debug = format!("{:?}", err);
+
+    // Check for credential errors first (these are dispatch failures, not service errors)
+    if err_debug.contains("NoCredentialsError")
+        || err_debug.contains("no credentials")
+        || err_debug.contains("No credentials")
+        || err_debug.contains("CredentialsError")
+        || err_debug.contains("failed to load credentials")
+    {
+        return CredentialsError::new_err(
+            "No AWS credentials found. Configure credentials via environment variables \
+            (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY), AWS profile, or IAM role.",
+        );
     }
+
+    if err_debug.contains("InvalidAccessKeyId") || err_debug.contains("invalid access key") {
+        return CredentialsError::new_err("Invalid AWS access key ID. Check your credentials.");
+    }
+
+    if err_debug.contains("SignatureDoesNotMatch") {
+        return CredentialsError::new_err("AWS signature mismatch. Check your secret access key.");
+    }
+
+    if err_debug.contains("ExpiredToken") || err_debug.contains("expired") {
+        return CredentialsError::new_err(
+            "AWS credentials have expired. Refresh your session token.",
+        );
+    }
+
+    // Extract error code from the debug string
+    let error_code = extract_error_code(&err_debug);
+
+    // Map based on error code
+    match error_code.as_deref() {
+        Some("ResourceNotFoundException") => {
+            let msg = if let Some(t) = table {
+                format!("Table '{}' not found", t)
+            } else {
+                "Resource not found".to_string()
+            };
+            TableNotFoundError::new_err(msg)
+        }
+        Some("ValidationException") => {
+            // Try to extract the actual validation message
+            let msg = extract_message(&err_debug).unwrap_or(err_display);
+            ValidationError::new_err(msg)
+        }
+        Some("ConditionalCheckFailedException") => {
+            ConditionCheckFailedError::new_err("The condition expression evaluated to false")
+        }
+        Some("TransactionCanceledException") => {
+            let reasons = extract_cancellation_reasons(&err_debug);
+            let msg = if reasons.is_empty() {
+                "Transaction was canceled".to_string()
+            } else {
+                format!("Transaction was canceled: {}", reasons.join("; "))
+            };
+            TransactionCanceledError::new_err(msg)
+        }
+        Some("ProvisionedThroughputExceededException") | Some("ThrottlingException") => {
+            ThrottlingError::new_err("Request rate too high. Try again with exponential backoff.")
+        }
+        Some("AccessDeniedException") => {
+            let msg = extract_message(&err_debug)
+                .unwrap_or_else(|| "Access denied. Check your IAM permissions.".to_string());
+            AccessDeniedError::new_err(msg)
+        }
+        Some("UnrecognizedClientException") => {
+            CredentialsError::new_err("Invalid AWS credentials. Check your access key and secret.")
+        }
+        Some("ItemCollectionSizeLimitExceededException") => {
+            ValidationError::new_err("Item collection size limit exceeded")
+        }
+        Some("RequestLimitExceeded") => {
+            ThrottlingError::new_err("Request limit exceeded. Try again later.")
+        }
+        _ => {
+            // For unknown errors, include as much detail as possible
+            let msg = extract_message(&err_debug).unwrap_or_else(|| {
+                // If we can't extract a message, use the debug string but clean it up
+                if err_display == "service error" {
+                    // The display is useless, use debug but truncate if too long
+                    let clean = err_debug.replace('\n', " ").replace("  ", " ");
+                    if clean.len() > 500 {
+                        format!("{}...", &clean[..500])
+                    } else {
+                        clean
+                    }
+                } else {
+                    err_display
+                }
+            });
+            PydynoxError::new_err(msg)
+        }
+    }
+}
+
+/// Extract error code from AWS SDK error debug string.
+fn extract_error_code(err_str: &str) -> Option<String> {
+    // Look for patterns like: code: Some("ResourceNotFoundException")
+    if let Some(start) = err_str.find("code: Some(\"") {
+        let rest = &err_str[start + 12..];
+        if let Some(end) = rest.find('"') {
+            return Some(rest[..end].to_string());
+        }
+    }
+
+    // Also check for error type names in the string
+    let known_errors = [
+        "ResourceNotFoundException",
+        "ValidationException",
+        "ConditionalCheckFailedException",
+        "TransactionCanceledException",
+        "ProvisionedThroughputExceededException",
+        "ThrottlingException",
+        "AccessDeniedException",
+        "UnrecognizedClientException",
+        "ItemCollectionSizeLimitExceededException",
+        "RequestLimitExceeded",
+    ];
+
+    for error in known_errors {
+        if err_str.contains(error) {
+            return Some(error.to_string());
+        }
+    }
+
+    None
+}
+
+/// Extract the error message from AWS SDK error debug string.
+fn extract_message(err_str: &str) -> Option<String> {
+    // Look for patterns like: message: Some("The actual error message")
+    if let Some(start) = err_str.find("message: Some(\"") {
+        let rest = &err_str[start + 15..];
+        if let Some(end) = rest.find('"') {
+            return Some(rest[..end].to_string());
+        }
+    }
+    None
+}
+
+/// Extract cancellation reasons from transaction error.
+fn extract_cancellation_reasons(err_str: &str) -> Vec<String> {
+    let mut reasons = Vec::new();
+
+    if err_str.contains("ConditionalCheckFailed") {
+        reasons.push("Condition check failed".to_string());
+    }
+    if err_str.contains("ItemCollectionSizeLimitExceeded") {
+        reasons.push("Item collection size limit exceeded".to_string());
+    }
+    if err_str.contains("TransactionConflict") {
+        reasons.push("Transaction conflict".to_string());
+    }
+    if err_str.contains("ProvisionedThroughputExceeded") {
+        reasons.push("Throughput exceeded".to_string());
+    }
+
+    reasons
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,5 +35,8 @@ fn pydynox_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(item_to_dynamo, m)?)?;
     m.add_function(wrap_pyfunction!(item_from_dynamo, m)?)?;
 
+    // Register exception classes
+    errors::register_exceptions(m)?;
+
     Ok(())
 }

--- a/tests/integration/operations/test_transaction.py
+++ b/tests/integration/operations/test_transaction.py
@@ -6,6 +6,7 @@ Requirements: 9.3, 9.4
 
 import pytest
 from pydynox import Transaction
+from pydynox.exceptions import PydynoxError, TransactionCanceledError
 
 
 def test_transact_write_puts_multiple_items(dynamo):
@@ -119,8 +120,8 @@ def test_transact_write_rollback_on_condition_failure(dynamo):
         },
     ]
 
-    # Transaction should fail (ValueError or RuntimeError depending on error details)
-    with pytest.raises((ValueError, RuntimeError)):
+    # Transaction should fail
+    with pytest.raises((TransactionCanceledError, PydynoxError)):
         dynamo.transact_write(operations)
 
     # Verify the put was rolled back - original value should remain

--- a/tests/integration/operations/test_update_item.py
+++ b/tests/integration/operations/test_update_item.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from pydynox.exceptions import ConditionCheckFailedError, TableNotFoundError
+
 
 def test_update_item_simple_set(dynamo):
     """Test simple update that sets field values."""
@@ -126,7 +128,7 @@ def test_update_item_with_condition_fails(dynamo):
     item = {"pk": "USER#UPD5", "sk": "PROFILE", "status": "active"}
     dynamo.put_item("test_table", item)
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(ConditionCheckFailedError):
         dynamo.update_item(
             "test_table",
             {"pk": "USER#UPD5", "sk": "PROFILE"},
@@ -135,8 +137,6 @@ def test_update_item_with_condition_fails(dynamo):
             expression_attribute_names={"#s": "status"},
             expression_attribute_values={":expected": "pending"},
         )
-
-    assert exc_info.type in (ValueError, RuntimeError)
 
     result = dynamo.get_item("test_table", {"pk": "USER#UPD5", "sk": "PROFILE"})
     assert result["status"] == "active"
@@ -182,7 +182,7 @@ def test_update_item_nonexistent_creates_item(dynamo):
 
 def test_update_item_table_not_found(dynamo):
     """Test update on non-existent table raises error."""
-    with pytest.raises((ValueError, RuntimeError)):
+    with pytest.raises(TableNotFoundError):
         dynamo.update_item(
             "nonexistent_table",
             {"pk": "X", "sk": "Y"},


### PR DESCRIPTION
Map AWS SDK errors to specific Python exceptions with useful messages.

- Add `map_sdk_error()` to centralize error handling
- New exceptions: `TableNotFoundError`, `ConditionCheckFailedError`, `ValidationError`, `CredentialsError`, `ThrottlingError`, `AccessDeniedError`, `TransactionCanceledError`
- Extract actual error messages instead of showing "service error"
- Simplify error handling code in all operations

Closes #16
