### PR TITLE
feat: add query class

### DIFF
--- a/docs/examples/query/async_query.py
+++ b/docs/examples/query/async_query.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+    status = StringAttribute()
+
+
+async def main():
+    # Async iteration
+    async for order in Order.async_query(hash_key="CUSTOMER#123"):
+        print(f"Order: {order.sk}")
+
+    # Get first result
+    first = await Order.async_query(hash_key="CUSTOMER#123").first()
+    if first:
+        print(f"First order: {first.sk}")
+
+    # Collect all results
+    orders = [order async for order in Order.async_query(hash_key="CUSTOMER#123")]
+    print(f"Found {len(orders)} orders")
+
+    # With conditions
+    shipped = [
+        order
+        async for order in Order.async_query(
+            hash_key="CUSTOMER#123",
+            filter_condition=Order.status == "shipped",
+        )
+    ]
+    print(f"Found {len(shipped)} shipped orders")
+
+
+asyncio.run(main())

--- a/docs/examples/query/basic_query.py
+++ b/docs/examples/query/basic_query.py
@@ -1,0 +1,24 @@
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+    status = StringAttribute()
+
+
+# Query all orders for a customer
+for order in Order.query(hash_key="CUSTOMER#123"):
+    print(f"Order: {order.sk}, Total: {order.total}")
+
+# Get first result only
+first_order = Order.query(hash_key="CUSTOMER#123").first()
+if first_order:
+    print(f"First order: {first_order.sk}")
+
+# Collect all results into a list
+orders = list(Order.query(hash_key="CUSTOMER#123"))
+print(f"Found {len(orders)} orders")

--- a/docs/examples/query/filter_condition.py
+++ b/docs/examples/query/filter_condition.py
@@ -1,0 +1,39 @@
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+    status = StringAttribute()
+
+
+# Filter by status
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    filter_condition=Order.status == "shipped",
+):
+    print(f"Shipped order: {order.sk}")
+
+# Filter by total amount
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    filter_condition=Order.total >= 100,
+):
+    print(f"Large order: {order.sk}, Total: {order.total}")
+
+# Combine multiple filters with & (AND)
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    filter_condition=(Order.status == "shipped") & (Order.total > 50),
+):
+    print(f"Shipped large order: {order.sk}")
+
+# Combine filters with | (OR)
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    filter_condition=(Order.status == "shipped") | (Order.status == "delivered"),
+):
+    print(f"Completed order: {order.sk}")

--- a/docs/examples/query/pagination.py
+++ b/docs/examples/query/pagination.py
@@ -1,0 +1,39 @@
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+    status = StringAttribute()
+
+
+# Automatic pagination - iterator fetches all pages
+for order in Order.query(hash_key="CUSTOMER#123"):
+    print(f"Order: {order.sk}")
+
+# Manual pagination - control page size
+result = Order.query(hash_key="CUSTOMER#123", limit=10)
+
+# Process first page
+page_count = 0
+for order in result:
+    print(f"Order: {order.sk}")
+    page_count += 1
+    if page_count >= 10:
+        break
+
+# Check if there are more pages
+if result.last_evaluated_key:
+    print("More pages available")
+
+    # Fetch next page
+    next_result = Order.query(
+        hash_key="CUSTOMER#123",
+        limit=10,
+        last_evaluated_key=result.last_evaluated_key,
+    )
+    for order in next_result:
+        print(f"Next page order: {order.sk}")

--- a/docs/examples/query/range_key_condition.py
+++ b/docs/examples/query/range_key_condition.py
@@ -1,0 +1,32 @@
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+    status = StringAttribute()
+
+
+# Query orders that start with "ORDER#"
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    range_key_condition=Order.sk.begins_with("ORDER#"),
+):
+    print(f"Order: {order.sk}")
+
+# Query orders between two sort keys
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    range_key_condition=Order.sk.between("ORDER#001", "ORDER#010"),
+):
+    print(f"Order: {order.sk}")
+
+# Query orders greater than a sort key
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    range_key_condition=Order.sk > "ORDER#005",
+):
+    print(f"Order: {order.sk}")

