### PR TITLE
feat: add multi-attribute GSI keys support

### DIFF
--- a/docs/examples/indexes/basic_gsi.py
+++ b/docs/examples/indexes/basic_gsi.py
@@ -1,51 +1,26 @@
-"""Basic GSI example - query users by email."""
-
-from pydynox import DynamoDBClient, GlobalSecondaryIndex, Model, ModelConfig, set_default_client
+from pydynox import Model, ModelConfig
 from pydynox.attributes import NumberAttribute, StringAttribute
-
-# Setup client
-client = DynamoDBClient(endpoint_url="http://localhost:8000")
-set_default_client(client)
+from pydynox.indexes import GlobalSecondaryIndex
 
 
 class User(Model):
-    """User model with email GSI."""
-
     model_config = ModelConfig(table="users")
 
     pk = StringAttribute(hash_key=True)
     sk = StringAttribute(range_key=True)
     email = StringAttribute()
-    name = StringAttribute()
+    status = StringAttribute()
     age = NumberAttribute()
 
-    # Define GSI to query by email
+    # GSI with hash key only
     email_index = GlobalSecondaryIndex(
         index_name="email-index",
         hash_key="email",
     )
 
-
-# Create table with GSI
-if not client.table_exists("users"):
-    client.create_table(
-        "users",
-        hash_key=("pk", "S"),
-        range_key=("sk", "S"),
-        global_secondary_indexes=[
-            {
-                "index_name": "email-index",
-                "hash_key": ("email", "S"),
-                "projection": "ALL",
-            }
-        ],
+    # GSI with hash and range key
+    status_index = GlobalSecondaryIndex(
+        index_name="status-index",
+        hash_key="status",
+        range_key="pk",
     )
-
-# Create some users
-User(pk="USER#1", sk="PROFILE", email="john@example.com", name="John", age=30).save()
-User(pk="USER#2", sk="PROFILE", email="jane@example.com", name="Jane", age=25).save()
-
-# Query by email using GSI
-print("Query by email:")
-for user in User.email_index.query(email="john@example.com"):
-    print(f"  Found: {user.name} (pk={user.pk})")

--- a/docs/examples/indexes/create_table_gsi.py
+++ b/docs/examples/indexes/create_table_gsi.py
@@ -1,0 +1,22 @@
+from pydynox import DynamoDBClient
+
+client = DynamoDBClient()
+
+client.create_table(
+    "users",
+    hash_key=("pk", "S"),
+    range_key=("sk", "S"),
+    global_secondary_indexes=[
+        {
+            "index_name": "email-index",
+            "hash_key": ("email", "S"),
+            "projection": "ALL",
+        },
+        {
+            "index_name": "status-index",
+            "hash_key": ("status", "S"),
+            "range_key": ("pk", "S"),
+            "projection": "ALL",
+        },
+    ],
+)

--- a/docs/examples/indexes/create_table_multi_attr.py
+++ b/docs/examples/indexes/create_table_multi_attr.py
@@ -1,0 +1,22 @@
+from pydynox import DynamoDBClient
+
+client = DynamoDBClient()
+
+client.create_table(
+    "products",
+    hash_key=("pk", "S"),
+    range_key=("sk", "S"),
+    global_secondary_indexes=[
+        {
+            "index_name": "location-index",
+            "hash_keys": [("tenant_id", "S"), ("region", "S")],
+            "range_keys": [("created_at", "S"), ("item_id", "S")],
+            "projection": "ALL",
+        },
+        {
+            "index_name": "category-index",
+            "hash_keys": [("category", "S"), ("subcategory", "S")],
+            "projection": "ALL",
+        },
+    ],
+)

--- a/docs/examples/indexes/filter_condition.py
+++ b/docs/examples/indexes/filter_condition.py
@@ -1,0 +1,6 @@
+# ruff: noqa: F821
+# Query active users over 30
+users = User.status_index.query(
+    status="active",
+    filter_condition=User.age >= 30,
+)

--- a/docs/examples/indexes/multi_attr_gsi.py
+++ b/docs/examples/indexes/multi_attr_gsi.py
@@ -1,0 +1,31 @@
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.indexes import GlobalSecondaryIndex
+
+
+class Product(Model):
+    model_config = ModelConfig(table="products")
+
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    tenant_id = StringAttribute()
+    region = StringAttribute()
+    created_at = StringAttribute()
+    item_id = StringAttribute()
+    category = StringAttribute()
+    subcategory = StringAttribute()
+    name = StringAttribute()
+    price = NumberAttribute()
+
+    # Multi-attribute GSI: 2 partition keys + 2 sort keys
+    location_index = GlobalSecondaryIndex(
+        index_name="location-index",
+        hash_key=["tenant_id", "region"],
+        range_key=["created_at", "item_id"],
+    )
+
+    # Multi-attribute GSI: 2 partition keys only
+    category_index = GlobalSecondaryIndex(
+        index_name="category-index",
+        hash_key=["category", "subcategory"],
+    )

--- a/docs/examples/indexes/query_gsi.py
+++ b/docs/examples/indexes/query_gsi.py
@@ -1,0 +1,10 @@
+# ruff: noqa: F821
+# Query by email
+users = User.email_index.query(email="john@example.com")
+for user in users:
+    print(user.name)
+
+# Query by status
+active_users = User.status_index.query(status="active")
+for user in active_users:
+    print(user.email)

--- a/docs/examples/indexes/query_multi_attr.py
+++ b/docs/examples/indexes/query_multi_attr.py
@@ -1,0 +1,22 @@
+# ruff: noqa: F821
+# All partition key attributes are required
+products = Product.location_index.query(
+    tenant_id="ACME",
+    region="us-east-1",
+)
+
+for product in products:
+    print(f"{product.name}: ${product.price}")
+
+# Query category index
+phones = Product.category_index.query(
+    category="electronics",
+    subcategory="phones",
+)
+
+# With filter
+expensive = Product.location_index.query(
+    tenant_id="ACME",
+    region="us-east-1",
+    filter_condition=Product.price >= 1000,
+)

--- a/docs/examples/indexes/range_key_condition.py
+++ b/docs/examples/indexes/range_key_condition.py
@@ -1,0 +1,12 @@
+# ruff: noqa: F821
+# Query active users with pk starting with "USER#"
+users = User.status_index.query(
+    status="active",
+    range_key_condition=User.pk.begins_with("USER#"),
+)
+
+# Query with comparison
+users = User.status_index.query(
+    status="active",
+    range_key_condition=User.pk >= "USER#100",
+)

--- a/docs/examples/s3/async_operations.py
+++ b/docs/examples/s3/async_operations.py
@@ -2,8 +2,8 @@
 
 import asyncio
 
-from pydynox import Model, ModelConfig, DynamoDBClient, set_default_client
-from pydynox.attributes import StringAttribute, S3Attribute, S3File
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import S3Attribute, S3File, StringAttribute
 
 # Setup client
 client = DynamoDBClient(region="us-east-1")

--- a/docs/examples/s3/basic_upload.py
+++ b/docs/examples/s3/basic_upload.py
@@ -1,7 +1,7 @@
 """Basic S3 upload example."""
 
-from pydynox import Model, ModelConfig, DynamoDBClient, set_default_client
-from pydynox.attributes import StringAttribute, S3Attribute, S3File
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import S3Attribute, S3File, StringAttribute
 
 # Setup client
 client = DynamoDBClient(region="us-east-1")

--- a/docs/examples/s3/download.py
+++ b/docs/examples/s3/download.py
@@ -1,7 +1,7 @@
 """Download S3 content."""
 
-from pydynox import Model, ModelConfig, DynamoDBClient, set_default_client
-from pydynox.attributes import StringAttribute, S3Attribute
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import S3Attribute, StringAttribute
 
 # Setup client
 client = DynamoDBClient(region="us-east-1")

--- a/docs/examples/s3/upload_from_file.py
+++ b/docs/examples/s3/upload_from_file.py
@@ -2,8 +2,8 @@
 
 from pathlib import Path
 
-from pydynox import Model, ModelConfig, DynamoDBClient, set_default_client
-from pydynox.attributes import StringAttribute, S3Attribute, S3File
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import S3Attribute, S3File, StringAttribute
 
 # Setup client
 client = DynamoDBClient(region="us-east-1")

--- a/docs/examples/s3/with_metadata.py
+++ b/docs/examples/s3/with_metadata.py
@@ -1,7 +1,7 @@
 """Upload with custom metadata."""
 
-from pydynox import Model, ModelConfig, DynamoDBClient, set_default_client
-from pydynox.attributes import StringAttribute, S3Attribute, S3File
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import S3Attribute, S3File, StringAttribute
 
 # Setup client
 client = DynamoDBClient(region="us-east-1")

--- a/docs/guides/indexes.md
+++ b/docs/guides/indexes.md
@@ -1,83 +1,50 @@
-# Global Secondary Indexes
+# Global secondary indexes
 
 GSIs let you query by attributes other than the table's primary key. Define them as class attributes on your Model.
 
+## Key features
+
+- Query by any attribute, not just the primary key
+- Single or multi-attribute composite keys (up to 4 per key)
+- Range key conditions for efficient filtering
+- Automatic pagination with metrics
+
 ## Define a GSI
 
-```python
-from pydynox import Model, ModelConfig, GlobalSecondaryIndex
-from pydynox.attributes import StringAttribute, NumberAttribute
-
-class User(Model):
-    model_config = ModelConfig(table="users")
-    
-    pk = StringAttribute(hash_key=True)
-    sk = StringAttribute(range_key=True)
-    email = StringAttribute()
-    status = StringAttribute()
-    age = NumberAttribute()
-    
-    # GSI with hash key only
-    email_index = GlobalSecondaryIndex(
-        index_name="email-index",
-        hash_key="email",
-    )
-    
-    # GSI with hash and range key
-    status_index = GlobalSecondaryIndex(
-        index_name="status-index",
-        hash_key="status",
-        range_key="pk",
-    )
-```
+=== "basic_gsi.py"
+    ```python
+    --8<-- "docs/examples/indexes/basic_gsi.py"
+    ```
 
 ## Query a GSI
 
 Use the index attribute to query:
 
-```python
-# Query by email
-users = User.email_index.query(email="john@example.com")
-for user in users:
-    print(user.name)
-
-# Query by status
-active_users = User.status_index.query(status="active")
-for user in active_users:
-    print(user.email)
-```
+=== "query_gsi.py"
+    ```python
+    --8<-- "docs/examples/indexes/query_gsi.py"
+    ```
 
 ## Range key conditions
 
 When your GSI has a range key, you can add conditions:
 
-```python
-# Query active users with pk starting with "USER#"
-users = User.status_index.query(
-    status="active",
-    range_key_condition=User.pk.begins_with("USER#"),
-)
-
-# Query with comparison
-users = User.status_index.query(
-    status="active",
-    range_key_condition=User.pk >= "USER#100",
-)
-```
+=== "range_key_condition.py"
+    ```python
+    --8<-- "docs/examples/indexes/range_key_condition.py"
+    ```
 
 ## Filter conditions
 
 Filter non-key attributes after the query:
 
-```python
-# Query active users over 30
-users = User.status_index.query(
-    status="active",
-    filter_condition=User.age >= 30,
-)
-```
+=== "filter_condition.py"
+    ```python
+    --8<-- "docs/examples/indexes/filter_condition.py"
+    ```
 
-Note: Filters run after the query. You still pay for RCU on filtered items.
+!!! warning
+    Filters run after the query. You still pay for RCU on filtered items.
 
 ## Sort order
 
@@ -96,7 +63,6 @@ users = User.status_index.query(status="active", scan_index_forward=False)
 Use `limit` to control page size:
 
 ```python
-# Get results in pages of 10
 result = User.status_index.query(status="active", limit=10)
 
 for user in result:
@@ -119,40 +85,63 @@ print(f"Duration: {result.metrics.duration_ms}ms")
 print(f"RCU consumed: {result.metrics.consumed_rcu}")
 ```
 
+## Multi-attribute composite keys
+
+DynamoDB supports up to 4 attributes per partition key and 4 per sort key in GSIs. This is useful for multi-tenant apps or complex access patterns.
+
+=== "multi_attr_gsi.py"
+    ```python
+    --8<-- "docs/examples/indexes/multi_attr_gsi.py"
+    ```
+
+### Query multi-attribute GSI
+
+All partition key attributes are required. Sort key attributes are optional.
+
+=== "query_multi_attr.py"
+    ```python
+    --8<-- "docs/examples/indexes/query_multi_attr.py"
+    ```
+
+### When to use multi-attribute keys
+
+| Use case | Example |
+|----------|---------|
+| Multi-tenant apps | `hash_key=["tenant_id", "entity_type"]` |
+| Hierarchical data | `hash_key=["country", "state"]` |
+| Time-series | `range_key=["year", "month", "day"]` |
+| Composite sorting | `range_key=["priority", "created_at"]` |
+
+!!! tip
+    Multi-attribute keys avoid the need to create synthetic composite keys like `tenant_id#region`. DynamoDB handles the composition for you.
+
 ## Create table with GSI
 
 When creating tables programmatically, include GSI definitions:
 
-```python
-client = DynamoDBClient()
+=== "create_table_gsi.py"
+    ```python
+    --8<-- "docs/examples/indexes/create_table_gsi.py"
+    ```
 
-client.create_table(
-    "users",
-    hash_key=("pk", "S"),
-    range_key=("sk", "S"),
-    global_secondary_indexes=[
-        {
-            "index_name": "email-index",
-            "hash_key": ("email", "S"),
-            "projection": "ALL",
-        },
-        {
-            "index_name": "status-index",
-            "hash_key": ("status", "S"),
-            "range_key": ("pk", "S"),
-            "projection": "ALL",
-        },
-    ],
-)
-```
+### Multi-attribute GSI in create_table
+
+Use `hash_keys` and `range_keys` (plural) for multi-attribute keys:
+
+=== "create_table_multi_attr.py"
+    ```python
+    --8<-- "docs/examples/indexes/create_table_multi_attr.py"
+    ```
 
 ## Projection types
 
 Control which attributes are copied to the index:
 
-- `"ALL"` - All attributes (default)
-- `"KEYS_ONLY"` - Only key attributes
-- `"INCLUDE"` - Specific attributes (use `non_key_attributes`)
+| Projection | Description | Use when |
+|------------|-------------|----------|
+| `"ALL"` | All attributes (default) | You need all data from the index |
+| `"KEYS_ONLY"` | Only key attributes | You just need to check existence |
+| `"INCLUDE"` | Specific attributes | You need some attributes, not all |
 
 ```python
 # Keys only - smallest index, lowest cost
@@ -176,7 +165,7 @@ Control which attributes are copied to the index:
 - GSIs are read-only. To update data, update the main table.
 - GSI queries are eventually consistent by default.
 - Each table can have up to 20 GSIs.
-
+- Multi-attribute keys: max 4 attributes per partition key, 4 per sort key.
 
 ## Next steps
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -478,13 +478,8 @@ impl DynamoDBClient {
             encryption,
             kms_key_id,
             gsis,
-        )?;
-
-        if wait {
-            table_operations::wait_for_table_active(&self.client, &self.runtime, table_name, None)?;
-        }
-
-        Ok(())
+            wait,
+        )
     }
 
     /// Check if a table exists.

--- a/src/table_operations/delete.rs
+++ b/src/table_operations/delete.rs
@@ -1,0 +1,31 @@
+//! Table deletion operation.
+
+use aws_sdk_dynamodb::Client;
+use pyo3::prelude::*;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+use crate::errors::map_sdk_error;
+
+/// Delete a table.
+///
+/// # Arguments
+///
+/// * `client` - The DynamoDB client
+/// * `runtime` - The Tokio runtime
+/// * `table_name` - Name of the table to delete
+pub fn delete_table(client: &Client, runtime: &Arc<Runtime>, table_name: &str) -> PyResult<()> {
+    let client = client.clone();
+    let table_name = table_name.to_string();
+
+    runtime.block_on(async {
+        client
+            .delete_table()
+            .table_name(&table_name)
+            .send()
+            .await
+            .map_err(|e| map_sdk_error(e, Some(&table_name)))?;
+
+        Ok(())
+    })
+}

--- a/src/table_operations/exists.rs
+++ b/src/table_operations/exists.rs
@@ -1,0 +1,40 @@
+//! Table existence check operation.
+
+use aws_sdk_dynamodb::Client;
+use pyo3::prelude::*;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+use crate::errors::map_sdk_error;
+
+/// Check if a table exists.
+///
+/// # Arguments
+///
+/// * `client` - The DynamoDB client
+/// * `runtime` - The Tokio runtime
+/// * `table_name` - Name of the table to check
+///
+/// # Returns
+///
+/// True if the table exists, false otherwise.
+pub fn table_exists(client: &Client, runtime: &Arc<Runtime>, table_name: &str) -> PyResult<bool> {
+    let client = client.clone();
+    let table_name = table_name.to_string();
+
+    runtime.block_on(async {
+        match client.describe_table().table_name(&table_name).send().await {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                // Check if it's a service error (ResourceNotFoundException)
+                if let Some(service_error) = e.as_service_error() {
+                    if service_error.is_resource_not_found_exception() {
+                        return Ok(false);
+                    }
+                }
+                // For any other error, use map_sdk_error
+                Err(map_sdk_error(e, Some(&table_name)))
+            }
+        }
+    })
+}

--- a/src/table_operations/gsi.rs
+++ b/src/table_operations/gsi.rs
@@ -1,0 +1,150 @@
+//! GSI (Global Secondary Index) definitions and parsing.
+//!
+//! Supports multi-attribute composite keys for GSIs (up to 4 attributes per key).
+//! See: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.DesignPattern.MultiAttributeKeys.html
+
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+
+use crate::errors::ValidationError;
+
+/// GSI key attribute (name, type).
+#[derive(Debug, Clone)]
+pub struct GsiKeyAttribute {
+    pub name: String,
+    pub attr_type: String,
+}
+
+/// GSI definition from Python.
+///
+/// Supports multi-attribute composite keys for GSIs (up to 4 attributes per key).
+#[derive(Debug)]
+pub struct GsiDefinition {
+    pub index_name: String,
+    /// Hash key attributes (1-4 attributes)
+    pub hash_keys: Vec<GsiKeyAttribute>,
+    /// Range key attributes (0-4 attributes)
+    pub range_keys: Vec<GsiKeyAttribute>,
+    pub projection: String,
+    pub non_key_attributes: Option<Vec<String>>,
+}
+
+/// Parse GSI definitions from Python list.
+///
+/// Accepts both single-attribute keys (backward compatible) and multi-attribute keys.
+///
+/// Single-attribute format:
+/// ```python
+/// {
+///     "index_name": "email-index",
+///     "hash_key": ("email", "S"),
+///     "range_key": ("created_at", "S"),  # optional
+/// }
+/// ```
+///
+/// Multi-attribute format:
+/// ```python
+/// {
+///     "index_name": "location-index",
+///     "hash_keys": [("tenant_id", "S"), ("region", "S")],
+///     "range_keys": [("created_at", "S"), ("id", "S")],  # optional
+/// }
+/// ```
+pub fn parse_gsi_definitions(
+    _py: Python<'_>,
+    gsis: &Bound<'_, PyList>,
+) -> PyResult<Vec<GsiDefinition>> {
+    let mut result = Vec::new();
+
+    for item in gsis.iter() {
+        let dict = item.cast::<pyo3::types::PyDict>()?;
+
+        let index_name: String = dict
+            .get_item("index_name")?
+            .ok_or_else(|| ValidationError::new_err("GSI missing 'index_name'"))?
+            .extract()?;
+
+        // Try multi-attribute format first (hash_keys), then fall back to single (hash_key)
+        let hash_keys = if let Some(keys) = dict.get_item("hash_keys")? {
+            parse_key_attributes(&keys, "hash_keys")?
+        } else if let Some(key) = dict.get_item("hash_key")? {
+            // Single attribute format: tuple (name, type)
+            let (name, attr_type): (String, String) = key.extract()?;
+            vec![GsiKeyAttribute { name, attr_type }]
+        } else {
+            return Err(ValidationError::new_err(
+                "GSI missing 'hash_key' or 'hash_keys'",
+            ));
+        };
+
+        // Validate hash key count (1-4)
+        if hash_keys.is_empty() || hash_keys.len() > 4 {
+            return Err(ValidationError::new_err(format!(
+                "GSI '{}': hash_keys must have 1-4 attributes, got {}",
+                index_name,
+                hash_keys.len()
+            )));
+        }
+
+        // Try multi-attribute format first (range_keys), then fall back to single (range_key)
+        let range_keys = if let Some(keys) = dict.get_item("range_keys")? {
+            parse_key_attributes(&keys, "range_keys")?
+        } else if let Some(key) = dict.get_item("range_key")? {
+            // Single attribute format: tuple (name, type)
+            let (name, attr_type): (String, String) = key.extract()?;
+            vec![GsiKeyAttribute { name, attr_type }]
+        } else {
+            vec![] // No range key
+        };
+
+        // Validate range key count (0-4)
+        if range_keys.len() > 4 {
+            return Err(ValidationError::new_err(format!(
+                "GSI '{}': range_keys must have 0-4 attributes, got {}",
+                index_name,
+                range_keys.len()
+            )));
+        }
+
+        // projection defaults to "ALL"
+        let projection: String = dict
+            .get_item("projection")?
+            .map(|v| v.extract())
+            .transpose()?
+            .unwrap_or_else(|| "ALL".to_string());
+
+        // non_key_attributes for INCLUDE projection
+        let non_key_attributes: Option<Vec<String>> = dict
+            .get_item("non_key_attributes")?
+            .map(|v| v.extract())
+            .transpose()?;
+
+        result.push(GsiDefinition {
+            index_name,
+            hash_keys,
+            range_keys,
+            projection,
+            non_key_attributes,
+        });
+    }
+
+    Ok(result)
+}
+
+/// Parse key attributes from a Python list of tuples.
+fn parse_key_attributes(
+    obj: &Bound<'_, PyAny>,
+    field_name: &str,
+) -> PyResult<Vec<GsiKeyAttribute>> {
+    let list: Vec<(String, String)> = obj.extract().map_err(|_| {
+        ValidationError::new_err(format!(
+            "'{}' must be a list of tuples: [(name, type), ...]",
+            field_name
+        ))
+    })?;
+
+    Ok(list
+        .into_iter()
+        .map(|(name, attr_type)| GsiKeyAttribute { name, attr_type })
+        .collect())
+}

--- a/src/table_operations/mod.rs
+++ b/src/table_operations/mod.rs
@@ -1,0 +1,21 @@
+//! Table management operations for DynamoDB.
+//!
+//! This module provides table lifecycle operations:
+//! - `create` - Create a new table with optional GSIs
+//! - `delete` - Delete a table
+//! - `exists` - Check if a table exists
+//! - `wait` - Wait for table to become active
+//! - `gsi` - GSI definition and parsing
+
+mod create;
+mod delete;
+mod exists;
+mod gsi;
+mod wait;
+
+// Re-export public functions
+pub use create::create_table;
+pub use delete::delete_table;
+pub use exists::table_exists;
+pub use gsi::parse_gsi_definitions;
+pub use wait::wait_for_table_active;

--- a/src/table_operations/wait.rs
+++ b/src/table_operations/wait.rs
@@ -1,0 +1,69 @@
+//! Wait for table to become active.
+
+use aws_sdk_dynamodb::types::TableStatus;
+use aws_sdk_dynamodb::Client;
+use pyo3::prelude::*;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+
+use crate::errors::map_sdk_error;
+
+/// Wait for a table to become active.
+///
+/// Polls the table status until it becomes ACTIVE or times out.
+///
+/// # Arguments
+///
+/// * `client` - The DynamoDB client
+/// * `runtime` - The Tokio runtime
+/// * `table_name` - Name of the table to wait for
+/// * `timeout_seconds` - Maximum time to wait (default: 60)
+pub fn wait_for_table_active(
+    client: &Client,
+    runtime: &Arc<Runtime>,
+    table_name: &str,
+    timeout_seconds: Option<u64>,
+) -> PyResult<()> {
+    let client = client.clone();
+    let table_name = table_name.to_string();
+    let timeout = timeout_seconds.unwrap_or(60);
+
+    runtime.block_on(async {
+        let start = std::time::Instant::now();
+        let poll_interval = Duration::from_millis(500);
+
+        loop {
+            if start.elapsed().as_secs() > timeout {
+                return Err(PyErr::new::<pyo3::exceptions::PyTimeoutError, _>(format!(
+                    "Timeout waiting for table '{}' to become active",
+                    table_name
+                )));
+            }
+
+            let result = client.describe_table().table_name(&table_name).send().await;
+
+            match result {
+                Ok(response) => {
+                    if let Some(table) = response.table() {
+                        if table.table_status() == Some(&TableStatus::Active) {
+                            return Ok(());
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Check if it's ResourceNotFoundException (table still being created)
+                    if let Some(service_error) = e.as_service_error() {
+                        if !service_error.is_resource_not_found_exception() {
+                            return Err(map_sdk_error(e, Some(&table_name)));
+                        }
+                    } else {
+                        return Err(map_sdk_error(e, Some(&table_name)));
+                    }
+                }
+            }
+
+            tokio::time::sleep(poll_interval).await;
+        }
+    })
+}

--- a/tests/integration/indexes/test_multi_attr_gsi.py
+++ b/tests/integration/indexes/test_multi_attr_gsi.py
@@ -1,0 +1,338 @@
+"""Integration tests for multi-attribute GSI keys.
+
+Tests the new DynamoDB feature (Nov 2025) that allows up to 4 attributes
+per partition key and 4 per sort key in GSIs.
+
+NOTE: LocalStack does not support multi-attribute GSI keys yet.
+These tests require real DynamoDB or a compatible emulator.
+Mark with @pytest.mark.skip_localstack to skip in CI.
+"""
+
+import pytest
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.indexes import GlobalSecondaryIndex
+
+# Skip all tests in this module - LocalStack doesn't support multi-attribute GSI
+pytestmark = pytest.mark.skip(
+    reason="LocalStack does not support multi-attribute GSI keys (Nov 2025 feature)"
+)
+
+
+@pytest.fixture
+def multi_attr_client(dynamodb_endpoint):
+    """Create a client and table with multi-attribute GSIs."""
+    client = DynamoDBClient(
+        region="us-east-1",
+        endpoint_url=dynamodb_endpoint,
+        access_key="testing",
+        secret_key="testing",
+    )
+
+    table_name = "multi_attr_gsi_test"
+
+    # Delete if exists
+    if client.table_exists(table_name):
+        client.delete_table(table_name)
+
+    # Create table with multi-attribute GSI
+    client.create_table(
+        table_name,
+        hash_key=("pk", "S"),
+        range_key=("sk", "S"),
+        global_secondary_indexes=[
+            {
+                "index_name": "location-index",
+                "hash_keys": [("tenant_id", "S"), ("region", "S")],
+                "range_keys": [("created_at", "S"), ("item_id", "S")],
+                "projection": "ALL",
+            },
+            {
+                "index_name": "category-index",
+                "hash_keys": [("category", "S"), ("subcategory", "S")],
+                "projection": "ALL",
+            },
+        ],
+    )
+
+    set_default_client(client)
+    return client
+
+
+class Product(Model):
+    """Test model with multi-attribute GSIs."""
+
+    model_config = ModelConfig(table="multi_attr_gsi_test")
+
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    tenant_id = StringAttribute()
+    region = StringAttribute()
+    created_at = StringAttribute()
+    item_id = StringAttribute()
+    category = StringAttribute()
+    subcategory = StringAttribute()
+    name = StringAttribute()
+    price = NumberAttribute()
+
+    # Multi-attribute GSI with 2 hash keys and 2 range keys
+    location_index = GlobalSecondaryIndex(
+        index_name="location-index",
+        hash_key=["tenant_id", "region"],
+        range_key=["created_at", "item_id"],
+    )
+
+    # Multi-attribute GSI with 2 hash keys only
+    category_index = GlobalSecondaryIndex(
+        index_name="category-index",
+        hash_key=["category", "subcategory"],
+    )
+
+
+def test_multi_attr_gsi_query_basic(multi_attr_client):
+    """Test basic query on multi-attribute GSI."""
+    # Create test products
+    Product(
+        pk="PROD#1",
+        sk="DATA",
+        tenant_id="ACME",
+        region="us-east-1",
+        created_at="2025-01-01",
+        item_id="001",
+        category="electronics",
+        subcategory="phones",
+        name="iPhone",
+        price=999,
+    ).save()
+
+    Product(
+        pk="PROD#2",
+        sk="DATA",
+        tenant_id="ACME",
+        region="us-east-1",
+        created_at="2025-01-02",
+        item_id="002",
+        category="electronics",
+        subcategory="laptops",
+        name="MacBook",
+        price=1999,
+    ).save()
+
+    Product(
+        pk="PROD#3",
+        sk="DATA",
+        tenant_id="ACME",
+        region="eu-west-1",
+        created_at="2025-01-01",
+        item_id="003",
+        category="electronics",
+        subcategory="phones",
+        name="Galaxy",
+        price=899,
+    ).save()
+
+    # Query by tenant_id + region (both hash key attrs required)
+    results = list(
+        Product.location_index.query(
+            tenant_id="ACME",
+            region="us-east-1",
+        )
+    )
+
+    assert len(results) == 2
+    names = {r.name for r in results}
+    assert names == {"iPhone", "MacBook"}
+
+
+def test_multi_attr_gsi_query_different_tenant(multi_attr_client):
+    """Test query returns only matching tenant/region combo."""
+    # Create products for different tenants
+    Product(
+        pk="PROD#10",
+        sk="DATA",
+        tenant_id="ACME",
+        region="us-east-1",
+        created_at="2025-01-01",
+        item_id="010",
+        category="books",
+        subcategory="fiction",
+        name="Book A",
+        price=20,
+    ).save()
+
+    Product(
+        pk="PROD#11",
+        sk="DATA",
+        tenant_id="GLOBEX",
+        region="us-east-1",
+        created_at="2025-01-01",
+        item_id="011",
+        category="books",
+        subcategory="fiction",
+        name="Book B",
+        price=25,
+    ).save()
+
+    # Query ACME only
+    results = list(
+        Product.location_index.query(
+            tenant_id="ACME",
+            region="us-east-1",
+        )
+    )
+
+    assert len(results) == 1
+    assert results[0].name == "Book A"
+    assert results[0].tenant_id == "ACME"
+
+
+def test_multi_attr_gsi_query_category_index(multi_attr_client):
+    """Test query on category index (2 hash keys, no range key)."""
+    Product(
+        pk="PROD#20",
+        sk="DATA",
+        tenant_id="ACME",
+        region="us-east-1",
+        created_at="2025-01-01",
+        item_id="020",
+        category="clothing",
+        subcategory="shirts",
+        name="T-Shirt",
+        price=30,
+    ).save()
+
+    Product(
+        pk="PROD#21",
+        sk="DATA",
+        tenant_id="ACME",
+        region="us-east-1",
+        created_at="2025-01-02",
+        item_id="021",
+        category="clothing",
+        subcategory="shirts",
+        name="Polo",
+        price=50,
+    ).save()
+
+    Product(
+        pk="PROD#22",
+        sk="DATA",
+        tenant_id="ACME",
+        region="us-east-1",
+        created_at="2025-01-01",
+        item_id="022",
+        category="clothing",
+        subcategory="pants",
+        name="Jeans",
+        price=80,
+    ).save()
+
+    # Query clothing/shirts
+    results = list(
+        Product.category_index.query(
+            category="clothing",
+            subcategory="shirts",
+        )
+    )
+
+    assert len(results) == 2
+    names = {r.name for r in results}
+    assert names == {"T-Shirt", "Polo"}
+
+
+def test_multi_attr_gsi_query_with_filter(multi_attr_client):
+    """Test multi-attribute GSI query with filter condition."""
+    Product(
+        pk="PROD#30",
+        sk="DATA",
+        tenant_id="FILTER_TEST",
+        region="us-west-2",
+        created_at="2025-01-01",
+        item_id="030",
+        category="toys",
+        subcategory="games",
+        name="Cheap Game",
+        price=10,
+    ).save()
+
+    Product(
+        pk="PROD#31",
+        sk="DATA",
+        tenant_id="FILTER_TEST",
+        region="us-west-2",
+        created_at="2025-01-02",
+        item_id="031",
+        category="toys",
+        subcategory="games",
+        name="Expensive Game",
+        price=100,
+    ).save()
+
+    # Query with price filter
+    results = list(
+        Product.location_index.query(
+            tenant_id="FILTER_TEST",
+            region="us-west-2",
+            filter_condition=Product.price >= 50,
+        )
+    )
+
+    assert len(results) == 1
+    assert results[0].name == "Expensive Game"
+
+
+def test_multi_attr_gsi_query_empty_result(multi_attr_client):
+    """Test multi-attribute GSI query with no matches."""
+    results = list(
+        Product.location_index.query(
+            tenant_id="NONEXISTENT",
+            region="nowhere",
+        )
+    )
+
+    assert len(results) == 0
+
+
+def test_multi_attr_gsi_query_returns_model_instances(multi_attr_client):
+    """Test that query returns proper model instances."""
+    Product(
+        pk="PROD#40",
+        sk="DATA",
+        tenant_id="INSTANCE_TEST",
+        region="ap-south-1",
+        created_at="2025-01-01",
+        item_id="040",
+        category="food",
+        subcategory="snacks",
+        name="Chips",
+        price=5,
+    ).save()
+
+    results = list(
+        Product.location_index.query(
+            tenant_id="INSTANCE_TEST",
+            region="ap-south-1",
+        )
+    )
+
+    assert len(results) == 1
+    product = results[0]
+
+    # Should be a Product instance
+    assert isinstance(product, Product)
+
+    # Should have all attributes
+    assert product.pk == "PROD#40"
+    assert product.tenant_id == "INSTANCE_TEST"
+    assert product.region == "ap-south-1"
+    assert product.name == "Chips"
+    assert product.price == 5
+
+
+def test_multi_attr_gsi_query_requires_all_hash_keys(multi_attr_client):
+    """Test that query fails if not all hash keys provided."""
+    with pytest.raises(ValueError, match="Missing"):
+        list(Product.location_index.query(tenant_id="ACME"))
+
+    with pytest.raises(ValueError, match="Missing"):
+        list(Product.category_index.query(category="electronics"))

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "pydynox"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Adds support for multi-attribute composite keys in Global Secondary Indexes, as announced by AWS in November 2025.

### Usage

```python
# Define multi-attribute GSI
location_index = GlobalSecondaryIndex(
    index_name="location-index",
    hash_key=["tenant_id", "region"],
    range_key=["created_at", "item_id"],
)

# Query (all hash key attrs required)
products = Product.location_index.query(
    tenant_id="ACME",
    region="us-east-1",
)
```

Closes #85