### PR TITLE
feat: add model base class with ORM-style CRUD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "base64",
+ "once_cell",
  "pyo3",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 base64 = "0.22"
+once_cell = "1.20"
 
 [dev-dependencies]
 pyo3 = { version = "0.27", features = ["auto-initialize"] }

--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -5,12 +5,30 @@ Example:
     >>> client = DynamoDBClient(region="us-east-1")
     >>> client.ping()
     True
+
+    >>> from pydynox import Model, StringAttribute, NumberAttribute
+    >>> class User(Model):
+    ...     class Meta:
+    ...         table = "users"
+    ...     pk = StringAttribute(hash_key=True)
+    ...     name = StringAttribute()
+    >>> user = User(pk="USER#1", name="John")
+    >>> user.save()
 """
 
 # Import from Rust core
 from pydynox import pydynox_core  # noqa: F401
 
 # Import Python wrappers
+from .attributes import (
+    Attribute,
+    BinaryAttribute,
+    BooleanAttribute,
+    ListAttribute,
+    MapAttribute,
+    NumberAttribute,
+    StringAttribute,
+)
 from .batch_operations import BatchWriter
 from .client import DynamoDBClient
 from .exceptions import (
@@ -24,6 +42,7 @@ from .exceptions import (
     TransactionCanceledError,
     ValidationError,
 )
+from .model import Model
 from .query import QueryResult
 from .transaction import Transaction
 
@@ -35,6 +54,15 @@ __all__ = [
     "DynamoDBClient",
     "QueryResult",
     "Transaction",
+    # Model ORM
+    "Model",
+    "Attribute",
+    "StringAttribute",
+    "NumberAttribute",
+    "BooleanAttribute",
+    "BinaryAttribute",
+    "ListAttribute",
+    "MapAttribute",
     # Exceptions
     "AccessDeniedError",
     "ConditionCheckFailedError",

--- a/python/pydynox/attributes.py
+++ b/python/pydynox/attributes.py
@@ -1,0 +1,90 @@
+"""Attribute types for Model definitions."""
+
+from typing import Any, Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class Attribute(Generic[T]):
+    """Base attribute class for Model fields.
+
+    Attributes define the schema of a DynamoDB item. They can be marked
+    as hash_key or range_key to define the table's primary key.
+
+    Example:
+        >>> class User(Model):
+        ...     pk = StringAttribute(hash_key=True)
+        ...     sk = StringAttribute(range_key=True)
+        ...     name = StringAttribute()
+        ...     age = NumberAttribute()
+    """
+
+    attr_type: str = "S"  # Default to string
+
+    def __init__(
+        self,
+        hash_key: bool = False,
+        range_key: bool = False,
+        default: Optional[T] = None,
+        null: bool = True,
+    ):
+        """Create an attribute.
+
+        Args:
+            hash_key: True if this is the partition key.
+            range_key: True if this is the sort key.
+            default: Default value when not provided.
+            null: Whether None is allowed.
+        """
+        self.hash_key = hash_key
+        self.range_key = range_key
+        self.default = default
+        self.null = null
+        self.attr_name: Optional[str] = None
+
+    def serialize(self, value: T) -> Any:
+        """Convert Python value to DynamoDB format."""
+        return value
+
+    def deserialize(self, value: Any) -> T:
+        """Convert DynamoDB value to Python format."""
+        return value
+
+
+class StringAttribute(Attribute[str]):
+    """String attribute (DynamoDB type S)."""
+
+    attr_type = "S"
+
+
+class NumberAttribute(Attribute[float]):
+    """Number attribute (DynamoDB type N).
+
+    Stores both int and float values.
+    """
+
+    attr_type = "N"
+
+
+class BooleanAttribute(Attribute[bool]):
+    """Boolean attribute (DynamoDB type BOOL)."""
+
+    attr_type = "BOOL"
+
+
+class BinaryAttribute(Attribute[bytes]):
+    """Binary attribute (DynamoDB type B)."""
+
+    attr_type = "B"
+
+
+class ListAttribute(Attribute[list]):
+    """List attribute (DynamoDB type L)."""
+
+    attr_type = "L"
+
+
+class MapAttribute(Attribute[dict]):
+    """Map attribute (DynamoDB type M)."""
+
+    attr_type = "M"

--- a/python/pydynox/model.py
+++ b/python/pydynox/model.py
@@ -1,0 +1,273 @@
+"""Model base class with ORM-style CRUD operations."""
+
+from typing import Any, ClassVar, Optional, Type, TypeVar
+
+from .attributes import Attribute
+from .client import DynamoDBClient
+
+M = TypeVar("M", bound="Model")
+
+
+class ModelMeta(type):
+    """Metaclass that collects attributes and builds schema."""
+
+    def __new__(mcs, name: str, bases: tuple[type, ...], namespace: dict[str, Any]) -> "ModelMeta":
+        # Collect attributes from parent classes
+        attributes: dict[str, Attribute] = {}
+        hash_key: Optional[str] = None
+        range_key: Optional[str] = None
+
+        for base in bases:
+            if hasattr(base, "_attributes"):
+                attributes.update(base._attributes)
+            if hasattr(base, "_hash_key") and base._hash_key:
+                hash_key = base._hash_key
+            if hasattr(base, "_range_key") and base._range_key:
+                range_key = base._range_key
+
+        # Collect attributes from this class
+        for attr_name, attr_value in namespace.items():
+            if isinstance(attr_value, Attribute):
+                attr_value.attr_name = attr_name
+                attributes[attr_name] = attr_value
+
+                if attr_value.hash_key:
+                    hash_key = attr_name
+                if attr_value.range_key:
+                    range_key = attr_name
+
+        # Create the class
+        cls = super().__new__(mcs, name, bases, namespace)
+
+        # Store metadata
+        cls._attributes = attributes
+        cls._hash_key = hash_key
+        cls._range_key = range_key
+
+        return cls
+
+
+class Model(metaclass=ModelMeta):
+    """Base class for DynamoDB models with ORM-style CRUD.
+
+    Define your model by subclassing and adding attributes:
+
+    Example:
+        >>> from pydynox import Model, StringAttribute, NumberAttribute
+        >>>
+        >>> class User(Model):
+        ...     class Meta:
+        ...         table = "users"
+        ...         region = "us-east-1"
+        ...
+        ...     pk = StringAttribute(hash_key=True)
+        ...     sk = StringAttribute(range_key=True)
+        ...     name = StringAttribute()
+        ...     age = NumberAttribute()
+        >>>
+        >>> # Create and save
+        >>> user = User(pk="USER#123", sk="PROFILE", name="John", age=30)
+        >>> user.save()
+        >>>
+        >>> # Get by key
+        >>> user = User.get(pk="USER#123", sk="PROFILE")
+        >>> print(user.name)
+        >>>
+        >>> # Update
+        >>> user.name = "Jane"
+        >>> user.save()
+        >>>
+        >>> # Delete
+        >>> user.delete()
+    """
+
+    _attributes: ClassVar[dict[str, Attribute]]
+    _hash_key: ClassVar[Optional[str]]
+    _range_key: ClassVar[Optional[str]]
+    _client: ClassVar[Optional[DynamoDBClient]] = None
+
+    class Meta:
+        """Model configuration.
+
+        Attributes:
+            table: DynamoDB table name (required).
+            region: AWS region (optional, uses default if not set).
+            endpoint_url: Custom endpoint (optional, for local testing).
+        """
+
+        table: str
+        region: Optional[str] = None
+        endpoint_url: Optional[str] = None
+
+    def __init__(self, **kwargs: Any):
+        """Create a model instance.
+
+        Args:
+            **kwargs: Attribute values.
+        """
+        for attr_name, attr in self._attributes.items():
+            if attr_name in kwargs:
+                setattr(self, attr_name, kwargs[attr_name])
+            elif attr.default is not None:
+                setattr(self, attr_name, attr.default)
+            elif not attr.null:
+                raise ValueError(f"Attribute '{attr_name}' is required")
+            else:
+                setattr(self, attr_name, None)
+
+    @classmethod
+    def _get_client(cls) -> DynamoDBClient:
+        """Get or create the DynamoDB client."""
+        if cls._client is None:
+            meta = cls.Meta
+            cls._client = DynamoDBClient(
+                region=getattr(meta, "region", None),
+                endpoint_url=getattr(meta, "endpoint_url", None),
+            )
+        return cls._client
+
+    @classmethod
+    def _get_table(cls) -> str:
+        """Get the table name from Meta."""
+        if not hasattr(cls.Meta, "table"):
+            raise ValueError(f"Model {cls.__name__} must define Meta.table")
+        return cls.Meta.table
+
+    @classmethod
+    def get(cls: Type[M], **keys: Any) -> Optional[M]:
+        """Get an item from DynamoDB by its key.
+
+        Args:
+            **keys: The key attributes (hash_key and optional range_key).
+
+        Returns:
+            The model instance if found, None otherwise.
+
+        Example:
+            >>> user = User.get(pk="USER#123", sk="PROFILE")
+            >>> if user:
+            ...     print(user.name)
+        """
+        client = cls._get_client()
+        table = cls._get_table()
+
+        item = client.get_item(table, keys)
+        if item is None:
+            return None
+
+        return cls.from_dict(item)
+
+    def save(self, condition: Optional[str] = None) -> None:
+        """Save the model to DynamoDB.
+
+        Creates a new item or replaces an existing one.
+
+        Args:
+            condition: Optional condition expression.
+
+        Example:
+            >>> user = User(pk="USER#123", sk="PROFILE", name="John")
+            >>> user.save()
+        """
+        client = self._get_client()
+        table = self._get_table()
+        item = self.to_dict()
+
+        # TODO: Add condition expression support when put_item supports it
+        client.put_item(table, item)
+
+    def delete(self, condition: Optional[str] = None) -> None:
+        """Delete the model from DynamoDB.
+
+        Args:
+            condition: Optional condition expression.
+
+        Example:
+            >>> user = User.get(pk="USER#123", sk="PROFILE")
+            >>> user.delete()
+        """
+        client = self._get_client()
+        table = self._get_table()
+        key = self._get_key()
+
+        # TODO: Add condition expression support
+        client.delete_item(table, key)
+
+    def update(self, **kwargs: Any) -> None:
+        """Update specific attributes on the model.
+
+        Updates both the local instance and DynamoDB.
+
+        Args:
+            **kwargs: Attribute values to update.
+
+        Example:
+            >>> user = User.get(pk="USER#123", sk="PROFILE")
+            >>> user.update(name="Jane", age=31)
+        """
+        client = self._get_client()
+        table = self._get_table()
+        key = self._get_key()
+
+        # Update local instance
+        for attr_name, value in kwargs.items():
+            if attr_name not in self._attributes:
+                raise ValueError(f"Unknown attribute: {attr_name}")
+            setattr(self, attr_name, value)
+
+        # Update in DynamoDB
+        client.update_item(table, key, updates=kwargs)
+
+    def _get_key(self) -> dict[str, Any]:
+        """Get the key dict for this instance."""
+        key = {}
+        if self._hash_key:
+            key[self._hash_key] = getattr(self, self._hash_key)
+        if self._range_key:
+            key[self._range_key] = getattr(self, self._range_key)
+        return key
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the model to a dict.
+
+        Returns:
+            Dict with all attribute values.
+
+        Example:
+            >>> user = User(pk="USER#123", sk="PROFILE", name="John")
+            >>> user.to_dict()
+            {'pk': 'USER#123', 'sk': 'PROFILE', 'name': 'John'}
+        """
+        result = {}
+        for attr_name in self._attributes:
+            value = getattr(self, attr_name, None)
+            if value is not None:
+                result[attr_name] = value
+        return result
+
+    @classmethod
+    def from_dict(cls: Type[M], data: dict[str, Any]) -> M:
+        """Create a model instance from a dict.
+
+        Args:
+            data: Dict with attribute values.
+
+        Returns:
+            A new model instance.
+
+        Example:
+            >>> data = {'pk': 'USER#123', 'sk': 'PROFILE', 'name': 'John'}
+            >>> user = User.from_dict(data)
+        """
+        return cls(**data)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the model."""
+        attrs = ", ".join(f"{k}={v!r}" for k, v in self.to_dict().items())
+        return f"{self.__class__.__name__}({attrs})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality based on key attributes."""
+        if not isinstance(other, self.__class__):
+            return False
+        return self._get_key() == other._get_key()