--- a/docs/examples/query/sorting_and_limit.py
+++ b/docs/examples/query/sorting_and_limit.py
@@ -1,0 +1,35 @@
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+    status = StringAttribute()
+
+
+# Ascending order (default)
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    scan_index_forward=True,
+):
+    print(f"Order: {order.sk}")
+
+# Descending order
+for order in Order.query(
+    hash_key="CUSTOMER#123",
+    scan_index_forward=False,
+):
+    print(f"Order: {order.sk}")
+
+# Get the 5 most recent orders (descending)
+recent_orders = Order.query(
+    hash_key="CUSTOMER#123",
+    scan_index_forward=False,
+    limit=5,
+).to_list()
+
+for order in recent_orders:
+    print(f"Recent order: {order.sk}")

--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -99,3 +99,10 @@ Fetch user and their orders at the same time:
 - No extra dependencies needed
 - Works with any asyncio event loop
 - Hooks still run synchronously (before/after save, etc.)
+
+
+## Next steps
+
+- [Batch operations](batch.md) - Work with multiple items at once
+- [Transactions](transactions.md) - All-or-nothing operations
+- [Query](query.md) - Query items with async support

--- a/docs/guides/atomic-updates.md
+++ b/docs/guides/atomic-updates.md
@@ -165,3 +165,10 @@ Use regular `update()` with kwargs when:
 - You're the only writer
 - You need to set values based on other fields
 - You're doing a simple field update
+
+
+## Next steps
+
+- [Observability](observability.md) - Track metrics on every operation
+- [Conditions](conditions.md) - Add conditions to atomic updates
+- [Transactions](transactions.md) - Combine atomic updates in transactions

--- a/docs/guides/attributes.md
+++ b/docs/guides/attributes.md
@@ -318,3 +318,10 @@ Modes:
 | Unique values | `StringSetAttribute` / `NumberSetAttribute` |
 | Large text | `CompressedAttribute` |
 | Sensitive data | `EncryptedAttribute` |
+
+
+## Next steps
+
+- [Indexes](indexes.md) - Query by non-key attributes with GSIs
+- [Auto-generate](auto-generate.md) - Generate IDs and timestamps
+- [Encryption](encryption.md) - Field-level encryption with KMS

--- a/docs/guides/auto-generate.md
+++ b/docs/guides/auto-generate.md
@@ -185,3 +185,10 @@ class Session(Model):
 session = Session(sk="SESSION#DATA", expires_at=ExpiresIn.hours(24))
 session.save()
 ```
+
+
+## Next steps
+
+- [Rate limiting](rate-limiting.md) - Control throughput
+- [Hooks](hooks.md) - Run code before/after operations
+- [Attributes](attributes.md) - All attribute types

--- a/docs/guides/batch.md
+++ b/docs/guides/batch.md
@@ -69,3 +69,10 @@ except Exception as e:
 2. **Don't batch single items** - For one or two items, use regular `put_item`. The overhead of batching isn't worth it.
 
 3. **Consider rate limiting** - If you're writing a lot of data, combine batch operations with rate limiting to avoid throttling.
+
+
+## Next steps
+
+- [Transactions](transactions.md) - All-or-nothing operations
+- [Rate limiting](rate-limiting.md) - Control throughput for bulk operations
+- [Observability](observability.md) - Track metrics on batch operations

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -216,3 +216,10 @@ client = DynamoDBClient(
 ### Missing something?
 
 Open a [feature request](https://github.com/leandrodamascena/pydynox/issues/new?template=feature_request.md) on GitHub. We prioritize based on community feedback.
+
+
+## Next steps
+
+- [Models](models.md) - Define models with typed attributes
+- [Rate limiting](rate-limiting.md) - Control throughput
+- [Observability](observability.md) - Logging and metrics

--- a/docs/guides/conditions.md
+++ b/docs/guides/conditions.md
@@ -154,3 +154,10 @@ from pydynox import Condition
 def apply_filter(cond: Condition) -> None:
     ...
 ```
+
+
+## Next steps
+
+- [Query](query.md) - Query items with conditions
+- [Atomic updates](atomic-updates.md) - Increment, append, and other atomic operations
+- [Transactions](transactions.md) - All-or-nothing operations

--- a/docs/guides/dataclass.md
+++ b/docs/guides/dataclass.md
@@ -144,3 +144,10 @@ class User:
 
 !!! note
     The `@dynamodb_model` decorator must come before `@dataclass` in the decorator order.
