### PR TITLE
feat: add rate limiting for DynamoDB operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "pydynox"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydynox"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Leandro Cavalcante Damascena <leandro.damascena@gmail.com>"]
 description = "A fast DynamoDB ORM for Python with a Rust core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pydynox"
-version = "0.3.0"
+version = "0.4.0"
 description = "A fast DynamoDB ORM for Python with a Rust core"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -25,6 +25,10 @@ Example:
     ...     name: str
     >>> user = User(pk="USER#1", name="John")
     >>> user.save()
+
+    >>> # With rate limiting
+    >>> from pydynox import DynamoDBClient, FixedRate
+    >>> client = DynamoDBClient(rate_limit=FixedRate(rcu=50))
 """
 
 # Import from Rust core
@@ -37,7 +41,7 @@ from pydynox.model import Model
 from pydynox.query import QueryResult
 from pydynox.transaction import Transaction
 
-__version__ = "0.2.0"
+__version__ = "0.4.0"
 
 __all__ = [
     # Client

--- a/python/pydynox/rate_limit.py
+++ b/python/pydynox/rate_limit.py
@@ -1,0 +1,101 @@
+"""Rate limiting for DynamoDB operations.
+
+Provides token bucket-based rate limiting to prevent throttling.
+Two strategies are available:
+
+- FixedRate: Use when you know exactly how much capacity to use
+- AdaptiveRate: Auto-adjusts based on throttling feedback
+
+Example:
+    >>> from pydynox import DynamoDBClient, FixedRate
+    >>> client = DynamoDBClient(rate_limit=FixedRate(rcu=50))
+    >>> # All operations now respect the 50 RCU limit
+
+    >>> from pydynox import AdaptiveRate
+    >>> client = DynamoDBClient(rate_limit=AdaptiveRate(max_rcu=100))
+    >>> # Rate auto-adjusts based on throttling
+"""
+
+from pydynox import pydynox_core
+
+# Re-export Rust classes
+FixedRate = pydynox_core.FixedRate
+AdaptiveRate = pydynox_core.AdaptiveRate
+RateLimitMetrics = pydynox_core.RateLimitMetrics
+
+# Add docstrings for IDE support
+FixedRate.__doc__ = """Fixed rate limiter.
+
+Use when you know exactly how much capacity to use.
+The rate stays constant unless you change it manually.
+
+Args:
+    rcu: Read capacity units per second (optional).
+    wcu: Write capacity units per second (optional).
+    burst: Burst capacity. Defaults to rate value if not set.
+
+Attributes:
+    rcu: The configured RCU rate.
+    wcu: The configured WCU rate.
+    consumed_rcu: Total RCU consumed so far.
+    consumed_wcu: Total WCU consumed so far.
+    throttle_count: Number of times throttled.
+
+Example:
+    >>> # Read only
+    >>> FixedRate(rcu=50)
+
+    >>> # Read and write
+    >>> FixedRate(rcu=50, wcu=25)
+
+    >>> # With burst (DynamoDB allows short bursts)
+    >>> FixedRate(rcu=50, burst=200)
+"""
+
+AdaptiveRate.__doc__ = """Adaptive rate limiter that adjusts based on throttling.
+
+Starts at 50% of max rate. When throttled, reduces by 20%.
+When no throttle for 10 seconds, increases by 10%.
+
+Args:
+    max_rcu: Maximum read capacity units per second.
+    max_wcu: Maximum write capacity units per second (optional).
+    min_rcu: Minimum RCU, won't go below this (default: 1).
+    min_wcu: Minimum WCU, won't go below this (default: 1).
+
+Attributes:
+    current_rcu: Current RCU rate (changes based on throttling).
+    current_wcu: Current WCU rate (changes based on throttling).
+    max_rcu: Maximum RCU configured.
+    max_wcu: Maximum WCU configured.
+    consumed_rcu: Total RCU consumed so far.
+    consumed_wcu: Total WCU consumed so far.
+    throttle_count: Number of times throttled.
+
+Example:
+    >>> # Just set the max, it figures out the rest
+    >>> AdaptiveRate(max_rcu=100)
+
+    >>> # With write limit too
+    >>> AdaptiveRate(max_rcu=100, max_wcu=50)
+
+    >>> # Custom min (won't go below this)
+    >>> AdaptiveRate(max_rcu=100, min_rcu=10)
+"""
+
+RateLimitMetrics.__doc__ = """Metrics for monitoring rate limiter behavior.
+
+Attributes:
+    consumed_rcu: Total RCU consumed.
+    consumed_wcu: Total WCU consumed.
+    throttle_count: Number of times throttled.
+
+Methods:
+    reset(): Reset all metrics to zero.
+"""
+
+__all__ = [
+    "FixedRate",
+    "AdaptiveRate",
+    "RateLimitMetrics",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,13 @@ mod basic_operations;
 mod batch_operations;
 mod client;
 mod errors;
+pub mod rate_limiter;
 mod serialization;
 mod table_operations;
 mod transaction_operations;
 
 use client::DynamoDBClient;
+use rate_limiter::{AdaptiveRate, FixedRate, RateLimitMetrics};
 use serialization::{dynamo_to_py_py, item_from_dynamo, item_to_dynamo, py_to_dynamo_py};
 
 /// Python module for pydynox's Rust core.
@@ -29,6 +31,11 @@ use serialization::{dynamo_to_py_py, item_from_dynamo, item_to_dynamo, py_to_dyn
 #[pymodule]
 fn pydynox_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DynamoDBClient>()?;
+
+    // Rate limiter classes
+    m.add_class::<FixedRate>()?;
+    m.add_class::<AdaptiveRate>()?;
+    m.add_class::<RateLimitMetrics>()?;
 
     // Serialization functions
     m.add_function(wrap_pyfunction!(py_to_dynamo_py, m)?)?;

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,0 +1,534 @@
+//! Rate limiting module for DynamoDB operations.
+//!
+//! Provides token bucket-based rate limiting to prevent throttling.
+//! Two strategies are available:
+//! - [`FixedRate`]: Use when you know exactly how much capacity to use
+//! - [`AdaptiveRate`]: Auto-adjusts based on throttling feedback
+
+use pyo3::prelude::*;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Token bucket for rate limiting with microsecond precision.
+///
+/// Uses the token bucket algorithm to control request rate.
+/// Tokens are added at a fixed rate and consumed by operations.
+pub struct TokenBucket {
+    /// Current tokens (stored as microtokens for precision)
+    tokens: AtomicU64,
+    /// Maximum tokens allowed (burst capacity)
+    max_tokens: f64,
+    /// Tokens added per second
+    refill_rate: AtomicU64,
+    /// Last time tokens were refilled
+    last_refill: Mutex<Instant>,
+}
+
+impl TokenBucket {
+    /// Create a new token bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `rate` - Tokens per second
+    /// * `burst` - Maximum tokens (burst capacity). Defaults to rate if None.
+    pub fn new(rate: f64, burst: Option<f64>) -> Self {
+        let max_tokens = burst.unwrap_or(rate);
+        let initial_tokens = (max_tokens * 1_000_000.0) as u64;
+
+        Self {
+            tokens: AtomicU64::new(initial_tokens),
+            max_tokens,
+            refill_rate: AtomicU64::new((rate * 1_000_000.0) as u64),
+            last_refill: Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Refill tokens based on elapsed time.
+    fn refill(&self) {
+        let mut last = self.last_refill.lock().unwrap();
+        let now = Instant::now();
+        let elapsed = now.duration_since(*last).as_secs_f64();
+
+        if elapsed > 0.0 {
+            let rate = self.refill_rate.load(Ordering::Relaxed) as f64 / 1_000_000.0;
+            let new_tokens = elapsed * rate;
+            let max_microtokens = (self.max_tokens * 1_000_000.0) as u64;
+
+            let current = self.tokens.load(Ordering::Relaxed);
+            let added = (new_tokens * 1_000_000.0) as u64;
+            let new_total = (current + added).min(max_microtokens);
+
+            self.tokens.store(new_total, Ordering::Relaxed);
+            *last = now;
+        }
+    }
+
+    /// Try to acquire tokens without blocking.
+    ///
+    /// Returns true if tokens were acquired, false otherwise.
+    pub fn try_acquire(&self, tokens: f64) -> bool {
+        self.refill();
+
+        let microtokens = (tokens * 1_000_000.0) as u64;
+        let current = self.tokens.load(Ordering::Relaxed);
+
+        if current >= microtokens {
+            self.tokens.fetch_sub(microtokens, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Wait until tokens are available, then consume them.
+    ///
+    /// This is a blocking operation that sleeps until enough tokens
+    /// are available.
+    pub fn acquire(&self, tokens: f64) {
+        loop {
+            self.refill();
+
+            let microtokens = (tokens * 1_000_000.0) as u64;
+            let current = self.tokens.load(Ordering::Relaxed);
+
+            if current >= microtokens {
+                self.tokens.fetch_sub(microtokens, Ordering::Relaxed);
+                return;
+            }
+
+            // Calculate wait time
+            let needed = microtokens - current;
+            let rate = self.refill_rate.load(Ordering::Relaxed) as f64;
+            let wait_secs = needed as f64 / rate;
+
+            // Sleep for the calculated time (minimum 1ms)
+            let sleep_duration = Duration::from_secs_f64(wait_secs.max(0.001));
+            std::thread::sleep(sleep_duration);
+        }
+    }
+
+    /// Update the refill rate.
+    pub fn set_rate(&self, rate: f64) {
+        self.refill_rate
+            .store((rate * 1_000_000.0) as u64, Ordering::Relaxed);
+    }
+
+    /// Get the current rate.
+    pub fn get_rate(&self) -> f64 {
+        self.refill_rate.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+}
+
+/// Metrics for monitoring rate limiter behavior.
+#[pyclass]
+#[derive(Default)]
+pub struct RateLimitMetrics {
+    /// Total RCU consumed
+    consumed_rcu: AtomicU64,
+    /// Total WCU consumed
+    consumed_wcu: AtomicU64,
+    /// Number of times throttled
+    throttle_count: AtomicU64,
+}
+
+impl RateLimitMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_rcu(&self, rcu: f64) {
+        let micros = (rcu * 1_000_000.0) as u64;
+        self.consumed_rcu.fetch_add(micros, Ordering::Relaxed);
+    }
+
+    pub fn add_wcu(&self, wcu: f64) {
+        let micros = (wcu * 1_000_000.0) as u64;
+        self.consumed_wcu.fetch_add(micros, Ordering::Relaxed);
+    }
+
+    pub fn record_throttle(&self) {
+        self.throttle_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[pymethods]
+impl RateLimitMetrics {
+    /// Get total consumed RCU.
+    #[getter]
+    fn get_consumed_rcu(&self) -> f64 {
+        self.consumed_rcu.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    /// Get total consumed WCU.
+    #[getter]
+    fn get_consumed_wcu(&self) -> f64 {
+        self.consumed_wcu.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    /// Get throttle count.
+    #[getter]
+    fn get_throttle_count(&self) -> u64 {
+        self.throttle_count.load(Ordering::Relaxed)
+    }
+
+    /// Reset all metrics to zero.
+    fn reset(&self) {
+        self.consumed_rcu.store(0, Ordering::Relaxed);
+        self.consumed_wcu.store(0, Ordering::Relaxed);
+        self.throttle_count.store(0, Ordering::Relaxed);
+    }
+}
+
+/// Fixed rate limiter.
+///
+/// Use when you know exactly how much capacity to use.
+/// The rate stays constant unless you change it manually.
+#[pyclass]
+pub struct FixedRate {
+    rcu_bucket: Option<TokenBucket>,
+    wcu_bucket: Option<TokenBucket>,
+    metrics: RateLimitMetrics,
+}
+
+#[pymethods]
+impl FixedRate {
+    /// Create a new fixed rate limiter.
+    ///
+    /// # Arguments
+    ///
+    /// * `rcu` - Read capacity units per second (optional)
+    /// * `wcu` - Write capacity units per second (optional)
+    /// * `burst` - Burst capacity (defaults to rate value)
+    #[new]
+    #[pyo3(signature = (rcu=None, wcu=None, burst=None))]
+    pub fn new(rcu: Option<f64>, wcu: Option<f64>, burst: Option<f64>) -> Self {
+        let rcu_bucket = rcu.map(|r| TokenBucket::new(r, burst));
+        let wcu_bucket = wcu.map(|w| TokenBucket::new(w, burst));
+
+        Self {
+            rcu_bucket,
+            wcu_bucket,
+            metrics: RateLimitMetrics::new(),
+        }
+    }
+
+    /// Get the configured RCU rate.
+    #[getter]
+    fn rcu(&self) -> Option<f64> {
+        self.rcu_bucket.as_ref().map(|b| b.get_rate())
+    }
+
+    /// Get the configured WCU rate.
+    #[getter]
+    fn wcu(&self) -> Option<f64> {
+        self.wcu_bucket.as_ref().map(|b| b.get_rate())
+    }
+
+    /// Get metrics.
+    #[getter]
+    fn metrics(&self) -> RateLimitMetrics {
+        RateLimitMetrics {
+            consumed_rcu: AtomicU64::new(self.metrics.consumed_rcu.load(Ordering::Relaxed)),
+            consumed_wcu: AtomicU64::new(self.metrics.consumed_wcu.load(Ordering::Relaxed)),
+            throttle_count: AtomicU64::new(self.metrics.throttle_count.load(Ordering::Relaxed)),
+        }
+    }
+
+    /// Get total consumed RCU.
+    #[getter]
+    fn consumed_rcu(&self) -> f64 {
+        self.metrics.consumed_rcu.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    /// Get total consumed WCU.
+    #[getter]
+    fn consumed_wcu(&self) -> f64 {
+        self.metrics.consumed_wcu.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    /// Get throttle count.
+    #[getter]
+    fn throttle_count(&self) -> u64 {
+        self.metrics.throttle_count.load(Ordering::Relaxed)
+    }
+
+    /// Acquire read capacity (called from Python).
+    fn _acquire_rcu(&self, rcu: f64) {
+        self.acquire_rcu(rcu);
+    }
+
+    /// Acquire write capacity (called from Python).
+    fn _acquire_wcu(&self, wcu: f64) {
+        self.acquire_wcu(wcu);
+    }
+
+    /// Record a throttle event (called from Python).
+    fn _on_throttle(&self) {
+        self.on_throttle();
+    }
+}
+
+impl FixedRate {
+    /// Acquire read capacity.
+    pub fn acquire_rcu(&self, rcu: f64) {
+        if let Some(bucket) = &self.rcu_bucket {
+            bucket.acquire(rcu);
+        }
+        self.metrics.add_rcu(rcu);
+    }
+
+    /// Acquire write capacity.
+    pub fn acquire_wcu(&self, wcu: f64) {
+        if let Some(bucket) = &self.wcu_bucket {
+            bucket.acquire(wcu);
+        }
+        self.metrics.add_wcu(wcu);
+    }
+
+    /// Record a throttle event.
+    pub fn on_throttle(&self) {
+        self.metrics.record_throttle();
+    }
+}
+
+/// Adaptive rate limiter that adjusts based on throttling.
+///
+/// Starts at 50% of max rate. When throttled, reduces by 20%.
+/// When no throttle for 10 seconds, increases by 10%.
+#[pyclass]
+pub struct AdaptiveRate {
+    rcu_bucket: TokenBucket,
+    wcu_bucket: Option<TokenBucket>,
+    max_rcu: f64,
+    min_rcu: f64,
+    max_wcu: Option<f64>,
+    min_wcu: f64,
+    current_rcu: AtomicU64,
+    current_wcu: AtomicU64,
+    last_throttle: Mutex<Option<Instant>>,
+    last_increase_check: Mutex<Instant>,
+    metrics: RateLimitMetrics,
+}
+
+#[pymethods]
+impl AdaptiveRate {
+    /// Create a new adaptive rate limiter.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_rcu` - Maximum read capacity units per second
+    /// * `max_wcu` - Maximum write capacity units per second (optional)
+    /// * `min_rcu` - Minimum RCU (default: 1)
+    /// * `min_wcu` - Minimum WCU (default: 1)
+    #[new]
+    #[pyo3(signature = (max_rcu, max_wcu=None, min_rcu=None, min_wcu=None))]
+    pub fn new(
+        max_rcu: f64,
+        max_wcu: Option<f64>,
+        min_rcu: Option<f64>,
+        min_wcu: Option<f64>,
+    ) -> Self {
+        let min_rcu = min_rcu.unwrap_or(1.0);
+        let min_wcu = min_wcu.unwrap_or(1.0);
+
+        // Start at 50% of max
+        let initial_rcu = max_rcu * 0.5;
+        let initial_wcu = max_wcu.map(|m| m * 0.5);
+
+        let rcu_bucket = TokenBucket::new(initial_rcu, Some(max_rcu));
+        let wcu_bucket = initial_wcu.map(|w| TokenBucket::new(w, max_wcu));
+
+        Self {
+            rcu_bucket,
+            wcu_bucket,
+            max_rcu,
+            min_rcu,
+            max_wcu,
+            min_wcu,
+            current_rcu: AtomicU64::new((initial_rcu * 1_000_000.0) as u64),
+            current_wcu: AtomicU64::new(initial_wcu.map(|w| (w * 1_000_000.0) as u64).unwrap_or(0)),
+            last_throttle: Mutex::new(None),
+            last_increase_check: Mutex::new(Instant::now()),
+            metrics: RateLimitMetrics::new(),
+        }
+    }
+
+    /// Get the current RCU rate.
+    #[getter]
+    fn current_rcu(&self) -> f64 {
+        self.current_rcu.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    /// Get the current WCU rate.
+    #[getter]
+    fn current_wcu(&self) -> Option<f64> {
+        if self.wcu_bucket.is_some() {
+            Some(self.current_wcu.load(Ordering::Relaxed) as f64 / 1_000_000.0)
+        } else {
+            None
+        }
+    }
+
+    /// Get the max RCU.
+    #[getter]
+    fn max_rcu(&self) -> f64 {
+        self.max_rcu
+    }
+
+    /// Get the max WCU.
+    #[getter]
+    fn max_wcu(&self) -> Option<f64> {
+        self.max_wcu
+    }
+
+    /// Get total consumed RCU.
+    #[getter]
+    fn consumed_rcu(&self) -> f64 {
+        self.metrics.consumed_rcu.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    /// Get total consumed WCU.
+    #[getter]
+    fn consumed_wcu(&self) -> f64 {
+        self.metrics.consumed_wcu.load(Ordering::Relaxed) as f64 / 1_000_000.0
+    }
+
+    /// Get throttle count.
+    #[getter]
+    fn throttle_count(&self) -> u64 {
+        self.metrics.throttle_count.load(Ordering::Relaxed)
+    }
+
+    /// Acquire read capacity (called from Python).
+    fn _acquire_rcu(&self, rcu: f64) {
+        self.acquire_rcu(rcu);
+    }
+
+    /// Acquire write capacity (called from Python).
+    fn _acquire_wcu(&self, wcu: f64) {
+        self.acquire_wcu(wcu);
+    }
+
+    /// Record a throttle event (called from Python).
+    fn _on_throttle(&self) {
+        self.on_throttle();
+    }
+}
+
+impl AdaptiveRate {
+    /// Acquire read capacity.
+    pub fn acquire_rcu(&self, rcu: f64) {
+        self.maybe_increase();
+        self.rcu_bucket.acquire(rcu);
+        self.metrics.add_rcu(rcu);
+    }
+
+    /// Acquire write capacity.
+    pub fn acquire_wcu(&self, wcu: f64) {
+        self.maybe_increase();
+        if let Some(bucket) = &self.wcu_bucket {
+            bucket.acquire(wcu);
+        }
+        self.metrics.add_wcu(wcu);
+    }
+
+    /// Called when DynamoDB returns ThrottlingException.
+    ///
+    /// Reduces rate by 20%, but not below minimum.
+    pub fn on_throttle(&self) {
+        self.metrics.record_throttle();
+
+        // Reduce RCU by 20%
+        let current = self.current_rcu.load(Ordering::Relaxed) as f64 / 1_000_000.0;
+        let new_rate = (current * 0.8).max(self.min_rcu);
+        self.current_rcu
+            .store((new_rate * 1_000_000.0) as u64, Ordering::Relaxed);
+        self.rcu_bucket.set_rate(new_rate);
+
+        // Reduce WCU by 20% if configured
+        if let Some(bucket) = &self.wcu_bucket {
+            let current = self.current_wcu.load(Ordering::Relaxed) as f64 / 1_000_000.0;
+            let new_rate = (current * 0.8).max(self.min_wcu);
+            self.current_wcu
+                .store((new_rate * 1_000_000.0) as u64, Ordering::Relaxed);
+            bucket.set_rate(new_rate);
+        }
+
+        // Record throttle time
+        let mut last = self.last_throttle.lock().unwrap();
+        *last = Some(Instant::now());
+    }
+
+    /// Check if we should increase rate (no throttle for 10s).
+    fn maybe_increase(&self) {
+        let mut last_check = self.last_increase_check.lock().unwrap();
+        let now = Instant::now();
+
+        // Only check every second
+        if now.duration_since(*last_check).as_secs() < 1 {
+            return;
+        }
+        *last_check = now;
+
+        // Check if no throttle for 10 seconds
+        let last_throttle = self.last_throttle.lock().unwrap();
+        let should_increase = match *last_throttle {
+            None => true,
+            Some(t) => now.duration_since(t).as_secs() >= 10,
+        };
+
+        if should_increase {
+            // Increase RCU by 10%
+            let current = self.current_rcu.load(Ordering::Relaxed) as f64 / 1_000_000.0;
+            let new_rate = (current * 1.1).min(self.max_rcu);
+            self.current_rcu
+                .store((new_rate * 1_000_000.0) as u64, Ordering::Relaxed);
+            self.rcu_bucket.set_rate(new_rate);
+
+            // Increase WCU by 10% if configured
+            if let (Some(bucket), Some(max)) = (&self.wcu_bucket, self.max_wcu) {
+                let current = self.current_wcu.load(Ordering::Relaxed) as f64 / 1_000_000.0;
+                let new_rate = (current * 1.1).min(max);
+                self.current_wcu
+                    .store((new_rate * 1_000_000.0) as u64, Ordering::Relaxed);
+                bucket.set_rate(new_rate);
+            }
+        }
+    }
+}
+
+/// Trait for rate limiters.
+pub trait RateLimiter: Send + Sync {
+    fn acquire_rcu(&self, rcu: f64);
+    fn acquire_wcu(&self, wcu: f64);
+    fn on_throttle(&self);
+}
+
+impl RateLimiter for FixedRate {
+    fn acquire_rcu(&self, rcu: f64) {
+        self.acquire_rcu(rcu);
+    }
+
+    fn acquire_wcu(&self, wcu: f64) {
+        self.acquire_wcu(wcu);
+    }
+
+    fn on_throttle(&self) {
+        self.on_throttle();
+    }
+}
+
+impl RateLimiter for AdaptiveRate {
+    fn acquire_rcu(&self, rcu: f64) {
+        self.acquire_rcu(rcu);
+    }
+
+    fn acquire_wcu(&self, wcu: f64) {
+        self.acquire_wcu(wcu);
+    }
+
+    fn on_throttle(&self) {
+        self.on_throttle();
+    }
+}

--- a/tests/integration/rate_limit/__init__.py
+++ b/tests/integration/rate_limit/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for rate limiting."""