--- a/tests/python/test_attributes.py
+++ b/tests/python/test_attributes.py
@@ -1,0 +1,76 @@
+"""Tests for attribute types."""
+
+import pytest
+
+from pydynox import (  # noqa: I001
+    Attribute,
+    BinaryAttribute,
+    BooleanAttribute,
+    ListAttribute,
+    MapAttribute,
+    NumberAttribute,
+    StringAttribute,
+)
+
+
+@pytest.mark.parametrize(
+    "attr_class,expected_type",
+    [
+        pytest.param(StringAttribute, "S", id="string"),
+        pytest.param(NumberAttribute, "N", id="number"),
+        pytest.param(BooleanAttribute, "BOOL", id="boolean"),
+        pytest.param(BinaryAttribute, "B", id="binary"),
+        pytest.param(ListAttribute, "L", id="list"),
+        pytest.param(MapAttribute, "M", id="map"),
+    ],
+)
+def test_attribute_types(attr_class, expected_type):
+    """Each attribute class has the correct DynamoDB type."""
+    attr = attr_class()
+    assert attr.attr_type == expected_type
+
+
+def test_attribute_hash_key():
+    """Attribute can be marked as hash key."""
+    attr = StringAttribute(hash_key=True)
+
+    assert attr.hash_key is True
+    assert attr.range_key is False
+
+
+def test_attribute_range_key():
+    """Attribute can be marked as range key."""
+    attr = StringAttribute(range_key=True)
+
+    assert attr.hash_key is False
+    assert attr.range_key is True
+
+
+def test_attribute_default():
+    """Attribute can have a default value."""
+    attr = StringAttribute(default="default_value")
+
+    assert attr.default == "default_value"
+
+
+def test_attribute_null():
+    """Attribute null flag controls if None is allowed."""
+    nullable = StringAttribute(null=True)
+    required = StringAttribute(null=False)
+
+    assert nullable.null is True
+    assert required.null is False
+
+
+def test_attribute_serialize():
+    """Attribute serialize returns the value as-is by default."""
+    attr = StringAttribute()
+
+    assert attr.serialize("hello") == "hello"
+
+
+def test_attribute_deserialize():
+    """Attribute deserialize returns the value as-is by default."""
+    attr = StringAttribute()
+
+    assert attr.deserialize("hello") == "hello"