+
+
+## Next steps
+
+- [Exceptions](exceptions.md) - Error handling
+- [Models](models.md) - Native pydynox models
+- [Pydantic](pydantic.md) - Use Pydantic for validation

--- a/docs/guides/encryption.md
+++ b/docs/guides/encryption.md
@@ -132,3 +132,10 @@ Common errors:
 | Access denied | Missing IAM permissions |
 | Cannot encrypt in ReadOnly mode | Wrong mode for operation |
 | Cannot decrypt in WriteOnly mode | Wrong mode for operation |
+
+
+## Next steps
+
+- [Size calculator](size-calculator.md) - Check item sizes
+- [IAM permissions](iam-permissions.md) - KMS permissions
+- [Attributes](attributes.md) - All attribute types

--- a/docs/guides/exceptions.md
+++ b/docs/guides/exceptions.md
@@ -167,3 +167,10 @@ Common causes:
 4. **Check credentials early** - Call `client.ping()` at startup to catch credential issues
 
 5. **Handle connection errors gracefully** - Especially in Lambda where cold starts can cause timeouts
+
+
+## Next steps
+
+- [IAM permissions](iam-permissions.md) - Required AWS permissions
+- [Rate limiting](rate-limiting.md) - Avoid throttling errors
+- [Observability](observability.md) - Logging and metrics

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -110,3 +110,10 @@ class User(Model):
 Hooks run for each item in a transaction. If you're saving 10 items in a transaction, `before_save` runs 10 times.
 
 If a hook raises an exception, the entire transaction fails and nothing is saved.
+
+
+## Next steps
+
+- [Auto-generate](auto-generate.md) - Generate IDs and timestamps
+- [Models](models.md) - Model CRUD operations
+- [Conditions](conditions.md) - Conditional writes

--- a/docs/guides/iam-permissions.md
+++ b/docs/guides/iam-permissions.md
@@ -174,3 +174,10 @@ A service that does CRUD, batch operations, and field encryption:
 - **Separate read and write** - Use different roles for read-only and write services
 - **Use KMS key aliases** - Easier to manage than key IDs in policies
 - **Test permissions** - Use IAM Policy Simulator to verify your policies
+
+
+## Next steps
+
+- [Client](client.md) - Configure the DynamoDB client
+- [Encryption](encryption.md) - KMS permissions for encryption
+- [Tables](tables.md) - Table management permissions

--- a/docs/guides/indexes.md
+++ b/docs/guides/indexes.md
@@ -176,3 +176,10 @@ Control which attributes are copied to the index:
 - GSIs are read-only. To update data, update the main table.
 - GSI queries are eventually consistent by default.
 - Each table can have up to 20 GSIs.
+
+
+## Next steps
+
+- [Conditions](conditions.md) - Filter and conditional writes
+- [Query](query.md) - Query items by hash key with conditions
+- [Tables](tables.md) - Create tables with GSIs

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -269,6 +269,7 @@ except ThrottlingError:
 
 ## Next steps
 
