### PR TITLE
chore: rename DynamoClient to DynamoDBClient

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,9 +14,9 @@ A clear description of the bug.
 
 ```python
 # Minimal code to reproduce the issue
-from pydynox import DynamoClient
+from pydynox import DynamoDBClient
 
-client = DynamoClient()
+client = DynamoDBClient()
 # ...
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ pydynox/
 │   └── transaction_operations.rs # transact_write
 ├── python/pydynox/        # Python wrappers
 │   ├── __init__.py        # Public API exports
-│   ├── client.py          # DynamoClient wrapper
+│   ├── client.py          # DynamoDBClient wrapper
 │   ├── query.py           # QueryResult wrapper
 │   └── transaction.py     # Transaction wrapper
 ├── tests/
@@ -98,7 +98,7 @@ Tests use moto server (DynamoDB mock). The conftest.py starts it automatically.
 from pydynox import pydynox_core
 
 # Use Rust classes
-client = pydynox_core.DynamoClient(...)
+client = pydynox_core.DynamoDBClient(...)
 ```
 
 Never import from `_rust` or other private modules.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "pydynox"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydynox"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Leandro Cavalcante Damascena <leandro.damascena@gmail.com>"]
 description = "A fast DynamoDB ORM for Python with a Rust core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pydynox"
-version = "0.1.0"
+version = "0.1.1"
 description = "A fast DynamoDB ORM for Python with a Rust core"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -1,8 +1,8 @@
 """pydynox - A fast DynamoDB client for Python with a Rust core.
 
 Example:
-    >>> from pydynox import DynamoClient
-    >>> client = DynamoClient(region="us-east-1")
+    >>> from pydynox import DynamoDBClient
+    >>> client = DynamoDBClient(region="us-east-1")
     >>> client.ping()
     True
 """
@@ -12,7 +12,7 @@ from pydynox import pydynox_core  # noqa: F401
 
 # Import Python wrappers
 from .batch_operations import BatchWriter