--- a/tests/python/test_model.py
+++ b/tests/python/test_model.py
@@ -1,0 +1,209 @@
+"""Tests for Model base class."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pydynox import Model, NumberAttribute, StringAttribute  # noqa: I001
+
+
+class User(Model):
+    """Test model for users."""
+
+    class Meta:
+        table = "users"
+        region = "us-east-1"
+
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    name = StringAttribute()
+    age = NumberAttribute()
+
+
+def test_model_collects_attributes():
+    """Model metaclass collects all attributes."""
+    assert "pk" in User._attributes
+    assert "sk" in User._attributes
+    assert "name" in User._attributes
+    assert "age" in User._attributes
+
+
+def test_model_identifies_keys():
+    """Model metaclass identifies hash and range keys."""
+    assert User._hash_key == "pk"
+    assert User._range_key == "sk"
+
+
+def test_model_init_sets_attributes():
+    """Model init sets attribute values."""
+    user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
+
+    assert user.pk == "USER#1"
+    assert user.sk == "PROFILE"
+    assert user.name == "John"
+    assert user.age == 30
+
+
+def test_model_init_sets_defaults():
+    """Model init uses default values for missing attributes."""
+    user = User(pk="USER#1", sk="PROFILE")
+
+    assert user.pk == "USER#1"
+    assert user.name is None
+    assert user.age is None
+
+
+def test_model_to_dict():
+    """to_dict returns all non-None attributes."""
+    user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
+
+    result = user.to_dict()
+
+    assert result == {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
+
+
+def test_model_to_dict_excludes_none():
+    """to_dict excludes None values."""
+    user = User(pk="USER#1", sk="PROFILE", name="John")
+
+    result = user.to_dict()
+
+    assert result == {"pk": "USER#1", "sk": "PROFILE", "name": "John"}
+    assert "age" not in result
+
+
+def test_model_from_dict():
+    """from_dict creates a model instance."""
+    data = {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
+
+    user = User.from_dict(data)
+
+    assert user.pk == "USER#1"
+    assert user.sk == "PROFILE"
+    assert user.name == "John"
+    assert user.age == 30
+
+
+def test_model_get_key():
+    """_get_key returns the primary key dict."""
+    user = User(pk="USER#1", sk="PROFILE", name="John")
+
+    key = user._get_key()
+
+    assert key == {"pk": "USER#1", "sk": "PROFILE"}
+
+
+def test_model_repr():
+    """__repr__ returns a readable string."""
+    user = User(pk="USER#1", sk="PROFILE", name="John")
+
+    result = repr(user)
+
+    assert "User" in result
+    assert "pk='USER#1'" in result
+    assert "name='John'" in result
+
+
+def test_model_equality():
+    """Models are equal if they have the same key."""
+    user1 = User(pk="USER#1", sk="PROFILE", name="John")
+    user2 = User(pk="USER#1", sk="PROFILE", name="Jane")
+    user3 = User(pk="USER#2", sk="PROFILE", name="John")
+
+    assert user1 == user2  # Same key, different name
+    assert user1 != user3  # Different key
+
+
+@patch("pydynox.model.DynamoDBClient")
+def test_model_get(mock_client_class):
+    """Model.get fetches item from DynamoDB."""
+    mock_client = MagicMock()
+    mock_client.get_item.return_value = {
+        "pk": "USER#1",
+        "sk": "PROFILE",
+        "name": "John",
+        "age": 30,
+    }
+    mock_client_class.return_value = mock_client
+    User._client = None  # Reset cached client
+
+    user = User.get(pk="USER#1", sk="PROFILE")
+
+    assert user is not None
+    assert user.pk == "USER#1"
+    assert user.name == "John"
+    mock_client.get_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
+
+
+@patch("pydynox.model.DynamoDBClient")
+def test_model_get_not_found(mock_client_class):
+    """Model.get returns None when item not found."""
+    mock_client = MagicMock()
+    mock_client.get_item.return_value = None
+    mock_client_class.return_value = mock_client
+    User._client = None
+
+    user = User.get(pk="USER#1", sk="PROFILE")
+
+    assert user is None
+
+
+@patch("pydynox.model.DynamoDBClient")
+def test_model_save(mock_client_class):
+    """Model.save puts item to DynamoDB."""
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    User._client = None
+
+    user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
+    user.save()
+
+    mock_client.put_item.assert_called_once_with(
+        "users", {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
+    )
+
+
+@patch("pydynox.model.DynamoDBClient")
+def test_model_delete(mock_client_class):
+    """Model.delete removes item from DynamoDB."""
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    User._client = None
+
+    user = User(pk="USER#1", sk="PROFILE", name="John")
+    user.delete()
+
+    mock_client.delete_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
+
+
+@patch("pydynox.model.DynamoDBClient")
+def test_model_update(mock_client_class):
+    """Model.update updates specific attributes."""
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    User._client = None
+
+    user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
+    user.update(name="Jane", age=31)
+
+    # Local instance updated
+    assert user.name == "Jane"
+    assert user.age == 31
+
+    # DynamoDB updated
+    mock_client.update_item.assert_called_once_with(
+        "users", {"pk": "USER#1", "sk": "PROFILE"}, updates={"name": "Jane", "age": 31}
+    )
+
+
+@patch("pydynox.model.DynamoDBClient")
+def test_model_update_unknown_attribute(mock_client_class):
+    """Model.update raises error for unknown attributes."""
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    User._client = None
+
+    user = User(pk="USER#1", sk="PROFILE", name="John")
+
+    with pytest.raises(ValueError, match="Unknown attribute"):
+        user.update(unknown_field="value")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "pydynox"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Adds a Model base class that lets users define DynamoDB models with typed attributes and ORM-style operations.

## Usage

```python
from pydynox import Model, StringAttribute, NumberAttribute

class User(Model):
    class Meta:
        table = "users"
        region = "us-east-1"

    pk = StringAttribute(hash_key=True)
    sk = StringAttribute(range_key=True)
    name = StringAttribute()
    age = NumberAttribute()

# Create and save
user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
user.save()

# Get by key
user = User.get(pk="USER#1", sk="PROFILE")

# Update
user.update(name="Jane")

# Delete
user.delete()
```

Also fixes a deadlock issue on Windows by using a shared global Tokio runtime instead of creating one per client.