+- [Query](query.md) - Query items by hash key with conditions
 - [Attribute types](attributes.md) - All available attribute types
 - [Indexes](indexes.md) - Query by non-key attributes with GSIs
 - [Conditions](conditions.md) - Conditional writes

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -181,3 +181,10 @@ def handler(event, context):
     
     return {"statusCode": 200}
 ```
+
+
+## Next steps
+
+- [Async support](async.md) - Async/await for high-concurrency apps
+- [Rate limiting](rate-limiting.md) - Control throughput
+- [Exceptions](exceptions.md) - Error handling

--- a/docs/guides/pydantic.md
+++ b/docs/guides/pydantic.md
@@ -193,3 +193,10 @@ class Session(BaseModel):
 
 !!! note
     Remember to enable TTL on your DynamoDB table and set the attribute name to `expires_at`.
+
+
+## Next steps
+
+- [Dataclass](dataclass.md) - Use dataclasses with DynamoDB
+- [Models](models.md) - Native pydynox models
+- [Hooks](hooks.md) - Lifecycle hooks for validation

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -1,0 +1,172 @@
+# Query
+
+Query items from DynamoDB using typed conditions. Returns model instances with full type hints.
+
+## Key features
+
+- Type-safe queries with model attributes
+- Range key conditions (begins_with, between, comparisons)
+- Filter conditions on any attribute
+- Automatic pagination
+- Ascending/descending sort order
+- Async support
+
+## Getting started
+
+### Basic query
+
+Use `Model.query()` to fetch items by hash key:
+
+=== "basic_query.py"
+    ```python
+    --8<-- "docs/examples/query/basic_query.py"
+    ```
+
+The query returns a `ModelQueryResult` that you can:
+
+- Iterate with `for` loop
+- Get first result with `.first()`
+- Collect all with `list()`
+
+### Range key conditions
+
+Filter by sort key using attribute conditions:
+
+=== "range_key_condition.py"
+    ```python
+    --8<-- "docs/examples/query/range_key_condition.py"
+    ```
+
+Available range key conditions:
+
+| Condition | Example | Description |
+|-----------|---------|-------------|
+| `begins_with` | `Order.sk.begins_with("ORDER#")` | Sort key starts with prefix |
+| `between` | `Order.sk.between("A", "Z")` | Sort key in range |
+| `=` | `Order.sk == "ORDER#001"` | Exact match |
+| `<` | `Order.sk < "ORDER#100"` | Less than |
+| `<=` | `Order.sk <= "ORDER#100"` | Less than or equal |
+| `>` | `Order.sk > "ORDER#001"` | Greater than |
+| `>=` | `Order.sk >= "ORDER#001"` | Greater than or equal |
+
+!!! tip
+    Range key conditions are efficient. DynamoDB uses them to limit the items it reads.
+
+### Filter conditions
+
+Filter results by any attribute:
+
+=== "filter_condition.py"
+    ```python
+    --8<-- "docs/examples/query/filter_condition.py"
+    ```
+
+!!! warning
+    Filter conditions are applied after DynamoDB reads the items. You still pay for the read capacity of filtered-out items.
+
+### Sorting and limit
+
+Control sort order and page size:
+
+=== "sorting_and_limit.py"
+    ```python
+    --8<-- "docs/examples/query/sorting_and_limit.py"
+    ```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `scan_index_forward` | `True` | `True` = ascending, `False` = descending |
+| `limit` | None | Items per page (iterator fetches all pages) |
+
+## Advanced
+
+### Pagination
+
+By default, the iterator fetches all pages automatically. For manual control:
+
+=== "pagination.py"
+    ```python
+    --8<-- "docs/examples/query/pagination.py"
+    ```
+
+Use `last_evaluated_key` to:
+
+- Implement "load more" buttons
+- Process large datasets in batches
+- Resume interrupted queries
+
+### Consistent reads
+
+For strongly consistent reads:
+
+```python
+orders = list(
+    Order.query(
+        hash_key="CUSTOMER#123",
+        consistent_read=True,
+    )
+)
+```
+
+Or set it as default in ModelConfig:
+
+```python
+class Order(Model):
+    model_config = ModelConfig(table="orders", consistent_read=True)
+```
+
+### Metrics
+
+Access query metrics after iteration:
+
+```python
+result = Order.query(hash_key="CUSTOMER#123")
+orders = list(result)
+
+print(f"Duration: {result.metrics.duration_ms}ms")
+print(f"RCU consumed: {result.metrics.consumed_rcu}")
+print(f"Items returned: {result.metrics.items_count}")
+```
+
+### Async queries
+
+Use `async_query()` for async code:
+
+=== "async_query.py"
+    ```python
+    --8<-- "docs/examples/query/async_query.py"
+    ```
+
+### Query parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `hash_key` | Any | Required | Hash key value |
+| `range_key_condition` | Condition | None | Condition on sort key |
+| `filter_condition` | Condition | None | Filter on any attribute |
+| `limit` | int | None | Items per page |
+| `scan_index_forward` | bool | True | Sort order |
+| `consistent_read` | bool | None | Strongly consistent read |
+| `last_evaluated_key` | dict | None | Start key for pagination |
+
+## Query vs GSI query
+
+Use `Model.query()` when querying by the table's hash key.
+
+Use [GSI query](indexes.md) when querying by a different attribute:
+
+```python
+# Table query - by pk
+for order in Order.query(hash_key="CUSTOMER#123"):
+    print(order.sk)
+
+# GSI query - by status
+for order in Order.status_index.query(status="shipped"):
+    print(order.pk)
+```
+
+## Next steps
+
+- [Atomic updates](atomic-updates.md) - Increment, append, and other atomic operations
+- [Conditions](conditions.md) - All condition operators
+- [Indexes](indexes.md) - Query by non-key attributes

--- a/docs/guides/rate-limiting.md
+++ b/docs/guides/rate-limiting.md
@@ -121,3 +121,10 @@ with BatchWriter(client, "users") as batch:
 
 !!! tip
     When doing bulk writes, combine rate limiting with batch operations. This gives you both efficiency (fewer API calls) and control (predictable throughput).
+
+
+## Next steps
+
+- [Encryption](encryption.md) - Field-level encryption with KMS
+- [Batch operations](batch.md) - Combine rate limiting with batch writes
+- [Observability](observability.md) - Track rate limit metrics

--- a/docs/guides/size-calculator.md
+++ b/docs/guides/size-calculator.md
@@ -130,3 +130,10 @@ The error includes:
 - **Debugging size issues** - Find which fields are too big
 - **Setting limits** - Enforce smaller limits than 400KB for your app
 - **Monitoring** - Track item sizes over time
+
+
+## Next steps
+
+- [Pydantic](pydantic.md) - Use Pydantic models with DynamoDB
+- [Attributes](attributes.md) - All attribute types
+- [Batch operations](batch.md) - Work with multiple items

--- a/docs/guides/tables.md
+++ b/docs/guides/tables.md
@@ -122,3 +122,10 @@ client.wait_for_table_active("users", timeout_seconds=30)
 | `encryption` | str | `"AWS_OWNED"` | Encryption type |
 | `kms_key_id` | str | None | KMS key ARN |
 | `wait` | bool | False | Wait for table to be active |
+
+
+## Next steps
+
+- [Indexes](indexes.md) - Add GSIs to your tables
+- [IAM permissions](iam-permissions.md) - Required permissions for table operations
+- [Models](models.md) - Define models for your tables

--- a/docs/guides/transactions.md
+++ b/docs/guides/transactions.md
@@ -100,3 +100,10 @@ Common reasons for transaction failures:
 - More than 100 items
 - Condition check failed
 - Throughput exceeded
+
+
+## Next steps
+
+- [Tables](tables.md) - Create and manage tables
+- [Conditions](conditions.md) - Add conditions to transactions
+- [Exceptions](exceptions.md) - Handle transaction errors

--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -64,7 +64,7 @@ from pydynox.config import (
 from pydynox.generators import AutoGenerate
 from pydynox.indexes import GlobalSecondaryIndex
 from pydynox.integrations.functions import dynamodb_model
-from pydynox.model import Model
+from pydynox.model import AsyncModelQueryResult, Model, ModelQueryResult
 from pydynox.query import QueryResult
 from pydynox.transaction import Transaction
 
@@ -77,11 +77,13 @@ __all__ = [
     "QueryResult",
     "Transaction",
     # Model ORM
+    "AsyncModelQueryResult",
     "AutoGenerate",
     "Condition",
     "GlobalSecondaryIndex",
     "Model",
     "ModelConfig",
+    "ModelQueryResult",
     # Metrics (public class for type hints)
     "OperationMetrics",
     # Logging

--- a/tests/integration/operations/test_model_query.py
+++ b/tests/integration/operations/test_model_query.py
@@ -1,0 +1,247 @@
+"""Integration tests for Model.query() method."""
+
+import pytest
+from pydynox import Model, ModelConfig, set_default_client
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+@pytest.fixture
+def order_model(dynamo):
+    """Create an Order model for testing."""
+    set_default_client(dynamo)
+
+    class Order(Model):
+        model_config = ModelConfig(table="test_table")
+        pk = StringAttribute(hash_key=True)
+        sk = StringAttribute(range_key=True)
+        total = NumberAttribute()
+        status = StringAttribute()
+
+    Order._client_instance = None
+    return Order
+
+
+@pytest.fixture
+def populated_orders(dynamo, order_model):
+    """Create test data for query tests."""
+    items = [
+        {"pk": "CUSTOMER#1", "sk": "ORDER#001", "total": 100, "status": "shipped"},
+        {"pk": "CUSTOMER#1", "sk": "ORDER#002", "total": 200, "status": "pending"},
+        {"pk": "CUSTOMER#1", "sk": "ORDER#003", "total": 50, "status": "shipped"},
+        {"pk": "CUSTOMER#1", "sk": "PROFILE", "total": 0, "status": "active"},
+        {"pk": "CUSTOMER#2", "sk": "ORDER#001", "total": 75, "status": "shipped"},
+    ]
+    for item in items:
+        dynamo.put_item("test_table", item)
+    return order_model
+
+
+def test_model_query_by_hash_key(populated_orders):
+    """Test Model.query returns typed instances."""
+    Order = populated_orders
+
+    orders = list(Order.query(hash_key="CUSTOMER#1"))
+
+    assert len(orders) == 4
+    for order in orders:
+        assert isinstance(order, Order)
+        assert order.pk == "CUSTOMER#1"
+
+
+def test_model_query_with_range_key_condition(populated_orders):
+    """Test Model.query with range_key_condition."""
+    Order = populated_orders
+
+    orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            range_key_condition=Order.sk.begins_with("ORDER#"),
+        )
+    )
+
+    assert len(orders) == 3
+    for order in orders:
+        assert order.sk.startswith("ORDER#")
+
+
+def test_model_query_with_filter_condition(populated_orders):
+    """Test Model.query with filter_condition."""
+    Order = populated_orders
+
+    orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            filter_condition=Order.status == "shipped",
+        )
+    )
+
+    assert len(orders) == 2
+    for order in orders:
+        assert order.status == "shipped"
+
+
+def test_model_query_with_range_and_filter(populated_orders):
+    """Test Model.query with both range_key_condition and filter_condition."""
+    Order = populated_orders
+
+    orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            range_key_condition=Order.sk.begins_with("ORDER#"),
+            filter_condition=Order.total >= 100,
+        )
+    )
+
+    assert len(orders) == 2
+    for order in orders:
+        assert order.sk.startswith("ORDER#")
+        assert order.total >= 100
+
+
+def test_model_query_descending_order(populated_orders):
+    """Test Model.query with scan_index_forward=False."""
+    Order = populated_orders
+
+    asc_orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            range_key_condition=Order.sk.begins_with("ORDER#"),
+            scan_index_forward=True,
+        )
+    )
+
+    desc_orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            range_key_condition=Order.sk.begins_with("ORDER#"),
+            scan_index_forward=False,
+        )
+    )
+
+    asc_sks = [o.sk for o in asc_orders]
+    desc_sks = [o.sk for o in desc_orders]
+
+    assert asc_sks == list(reversed(desc_sks))
+
+
+def test_model_query_with_limit(populated_orders):
+    """Test Model.query with limit (auto-paginates)."""
+    Order = populated_orders
+
+    # limit is per page, but iterator fetches all
+    orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            limit=2,
+        )
+    )
+
+    assert len(orders) == 4
+
+
+def test_model_query_first(populated_orders):
+    """Test Model.query().first() returns first result."""
+    Order = populated_orders
+
+    order = Order.query(
+        hash_key="CUSTOMER#1",
+        range_key_condition=Order.sk.begins_with("ORDER#"),
+    ).first()
+
+    assert order is not None
+    assert isinstance(order, Order)
+    assert order.sk == "ORDER#001"
+
+
+def test_model_query_first_empty(populated_orders):
+    """Test Model.query().first() returns None when no results."""
+    Order = populated_orders
+
+    order = Order.query(hash_key="NONEXISTENT").first()
+
+    assert order is None
+
+
+def test_model_query_iteration(populated_orders):
+    """Test Model.query can be iterated with for loop."""
+    Order = populated_orders
+
+    count = 0
+    for order in Order.query(hash_key="CUSTOMER#1"):
+        assert isinstance(order, Order)
+        count += 1
+
+    assert count == 4
+
+
+def test_model_query_empty_result(populated_orders):
+    """Test Model.query with no matching items."""
+    Order = populated_orders
+
+    orders = list(Order.query(hash_key="NONEXISTENT"))
+
+    assert orders == []
+
+
+def test_model_query_metrics(populated_orders):
+    """Test Model.query exposes metrics after iteration."""
+    Order = populated_orders
+
+    result = Order.query(hash_key="CUSTOMER#1")
+
+    # metrics is None before iteration
+    assert result.metrics is None
+
+    # iterate
+    _ = list(result)
+
+    # metrics available after iteration
+    assert result.metrics is not None
+    assert result.metrics.duration_ms > 0
+
+
+def test_model_query_last_evaluated_key(populated_orders):
+    """Test Model.query exposes last_evaluated_key."""
+    Order = populated_orders
+
+    result = Order.query(hash_key="CUSTOMER#1")
+
+    # None before iteration
+    assert result.last_evaluated_key is None
+
+    # iterate all
+    _ = list(result)
+
+    # None after consuming all (no more pages)
+    assert result.last_evaluated_key is None
+
+
+def test_model_query_consistent_read(populated_orders):
+    """Test Model.query with consistent_read=True."""
+    Order = populated_orders
+
+    orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            consistent_read=True,
+        )
+    )
+
+    assert len(orders) == 4
+
+
+def test_model_query_complex_filter(populated_orders):
+    """Test Model.query with complex filter condition."""
+    Order = populated_orders
+
+    orders = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            range_key_condition=Order.sk.begins_with("ORDER#"),
+            filter_condition=(Order.status == "shipped") & (Order.total > 50),
+        )
+    )
+
+    assert len(orders) == 1
+    assert orders[0].total == 100
+    assert orders[0].status == "shipped"

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,0 +1,198 @@
+"""Tests for Model.query() method."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydynox import Model, ModelConfig, clear_default_client
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.model import AsyncModelQueryResult, ModelQueryResult
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Reset default client before and after each test."""
+    clear_default_client()
+    yield
+    clear_default_client()
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock DynamoDB client."""
+    client = MagicMock()
+    client._client = MagicMock()
+    client._acquire_rcu = MagicMock()
+    return client
+
+
+@pytest.fixture
+def user_model(mock_client):
+    """Create a User model with mock client."""
+
+    class User(Model):
+        model_config = ModelConfig(table="users", client=mock_client)
+        pk = StringAttribute(hash_key=True)
+        sk = StringAttribute(range_key=True)
+        name = StringAttribute()
+        age = NumberAttribute()
+
+    User._client_instance = None
+    return User
+
+
+def test_query_returns_model_query_result(user_model):
+    """Model.query returns a ModelQueryResult."""
+    result = user_model.query(hash_key="USER#123")
+
+    assert isinstance(result, ModelQueryResult)
+
+
+def test_query_stores_parameters(user_model):
+    """ModelQueryResult stores all query parameters."""
+    result = user_model.query(
+        hash_key="USER#123",
+        limit=10,
+        scan_index_forward=False,
+        consistent_read=True,
+    )
+
+    assert result._hash_key_value == "USER#123"
+    assert result._limit == 10
+    assert result._scan_index_forward is False
+    assert result._consistent_read is True
+
+
+def test_query_with_range_key_condition(user_model):
+    """Model.query accepts range_key_condition."""
+    condition = user_model.sk.begins_with("ORDER#")
+
+    result = user_model.query(
+        hash_key="USER#123",
+        range_key_condition=condition,
+    )
+
+    assert result._range_key_condition is condition
+
+
+def test_query_with_filter_condition(user_model):
+    """Model.query accepts filter_condition."""
+    condition = user_model.age > 18
+
+    result = user_model.query(
+        hash_key="USER#123",
+        filter_condition=condition,
+    )
+
+    assert result._filter_condition is condition
+
+
+def test_query_with_pagination(user_model):
+    """Model.query accepts last_evaluated_key for pagination."""
+    last_key = {"pk": "USER#123", "sk": "ORDER#999"}
+
+    result = user_model.query(
+        hash_key="USER#123",
+        last_evaluated_key=last_key,
+    )
+
+    assert result._start_key == last_key
+
+
+def test_model_query_result_first_returns_none_when_empty(user_model):
+    """ModelQueryResult.first() returns None when no results."""
+    with patch.object(ModelQueryResult, "_build_query") as mock_build:
+        mock_query_result = MagicMock()
+        mock_query_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_build.return_value = mock_query_result
+
+        result = user_model.query(hash_key="USER#123")
+        first = result.first()
+
+        assert first is None
+
+
+def test_model_query_result_list(user_model):
+    """list(ModelQueryResult) collects all results."""
+    with patch.object(ModelQueryResult, "_build_query") as mock_build:
+        mock_query_result = MagicMock()
+        items = [
+            {"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1"},
+            {"pk": "USER#123", "sk": "ORDER#2", "name": "Order 2"},
+        ]
+        mock_query_result.__iter__ = MagicMock(return_value=iter(items))
+        mock_build.return_value = mock_query_result
+
+        result = user_model.query(hash_key="USER#123")
+        users = list(result)
+
+        assert len(users) == 2
+        assert users[0].sk == "ORDER#1"
+        assert users[1].sk == "ORDER#2"
+
+
+def test_model_query_result_iteration(user_model):
+    """ModelQueryResult can be iterated."""
+    with patch.object(ModelQueryResult, "_build_query") as mock_build:
+        mock_query_result = MagicMock()
+        items = [
+            {"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1"},
+        ]
+        mock_query_result.__iter__ = MagicMock(return_value=iter(items))
+        mock_build.return_value = mock_query_result
+
+        result = user_model.query(hash_key="USER#123")
+        users = list(result)
+
+        assert len(users) == 1
+        assert isinstance(users[0], user_model)
+
+
+def test_model_query_result_metrics_before_iteration(user_model):
+    """ModelQueryResult.metrics is None before iteration."""
+    result = user_model.query(hash_key="USER#123")
+
+    assert result.metrics is None
+
+
+def test_model_query_result_last_evaluated_key_before_iteration(user_model):
+    """ModelQueryResult.last_evaluated_key is None before iteration."""
+    result = user_model.query(hash_key="USER#123")
+
+    assert result.last_evaluated_key is None
+
+
+def test_async_query_returns_async_model_query_result(user_model):
+    """Model.async_query returns an AsyncModelQueryResult."""
+    result = user_model.async_query(hash_key="USER#123")
+
+    assert isinstance(result, AsyncModelQueryResult)
+
+
+def test_async_query_stores_parameters(user_model):
+    """AsyncModelQueryResult stores all query parameters."""
+    result = user_model.async_query(
+        hash_key="USER#123",
+        limit=10,
+        scan_index_forward=False,
+        consistent_read=True,
+    )
+
+    assert result._hash_key_value == "USER#123"
+    assert result._limit == 10
+    assert result._scan_index_forward is False
+    assert result._consistent_read is True
+
+
+def test_query_raises_error_without_hash_key(mock_client):
+    """Model.query raises error if model has no hash key."""
+
+    class BadModel(Model):
+        model_config = ModelConfig(table="bad", client=mock_client)
+        name = StringAttribute()
+
+    BadModel._client_instance = None
+
+    result = BadModel.query(hash_key="test")
+
+    with pytest.raises(ValueError, match="has no hash key defined"):
+        result.first()

--- a/zensical.toml
+++ b/zensical.toml
@@ -15,6 +15,7 @@ nav = [
         "guides/attributes.md",
         "guides/indexes.md",
         "guides/conditions.md",
+        "guides/query.md",
         "guides/atomic-updates.md",
         "guides/observability.md",
     ] },


### PR DESCRIPTION
Adds `Model.query()` and `Model.async_query()` class methods for querying items by hash key with typed conditions.

### Usage

```python
# Query by hash key
for order in Order.query(hash_key="CUSTOMER#123"):
    print(order.total)

# With range key condition
for order in Order.query(
    hash_key="CUSTOMER#123",
    range_key_condition=Order.sk.begins_with("ORDER#"),
):
    print(order.sk)

# With filter
for order in Order.query(
    hash_key="CUSTOMER#123",
    filter_condition=Order.status == "shipped",
):
    print(order.status)

# Get first result
first = Order.query(hash_key="CUSTOMER#123").first()

# Collect all
all_orders = list(Order.query(hash_key="CUSTOMER#123"))

# Async
async for order in Order.async_query(hash_key="CUSTOMER#123"):
    print(order.total)
```

closes #6 