### PR TITLE
feat: add consistent_read toggle for get and query operations

### DIFF
--- a/docs/examples/client/consistent_read.py
+++ b/docs/examples/client/consistent_read.py
@@ -1,0 +1,22 @@
+"""Consistent read with low-level client."""
+
+from pydynox import DynamoDBClient
+
+client = DynamoDBClient(region="us-east-1")
+
+# get_item with consistent read
+item = client.get_item(
+    "users",
+    {"pk": "USER#123", "sk": "PROFILE"},
+    consistent_read=True,
+)
+
+# query with consistent read
+for item in client.query(
+    "users",
+    key_condition_expression="#pk = :pk",
+    expression_attribute_names={"#pk": "pk"},
+    expression_attribute_values={":pk": "USER#123"},
+    consistent_read=True,
+):
+    print(item)

--- a/docs/examples/models/consistent_read.py
+++ b/docs/examples/models/consistent_read.py
@@ -1,0 +1,40 @@
+"""Consistent read examples."""
+
+from pydynox import DynamoDBClient, Model, ModelConfig, StringAttribute
+
+client = DynamoDBClient(region="us-east-1")
+
+
+# Option 1: Per-operation (highest priority)
+class User(Model):
+    model_config = ModelConfig(table="users", client=client)
+
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    name = StringAttribute()
+
+
+# Eventually consistent (default)
+user = User.get(pk="USER#123", sk="PROFILE")
+
+# Strongly consistent
+user = User.get(pk="USER#123", sk="PROFILE", consistent_read=True)
+
+
+# Option 2: Model-level default
+class Order(Model):
+    model_config = ModelConfig(
+        table="orders",
+        client=client,
+        consistent_read=True,  # All reads are strongly consistent
+    )
+
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+
+
+# Uses strongly consistent read (from model_config)
+order = Order.get(pk="ORDER#456", sk="ITEM#1")
+
+# Override to eventually consistent for this call
+order = Order.get(pk="ORDER#456", sk="ITEM#1", consistent_read=False)

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -144,6 +144,17 @@ The client has methods for direct DynamoDB operations. Each sync method has an a
 
 All operations return metrics (duration, RCU/WCU consumed). See [observability](observability.md) for details.
 