--- a/tests/integration/rate_limit/test_rate_limit_operations.py
+++ b/tests/integration/rate_limit/test_rate_limit_operations.py
@@ -1,0 +1,281 @@
+"""Integration tests for rate limiting with DynamoDB operations.
+
+Note: Moto does not simulate DynamoDB throttling, so we test that:
+1. Rate limiter is called during operations
+2. Metrics are tracked correctly
+3. Operations still work with rate limiting enabled
+"""
+
+import time
+
+import pytest
+from pydynox import DynamoDBClient
+from pydynox.rate_limit import AdaptiveRate, FixedRate
+
+MOTO_ENDPOINT = "http://127.0.0.1:5556"
+
+
+@pytest.fixture
+def client_with_fixed_rate(table):
+    """Create a client with fixed rate limiting."""
+    return DynamoDBClient(
+        region="us-east-1",
+        endpoint_url=MOTO_ENDPOINT,
+        access_key="testing",
+        secret_key="testing",
+        rate_limit=FixedRate(rcu=100, wcu=50),
+    )
+
+
+@pytest.fixture
+def client_with_adaptive_rate(table):
+    """Create a client with adaptive rate limiting."""
+    return DynamoDBClient(
+        region="us-east-1",
+        endpoint_url=MOTO_ENDPOINT,
+        access_key="testing",
+        secret_key="testing",
+        rate_limit=AdaptiveRate(max_rcu=100, max_wcu=50),
+    )
+
+
+def test_put_item_tracks_wcu(client_with_fixed_rate):
+    """Test that put_item tracks WCU consumption."""
+    client = client_with_fixed_rate
+
+    # Initial WCU should be 0
+    assert client.rate_limit.consumed_wcu == pytest.approx(0.0)
+
+    # Put an item
+    client.put_item("test_table", {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"})
+
+    # WCU should be tracked
+    assert client.rate_limit.consumed_wcu == pytest.approx(1.0)
+
+
+def test_get_item_tracks_rcu(client_with_fixed_rate):
+    """Test that get_item tracks RCU consumption."""
+    client = client_with_fixed_rate
+
+    # Put an item first
+    client.put_item("test_table", {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"})
+
+    # Reset by creating new client (or just check delta)
+    initial_rcu = client.rate_limit.consumed_rcu
+
+    # Get the item
+    client.get_item("test_table", {"pk": "USER#1", "sk": "PROFILE"})
+
+    # RCU should be tracked
+    assert client.rate_limit.consumed_rcu == pytest.approx(initial_rcu + 1.0)
+
+
+def test_delete_item_tracks_wcu(client_with_fixed_rate):
+    """Test that delete_item tracks WCU consumption."""
+    client = client_with_fixed_rate
+
+    # Put an item first
+    client.put_item("test_table", {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"})
+    initial_wcu = client.rate_limit.consumed_wcu
+
+    # Delete the item
+    client.delete_item("test_table", {"pk": "USER#1", "sk": "PROFILE"})
+
+    # WCU should be tracked
+    assert client.rate_limit.consumed_wcu == pytest.approx(initial_wcu + 1.0)
+
+
+def test_update_item_tracks_wcu(client_with_fixed_rate):
+    """Test that update_item tracks WCU consumption."""
+    client = client_with_fixed_rate
+
+    # Put an item first
+    client.put_item("test_table", {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"})
+    initial_wcu = client.rate_limit.consumed_wcu
+
+    # Update the item
+    client.update_item(
+        "test_table",
+        {"pk": "USER#1", "sk": "PROFILE"},
+        updates={"name": "Bob"},
+    )
+
+    # WCU should be tracked
+    assert client.rate_limit.consumed_wcu == pytest.approx(initial_wcu + 1.0)
+
+
+def test_batch_write_tracks_wcu(client_with_fixed_rate):
+    """Test that batch_write tracks WCU for all items."""
+    client = client_with_fixed_rate
+
+    initial_wcu = client.rate_limit.consumed_wcu
+
+    # Batch write 3 items
+    client.batch_write(
+        "test_table",
+        put_items=[
+            {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"},
+            {"pk": "USER#2", "sk": "PROFILE", "name": "Bob"},
+            {"pk": "USER#3", "sk": "PROFILE", "name": "Charlie"},
+        ],
+    )
+
+    # WCU should track all 3 items
+    assert client.rate_limit.consumed_wcu == pytest.approx(initial_wcu + 3.0)
+
+
+def test_batch_get_tracks_rcu(client_with_fixed_rate):
+    """Test that batch_get tracks RCU for all keys."""
+    client = client_with_fixed_rate
+
+    # Put items first
+    client.batch_write(
+        "test_table",
+        put_items=[
+            {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"},
+            {"pk": "USER#2", "sk": "PROFILE", "name": "Bob"},
+        ],
+    )
+
+    initial_rcu = client.rate_limit.consumed_rcu
+
+    # Batch get 2 items
+    client.batch_get(
+        "test_table",
+        keys=[
+            {"pk": "USER#1", "sk": "PROFILE"},
+            {"pk": "USER#2", "sk": "PROFILE"},
+        ],
+    )
+
+    # RCU should track both keys
+    assert client.rate_limit.consumed_rcu == pytest.approx(initial_rcu + 2.0)
+
+
+def test_query_tracks_rcu(client_with_fixed_rate):
+    """Test that query tracks RCU consumption."""
+    client = client_with_fixed_rate
+
+    # Put items first
+    client.batch_write(
+        "test_table",
+        put_items=[
+            {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"},
+            {"pk": "USER#1", "sk": "SETTINGS", "theme": "dark"},
+        ],
+    )
+
+    initial_rcu = client.rate_limit.consumed_rcu
+
+    # Query items
+    results = list(
+        client.query(
+            "test_table",
+            key_condition_expression="#pk = :pk",
+            expression_attribute_names={"#pk": "pk"},
+            expression_attribute_values={":pk": "USER#1"},
+        )
+    )
+
+    # Should have found 2 items
+    assert len(results) == 2
+
+    # RCU should be tracked (at least 1 for the query)
+    assert client.rate_limit.consumed_rcu > initial_rcu
+
+
+def test_adaptive_rate_starts_at_half_max(client_with_adaptive_rate):
+    """Test that adaptive rate starts at 50% of max."""
+    client = client_with_adaptive_rate
+
+    assert client.rate_limit.current_rcu == pytest.approx(50.0)  # 50% of 100
+    assert client.rate_limit.current_wcu == pytest.approx(25.0)  # 50% of 50
+
+
+def test_operations_work_with_rate_limiting(client_with_fixed_rate):
+    """Test that all operations work correctly with rate limiting."""
+    client = client_with_fixed_rate
+
+    # Put
+    client.put_item("test_table", {"pk": "USER#1", "sk": "PROFILE", "name": "Alice"})
+
+    # Get
+    item = client.get_item("test_table", {"pk": "USER#1", "sk": "PROFILE"})
+    assert item["name"] == "Alice"
+
+    # Update
+    client.update_item(
+        "test_table",
+        {"pk": "USER#1", "sk": "PROFILE"},
+        updates={"name": "Bob"},
+    )
+
+    # Verify update
+    item = client.get_item("test_table", {"pk": "USER#1", "sk": "PROFILE"})
+    assert item["name"] == "Bob"
+
+    # Delete
+    client.delete_item("test_table", {"pk": "USER#1", "sk": "PROFILE"})
+
+    # Verify delete
+    item = client.get_item("test_table", {"pk": "USER#1", "sk": "PROFILE"})
+    assert item is None
+
+
+def test_rate_limiting_slows_operations(table):
+    """Test that rate limiting actually slows down operations."""
+    # Create client with very low rate
+    client = DynamoDBClient(
+        region="us-east-1",
+        endpoint_url=MOTO_ENDPOINT,
+        access_key="testing",
+        secret_key="testing",
+        rate_limit=FixedRate(wcu=2),  # Only 2 WCU per second
+    )
+
+    # First 2 writes should be fast (tokens available)
+    start = time.time()
+    client.put_item("test_table", {"pk": "USER#1", "sk": "A", "data": "x"})
+    client.put_item("test_table", {"pk": "USER#2", "sk": "A", "data": "x"})
+    first_two = time.time() - start
+
+    # Third write should wait for token refill
+    start = time.time()
+    client.put_item("test_table", {"pk": "USER#3", "sk": "A", "data": "x"})
+    third = time.time() - start
+
+    # First two should be fast
+    assert first_two < 0.5
+
+    # Third should have waited (at least 0.4 seconds for 1 token at 2/sec)
+    assert third >= 0.4
+
+
+def test_client_without_rate_limit_has_none(dynamo):
+    """Test that client without rate_limit parameter has None."""
+    assert dynamo.rate_limit is None
+
+
+@pytest.mark.parametrize(
+    "rate_limit",
+    [
+        pytest.param(FixedRate(rcu=50), id="fixed_rcu_only"),
+        pytest.param(FixedRate(rcu=50, wcu=25), id="fixed_rcu_wcu"),
+        pytest.param(AdaptiveRate(max_rcu=100), id="adaptive_rcu_only"),
+        pytest.param(AdaptiveRate(max_rcu=100, max_wcu=50), id="adaptive_rcu_wcu"),
+    ],
+)
+def test_various_rate_limit_configs_work(table, rate_limit):
+    """Test that various rate limit configurations work."""
+    client = DynamoDBClient(
+        region="us-east-1",
+        endpoint_url=MOTO_ENDPOINT,
+        access_key="testing",
+        secret_key="testing",
+        rate_limit=rate_limit,
+    )
+
+    # Should be able to do basic operations
+    client.put_item("test_table", {"pk": "TEST#1", "sk": "A", "data": "test"})
+    item = client.get_item("test_table", {"pk": "TEST#1", "sk": "A"})
+    assert item["data"] == "test"

--- a/tests/python/test_rate_limit.py
+++ b/tests/python/test_rate_limit.py
@@ -1,0 +1,160 @@
+"""Tests for rate limiting."""
+
+import time
+
+import pytest
+
+
+def test_fixed_rate_creation():
+    """Test creating a FixedRate limiter."""
+    from pydynox.rate_limit import FixedRate
+
+    limiter = FixedRate(rcu=50)
+    assert limiter.rcu == 50
+    assert limiter.wcu is None
+
+
+def test_fixed_rate_with_wcu():
+    """Test FixedRate with both RCU and WCU."""
+    from pydynox.rate_limit import FixedRate
+
+    limiter = FixedRate(rcu=50, wcu=25)
+    assert limiter.rcu == 50
+    assert limiter.wcu == 25
+
+
+def test_fixed_rate_metrics():
+    """Test FixedRate metrics tracking."""
+    from pydynox.rate_limit import FixedRate
+
+    limiter = FixedRate(rcu=100, wcu=50)
+
+    # Initial metrics should be zero
+    assert limiter.consumed_rcu == 0
+    assert limiter.consumed_wcu == 0
+    assert limiter.throttle_count == 0
+
+    # Acquire some capacity
+    limiter._acquire_rcu(10.0)
+    limiter._acquire_wcu(5.0)
+
+    assert limiter.consumed_rcu == 10.0
+    assert limiter.consumed_wcu == 5.0
+
+
+def test_adaptive_rate_creation():
+    """Test creating an AdaptiveRate limiter."""
+    from pydynox.rate_limit import AdaptiveRate
+
+    limiter = AdaptiveRate(max_rcu=100)
+
+    # Should start at 50% of max
+    assert limiter.current_rcu == 50.0
+    assert limiter.max_rcu == 100.0
+
+
+def test_adaptive_rate_with_wcu():
+    """Test AdaptiveRate with both RCU and WCU."""
+    from pydynox.rate_limit import AdaptiveRate
+
+    limiter = AdaptiveRate(max_rcu=100, max_wcu=50)
+
+    assert limiter.current_rcu == 50.0
+    assert limiter.current_wcu == 25.0
+    assert limiter.max_rcu == 100.0
+    assert limiter.max_wcu == 50.0
+
+
+def test_adaptive_rate_throttle_reduces_rate():
+    """Test that throttle events reduce the rate."""
+    from pydynox.rate_limit import AdaptiveRate
+
+    limiter = AdaptiveRate(max_rcu=100)
+
+    # Initial rate is 50
+    assert limiter.current_rcu == 50.0
+
+    # After throttle, should be 40 (50 * 0.8)
+    limiter._on_throttle()
+    assert limiter.current_rcu == 40.0
+
+    # After another throttle, should be 32 (40 * 0.8)
+    limiter._on_throttle()
+    assert limiter.current_rcu == 32.0
+
+    # Throttle count should be 2
+    assert limiter.throttle_count == 2
+
+
+def test_adaptive_rate_min_rcu():
+    """Test that rate doesn't go below min_rcu."""
+    from pydynox.rate_limit import AdaptiveRate
+
+    limiter = AdaptiveRate(max_rcu=100, min_rcu=10)
+
+    # Throttle many times
+    for _ in range(20):
+        limiter._on_throttle()
+
+    # Should not go below min
+    assert limiter.current_rcu >= 10.0
+
+
+def test_fixed_rate_rate_limiting():
+    """Test that FixedRate actually limits the rate."""
+    from pydynox.rate_limit import FixedRate
+
+    # Very low rate to make test fast
+    limiter = FixedRate(rcu=10)
+
+    # Acquire all tokens
+    start = time.time()
+    limiter._acquire_rcu(10.0)
+    first_acquire = time.time() - start
+
+    # First acquire should be instant (tokens available)
+    assert first_acquire < 0.1
+
+    # Second acquire should wait for refill
+    start = time.time()
+    limiter._acquire_rcu(5.0)
+    second_acquire = time.time() - start
+
+    # Should have waited ~0.5 seconds for 5 tokens at 10/sec
+    assert second_acquire >= 0.4
+
+
+@pytest.mark.parametrize(
+    "rcu,wcu,burst",
+    [
+        pytest.param(50, None, None, id="rcu_only"),
+        pytest.param(50, 25, None, id="rcu_and_wcu"),
+        pytest.param(50, 25, 100, id="with_burst"),
+    ],
+)
+def test_fixed_rate_configurations(rcu, wcu, burst):
+    """Test various FixedRate configurations."""
+    from pydynox.rate_limit import FixedRate
+
+    limiter = FixedRate(rcu=rcu, wcu=wcu, burst=burst)
+    assert limiter.rcu == rcu
+    assert limiter.wcu == wcu
+
+
+@pytest.mark.parametrize(
+    "max_rcu,max_wcu,min_rcu",
+    [
+        pytest.param(100, None, None, id="rcu_only"),
+        pytest.param(100, 50, None, id="rcu_and_wcu"),
+        pytest.param(100, 50, 10, id="with_min"),
+    ],
+)
+def test_adaptive_rate_configurations(max_rcu, max_wcu, min_rcu):
+    """Test various AdaptiveRate configurations."""
+    from pydynox.rate_limit import AdaptiveRate
+
+    limiter = AdaptiveRate(max_rcu=max_rcu, max_wcu=max_wcu, min_rcu=min_rcu)
+    assert limiter.max_rcu == max_rcu
+    assert limiter.max_wcu == max_wcu
+    # Should start at 50% of max
+    assert limiter.current_rcu == max_rcu * 0.5

--- a/tests/python/test_ttl.py
+++ b/tests/python/test_ttl.py
@@ -4,10 +4,8 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
-
 from pydynox.attributes import ExpiresIn, StringAttribute, TTLAttribute
 from pydynox.model import Model
-
 
 # --- ExpiresIn tests ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -1067,7 +1067,7 @@ wheels = [
 
 [[package]]
 name = "pydynox"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #30 

When you scan or query large tables, you can burn through your provisioned capacity fast. DynamoDB will throttle you. This gives you control over how fast operations run.

## How to use

```python
from pydynox import DynamoDBClient
from pydynox.rate_limit import FixedRate, AdaptiveRate

# Fixed rate - you know what you want
client = DynamoDBClient(rate_limit=FixedRate(rcu=50, wcu=25))

# Adaptive rate - auto-adjusts based on throttling
client = DynamoDBClient(rate_limit=AdaptiveRate(max_rcu=100))
```

## Two strategies

**FixedRate** - Set a constant rate. Good when you know your table capacity.

**AdaptiveRate** - Starts at 50% of max. Reduces by 20% when throttled. Increases by 10% after 10 seconds without throttle.

## Client-level or per-operation

You can set rate limiting at the client level (all operations share the limit):

```python
client = DynamoDBClient(rate_limit=FixedRate(rcu=100))

# All operations share this limit
client.query("users", ...)
client.batch_get("users", keys)
```

Or override for a specific operation (not yet implemented, coming soon):

```python
# Future: per-operation override
for user in client.scan("users", rate_limit=FixedRate(rcu=10)):
    process(user)
```

## Metrics

```python
client.rate_limit.consumed_rcu   # total RCU used
client.rate_limit.consumed_wcu   # total WCU used
client.rate_limit.throttle_count # how many times throttled
```