-from .client import DynamoClient
+from .client import DynamoDBClient
 from .exceptions import (
     AccessDeniedError,
     ConditionCheckFailedError,
@@ -27,12 +27,12 @@ from .exceptions import (
 from .query import QueryResult
 from .transaction import Transaction
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     # Client
     "BatchWriter",
-    "DynamoClient",
+    "DynamoDBClient",
     "QueryResult",
     "Transaction",
     # Exceptions

--- a/python/pydynox/batch_operations.py
+++ b/python/pydynox/batch_operations.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from pydynox.client import DynamoClient
+    from pydynox.client import DynamoDBClient
 
 
 class BatchWriter:
@@ -20,11 +20,11 @@ class BatchWriter:
         ...     batch.delete({"pk": "USER#3", "sk": "PROFILE"})
     """
 
-    def __init__(self, client: "DynamoClient", table: str):
+    def __init__(self, client: "DynamoDBClient", table: str):
         """Create a BatchWriter.
 
         Args:
-            client: The DynamoClient to use.
+            client: The DynamoDBClient to use.
             table: The table name.
         """
         self._client = client

--- a/python/pydynox/client.py
+++ b/python/pydynox/client.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 from .query import QueryResult
 
 
-class DynamoClient:
+class DynamoDBClient:
     """DynamoDB client with flexible credential configuration.
 
     Supports multiple credential sources in order of priority:
@@ -16,20 +16,20 @@ class DynamoClient:
 
     Example:
         >>> # Use environment variables
-        >>> client = DynamoClient()
+        >>> client = DynamoDBClient()
 
         >>> # Use hardcoded credentials
-        >>> client = DynamoClient(
+        >>> client = DynamoDBClient(
         ...     access_key="AKIA...",
         ...     secret_key="secret...",
         ...     region="us-east-1"
         ... )
 
         >>> # Use AWS profile
-        >>> client = DynamoClient(profile="my-profile")
+        >>> client = DynamoDBClient(profile="my-profile")
 
         >>> # Use local endpoint (localstack, moto)
-        >>> client = DynamoClient(endpoint_url="http://localhost:4566")
+        >>> client = DynamoDBClient(endpoint_url="http://localhost:4566")
     """
 
     def __init__(
@@ -43,7 +43,7 @@ class DynamoClient:
     ):
         from pydynox import pydynox_core
 
-        self._client = pydynox_core.DynamoClient(
+        self._client = pydynox_core.DynamoDBClient(
             region=region,
             access_key=access_key,
             secret_key=secret_key,

--- a/python/pydynox/exceptions.py
+++ b/python/pydynox/exceptions.py
@@ -4,10 +4,10 @@ These exceptions mirror the error structure from botocore's ClientError,
 making it easy for users familiar with boto3 to handle errors.
 
 Example:
-    >>> from pydynox import DynamoClient
+    >>> from pydynox import DynamoDBClient
     >>> from pydynox.exceptions import TableNotFoundError, ValidationError
     >>>
-    >>> client = DynamoClient()
+    >>> client = DynamoDBClient()
     >>> try:
     ...     client.get_item("nonexistent-table", {"pk": "123"})
     ... except TableNotFoundError as e:

--- a/python/pydynox/transaction.py
+++ b/python/pydynox/transaction.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
-    from pydynox.client import DynamoClient
+    from pydynox.client import DynamoDBClient
 
 
 class Transaction:
@@ -37,11 +37,11 @@ class Transaction:
         ...     )
     """
 
-    def __init__(self, client: "DynamoClient"):
+    def __init__(self, client: "DynamoDBClient"):
         """Create a Transaction.
 
         Args:
-            client: The DynamoClient to use.
+            client: The DynamoDBClient to use.
         """
         self._client = client
         self._operations: list[dict[str, Any]] = []

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,8 @@
 //! - Environment variables
 //! - Hardcoded credentials
 //! - AWS profiles
+//!
+//! The main struct is [`DynamoDBClient`], which wraps the AWS SDK client.
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_config::profile::ProfileFileCredentialsProvider;
@@ -31,30 +33,30 @@ use crate::transaction_operations;
 ///
 /// ```python
 /// # Use environment variables
-/// client = DynamoClient()
+/// client = DynamoDBClient()
 ///
 /// # Use hardcoded credentials
-/// client = DynamoClient(
+/// client = DynamoDBClient(
 ///     access_key="AKIA...",
 ///     secret_key="secret...",
 ///     region="us-east-1"
 /// )
 ///
 /// # Use AWS profile
-/// client = DynamoClient(profile="my-profile")
+/// client = DynamoDBClient(profile="my-profile")
 ///
 /// # Use local endpoint (localstack, moto)
-/// client = DynamoClient(endpoint_url="http://localhost:4566")
+/// client = DynamoDBClient(endpoint_url="http://localhost:4566")
 /// ```
 #[pyclass]
-pub struct DynamoClient {
+pub struct DynamoDBClient {
     client: Client,
     runtime: Arc<Runtime>,
     region: String,
 }
 
 #[pymethods]
-impl DynamoClient {
+impl DynamoDBClient {
     /// Create a new DynamoDB client.
     ///
     /// # Arguments
@@ -68,7 +70,7 @@ impl DynamoClient {
     ///
     /// # Returns
     ///
-    /// A new DynamoClient instance.
+    /// A new DynamoDBClient instance.
     #[new]
     #[pyo3(signature = (region=None, access_key=None, secret_key=None, session_token=None, profile=None, endpoint_url=None))]
     pub fn new(
@@ -111,7 +113,7 @@ impl DynamoClient {
                 .unwrap_or_else(|_| "us-east-1".to_string())
         });
 
-        Ok(DynamoClient {
+        Ok(DynamoDBClient {
             client,
             runtime: Arc::new(runtime),
             region: final_region,
@@ -150,7 +152,7 @@ impl DynamoClient {
     /// # Examples
     ///
     /// ```python
-    /// client = DynamoClient()
+    /// client = DynamoDBClient()
     /// client.put_item("users", {"pk": "USER#123", "name": "John", "age": 30})
     /// ```
     pub fn put_item(&self, py: Python<'_>, table: &str, item: &Bound<'_, PyDict>) -> PyResult<()> {
@@ -171,7 +173,7 @@ impl DynamoClient {
     /// # Examples
     ///
     /// ```python
-    /// client = DynamoClient()
+    /// client = DynamoDBClient()
     /// item = client.get_item("users", {"pk": "USER#123"})
     /// if item:
     ///     print(item["name"])  # "John"
@@ -202,7 +204,7 @@ impl DynamoClient {
     /// # Examples
     ///
     /// ```python
-    /// client = DynamoClient()
+    /// client = DynamoDBClient()
     ///
     /// # Simple delete
     /// client.delete_item("users", {"pk": "USER#123"})
@@ -260,7 +262,7 @@ impl DynamoClient {
     /// # Examples
     ///
     /// ```python
-    /// client = DynamoClient()
+    /// client = DynamoDBClient()
     ///
     /// # Simple update - set fields
     /// client.update_item("users", {"pk": "USER#123"}, updates={"name": "John", "age": 31})
@@ -381,7 +383,7 @@ impl DynamoClient {
     /// # Examples
     ///
     /// ```python
-    /// client = DynamoClient()
+    /// client = DynamoDBClient()
     ///
     /// # Batch put items
     /// client.batch_write(
@@ -446,7 +448,7 @@ impl DynamoClient {
     /// # Examples
     ///
     /// ```python
-    /// client = DynamoClient()
+    /// client = DynamoDBClient()
     ///
     /// # Batch get items
     /// keys = [
@@ -486,7 +488,7 @@ impl DynamoClient {
     /// # Examples
     ///
     /// ```python
-    /// client = DynamoClient()
+    /// client = DynamoDBClient()
     ///
     /// # Transfer money between accounts atomically
     /// client.transact_write([

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod errors;
 mod serialization;
 mod transaction_operations;
 
-use client::DynamoClient;
+use client::DynamoDBClient;
 use serialization::{dynamo_to_py_py, item_from_dynamo, item_to_dynamo, py_to_dynamo_py};
 
 /// Python module for pydynox's Rust core.
@@ -27,7 +27,7 @@ use serialization::{dynamo_to_py_py, item_from_dynamo, item_to_dynamo, py_to_dyn
 /// the low-level DynamoDB client implementation.
 #[pymodule]
 fn pydynox_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<DynamoClient>()?;
+    m.add_class::<DynamoDBClient>()?;
 
     // Serialization functions
     m.add_function(wrap_pyfunction!(py_to_dynamo_py, m)?)?;


### PR DESCRIPTION
Renamed `DynamoClient` to `DynamoDBClient` to match AWS service naming.

Other changes:
- Fixed Windows test cleanup using `taskkill /F /T /PID`
- Bumped version to 0.1.1

Closes #20