+### Consistent reads
+
+`get_item` and `query` support strongly consistent reads:
+
+=== "consistent_read.py"
+    ```python
+    --8<-- "docs/examples/client/consistent_read.py"
+    ```
+
+By default, reads are eventually consistent. Pass `consistent_read=True` when you need the latest data.
+
 See [async support](async.md) for more details on async operations.
 
 Most of the time you'll use the Model ORM instead of these methods directly.

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -90,6 +90,31 @@ If your table has only a hash key (no range key), you only need to pass the hash
 user = User.get(pk="USER#123")
 ```
 
+#### Consistent reads
+
+By default, `get()` uses eventually consistent reads. For strongly consistent reads, use `consistent_read=True`:
+
+=== "consistent_read.py"
+    ```python
+    --8<-- "docs/examples/models/consistent_read.py"
+    ```
+
+**When to use strongly consistent reads:**
+
+- You need to read data right after writing it
+- Your app can't tolerate stale data (even for a second)
+- You're building a financial or inventory system
+
+**Trade-offs:**
+
+| | Eventually consistent | Strongly consistent |
+|---|---|---|
+| Latency | Lower | Higher |
+| Cost | 0.5 RCU per 4KB | 1 RCU per 4KB |
+| Availability | Higher | Lower during outages |
+
+Most apps work fine with eventually consistent reads. Use strongly consistent only when you need it.
+
 ### Update
 
 There are two ways to update an item:
@@ -135,6 +160,7 @@ After deletion, the object still exists in Python, but the item is gone from Dyn
 | `client` | DynamoDBClient | None | Client to use (uses default if None) |
 | `skip_hooks` | bool | False | Skip lifecycle hooks |
 | `max_size` | int | None | Max item size in bytes |
+| `consistent_read` | bool | False | Use strongly consistent reads by default |
 
 ### Setting a default client
 

--- a/python/pydynox/config.py
+++ b/python/pydynox/config.py
@@ -66,6 +66,8 @@ class ModelConfig:
         client: DynamoDBClient to use. If None, uses the default client.
         skip_hooks: Skip lifecycle hooks by default (default: False).
         max_size: Max item size in bytes. If set, validates before save.
+        consistent_read: Use strongly consistent reads by default (default: False).
+            Strongly consistent reads cost 2x RCU but always return latest data.
 
     Example:
         >>> from pydynox import DynamoDBClient, Model, ModelConfig
@@ -80,9 +82,18 @@ class ModelConfig:
         ...     )
         ...     pk = StringAttribute(hash_key=True)
         ...     name = StringAttribute()
+        >>>
+        >>> # Model with consistent reads enabled by default
+        >>> class CriticalData(Model):
+        ...     model_config = ModelConfig(
+        ...         table="critical",
+        ...         consistent_read=True,  # Always use strongly consistent reads
+        ...     )
+        ...     pk = StringAttribute(hash_key=True)
     """
 
     table: str
     client: DynamoDBClient | None = field(default=None)
     skip_hooks: bool = field(default=False)
     max_size: int | None = field(default=None)
+    consistent_read: bool = field(default=False)

--- a/python/pydynox/pydynox_core.pyi
+++ b/python/pydynox/pydynox_core.pyi
@@ -41,6 +41,7 @@ class DynamoDBClient:
         self,
         table: str,
         key: dict[str, Any],
+        consistent_read: bool = False,
     ) -> tuple[dict[str, Any] | None, OperationMetrics]: ...
     def delete_item(
         self,
@@ -71,6 +72,7 @@ class DynamoDBClient:
         exclusive_start_key: dict[str, Any] | None = None,
         scan_index_forward: bool | None = None,
         index_name: str | None = None,
+        consistent_read: bool = False,
     ) -> tuple[list[dict[str, Any]], dict[str, Any] | None, OperationMetrics]: ...
     def batch_write(
         self,
@@ -111,6 +113,7 @@ class DynamoDBClient:
         self,
         table: str,
         key: dict[str, Any],
+        consistent_read: bool = False,
     ) -> Coroutine[Any, Any, dict[str, Any]]: ...
     def async_put_item(
         self,
@@ -149,6 +152,7 @@ class DynamoDBClient:
         exclusive_start_key: dict[str, Any] | None = None,
         scan_index_forward: bool | None = None,
         index_name: str | None = None,
+        consistent_read: bool = False,
     ) -> Coroutine[Any, Any, dict[str, Any]]: ...
 
 # Rate limiting

--- a/python/pydynox/query.py
+++ b/python/pydynox/query.py
@@ -44,6 +44,7 @@ class QueryResult:
         index_name: str | None = None,
         last_evaluated_key: dict[str, Any] | None = None,
         acquire_rcu: Callable[[float], None] | None = None,
+        consistent_read: bool = False,
     ):
         self._client = client
         self._table = table
@@ -56,6 +57,7 @@ class QueryResult:
         self._index_name = index_name
         self._start_key = last_evaluated_key
         self._acquire_rcu = acquire_rcu
+        self._consistent_read = consistent_read
 
         self._current_page: list[dict[str, Any]] = []
         self._page_index = 0
@@ -133,6 +135,7 @@ class QueryResult:
             exclusive_start_key=start_key,
             scan_index_forward=self._scan_index_forward,
             index_name=self._index_name,
+            consistent_read=self._consistent_read,
         )
 
         self._current_page = items
@@ -177,6 +180,7 @@ class AsyncQueryResult:
         index_name: str | None = None,
         last_evaluated_key: dict[str, Any] | None = None,
         acquire_rcu: Callable[[float], None] | None = None,
+        consistent_read: bool = False,
     ):
         self._client = client
         self._table = table
@@ -189,6 +193,7 @@ class AsyncQueryResult:
         self._index_name = index_name
         self._start_key = last_evaluated_key
         self._acquire_rcu = acquire_rcu
+        self._consistent_read = consistent_read
 
         self._current_page: list[dict[str, Any]] = []
         self._page_index = 0
@@ -258,6 +263,7 @@ class AsyncQueryResult:
             exclusive_start_key=start_key,
             scan_index_forward=self._scan_index_forward,
             index_name=self._index_name,
+            consistent_read=self._consistent_read,
         )
 
         self._current_page = result["items"]

--- a/tests/integration/operations/test_get_item.py
+++ b/tests/integration/operations/test_get_item.py
@@ -56,3 +56,42 @@ def test_get_item_with_partial_key(dynamo):
 
     assert result is not None
     assert result["data"] == "first"
+
+
+def test_get_item_eventually_consistent(dynamo):
+    """Test get_item with eventually consistent read (default)."""
+    dynamo.put_item("test_table", {"pk": "CONSISTENT#1", "sk": "TEST", "data": "value"})
+
+    # Default is eventually consistent
+    result = dynamo.get_item(
+        "test_table",
+        {"pk": "CONSISTENT#1", "sk": "TEST"},
+    )
+
+    assert result is not None
+    assert result["data"] == "value"
+
+
+def test_get_item_strongly_consistent(dynamo):
+    """Test get_item with strongly consistent read."""
+    dynamo.put_item("test_table", {"pk": "CONSISTENT#2", "sk": "TEST", "data": "value"})
+
+    # Strongly consistent read
+    result = dynamo.get_item(
+        "test_table",
+        {"pk": "CONSISTENT#2", "sk": "TEST"},
+        consistent_read=True,
+    )
+
+    assert result is not None
+    assert result["data"] == "value"
+
+
+def test_get_item_consistent_read_not_found(dynamo):
+    """Test get_item with consistent_read returns None for non-existent items."""
+    result = dynamo.get_item(
+        "test_table",
+        {"pk": "NONEXISTENT", "sk": "NONE"},
+        consistent_read=True,
+    )
+    assert result is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -98,7 +98,7 @@ def test_model_uses_config_client():
 
     User.get(pk="USER#1")
 
-    mock_client.get_item.assert_called_once_with("users", {"pk": "USER#1"})
+    mock_client.get_item.assert_called_once_with("users", {"pk": "USER#1"}, consistent_read=False)
 
 
 def test_model_uses_default_client_when_no_config_client():
@@ -116,7 +116,7 @@ def test_model_uses_default_client_when_no_config_client():
 
     User.get(pk="USER#1")
 
-    mock_client.get_item.assert_called_once_with("users", {"pk": "USER#1"})
+    mock_client.get_item.assert_called_once_with("users", {"pk": "USER#1"}, consistent_read=False)
 
 
 def test_model_config_client_takes_priority_over_default():

--- a/tests/unit/test_consistent_read.py
+++ b/tests/unit/test_consistent_read.py
@@ -1,0 +1,91 @@
+"""Tests for consistent_read toggle feature."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock DynamoDB client."""
+    client = MagicMock()
+    client.get_item.return_value = None
+    return client
+
+
+def test_model_config_consistent_read_default():
+    """ModelConfig.consistent_read defaults to False."""
+    config = ModelConfig(table="test")
+    assert config.consistent_read is False
+
+
+def test_model_config_consistent_read_true():
+    """ModelConfig.consistent_read can be set to True."""
+    config = ModelConfig(table="test", consistent_read=True)
+    assert config.consistent_read is True
+
+
+def test_model_get_uses_config_consistent_read(mock_client):
+    """Model.get() uses model_config.consistent_read when not specified."""
+
+    class User(Model):
+        model_config = ModelConfig(table="users", client=mock_client, consistent_read=True)
+        pk = StringAttribute(hash_key=True)
+        name = StringAttribute()
+
+    User.get(pk="USER#123")
+
+    mock_client.get_item.assert_called_once()
+    call_kwargs = mock_client.get_item.call_args
+    assert call_kwargs[1]["consistent_read"] is True
+
+
+def test_model_get_override_consistent_read(mock_client):
+    """Model.get() can override model_config.consistent_read."""
+
+    class User(Model):
+        model_config = ModelConfig(table="users", client=mock_client, consistent_read=True)
+        pk = StringAttribute(hash_key=True)
+        name = StringAttribute()
+
+    # Override to False
+    User.get(pk="USER#123", consistent_read=False)
+
+    mock_client.get_item.assert_called_once()
+    call_kwargs = mock_client.get_item.call_args
+    assert call_kwargs[1]["consistent_read"] is False
+
+
+def test_model_get_default_eventually_consistent(mock_client):
+    """Model.get() defaults to eventually consistent when not configured."""
+
+    class User(Model):
+        model_config = ModelConfig(table="users", client=mock_client)
+        pk = StringAttribute(hash_key=True)
+        name = StringAttribute()
+
+    User.get(pk="USER#123")
+
+    mock_client.get_item.assert_called_once()
+    call_kwargs = mock_client.get_item.call_args
+    assert call_kwargs[1]["consistent_read"] is False
+
+
+def test_model_get_explicit_consistent_read(mock_client):
+    """Model.get() can request consistent read explicitly."""
+
+    class User(Model):
+        model_config = ModelConfig(table="users", client=mock_client)
+        pk = StringAttribute(hash_key=True)
+        name = StringAttribute()
+
+    User.get(pk="USER#123", consistent_read=True)
+
+    mock_client.get_item.assert_called_once()
+    call_kwargs = mock_client.get_item.call_args
+    assert call_kwargs[1]["consistent_read"] is True

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -144,7 +144,9 @@ def test_model_get(user_model, mock_client):
     assert user is not None
     assert user.pk == "USER#1"
     assert user.name == "John"
-    mock_client.get_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
+    mock_client.get_item.assert_called_once_with(
+        "users", {"pk": "USER#1", "sk": "PROFILE"}, consistent_read=False
+    )
 
 
 def test_model_get_not_found(user_model, mock_client):


### PR DESCRIPTION
Closes #61

Added `consistent_read` parameter to control read consistency at three levels:

1. **Per-operation** - pass `consistent_read=True` to `get()` or `query()`
2. **Model default** - set `consistent_read=True` in `ModelConfig`
3. **Low-level client** - pass to `get_item()` or `query()` directly

Per-operation takes priority over model config.

## Usage

```python
# Per-operation
user = User.get(pk="USER#123", consistent_read=True)

# Model default
class Order(Model):
    model_config = ModelConfig(table="orders", consistent_read=True)

# Low-level client
item = client.get_item("users", key, consistent_read=True)
```
