### PR TITLE
refactor: use kms data key instead of encrypt operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,7 +732,7 @@ checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest",
- "rand",
+ "rand 0.9.2",
  "regex",
  "rustversion",
 ]
@@ -730,7 +775,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1013,6 +1068,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1417,6 +1482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,6 +1659,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1722,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1776,7 @@ dependencies = [
 name = "pydynox"
 version = "0.13.0"
 dependencies = [
+ "aes-gcm",
  "aws-config",
  "aws-sdk-dynamodb",
  "aws-sdk-kms",
@@ -1696,6 +1789,7 @@ dependencies = [
  "once_cell",
  "pyo3",
  "pyo3-async-runtimes",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "svix-ksuid",
@@ -1799,12 +1893,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2471,7 +2586,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.2",
  "web-time",
 ]
 
@@ -2486,6 +2601,16 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ chrono = { version = "0.4", default-features = false, features = [
     "std",
     "clock",
 ] }
+aes-gcm = "0.10"
+rand = "0.8"
 
 [dev-dependencies]
 pyo3 = { version = "0.27", features = ["auto-initialize"] }

--- a/docs/guides/exceptions.md
+++ b/docs/guides/exceptions.md
@@ -152,7 +152,7 @@ Common causes:
 
 - KMS key not found (wrong key ID or alias)
 - KMS key is disabled
-- Missing IAM permissions for `kms:Encrypt` or `kms:Decrypt`
+- Missing IAM permissions for `kms:GenerateDataKey` or `kms:Decrypt`
 - Wrong encryption context on decrypt
 - Invalid ciphertext (data corrupted)
 

--- a/docs/guides/iam-permissions.md
+++ b/docs/guides/iam-permissions.md
@@ -83,6 +83,8 @@ For creating and managing tables:
 
 ## KMS permissions (for encryption)
 
+pydynox uses envelope encryption with `kms:GenerateDataKey` instead of `kms:Encrypt`. This removes the 4KB size limit and reduces KMS API calls.
+
 ### Full access (ReadWrite mode)
 
 For services that encrypt and decrypt:
@@ -94,7 +96,7 @@ For services that encrypt and decrypt:
         {
             "Effect": "Allow",
             "Action": [
-                "kms:Encrypt",
+                "kms:GenerateDataKey",
                 "kms:Decrypt"
             ],
             "Resource": "arn:aws:kms:REGION:ACCOUNT:key/KEY_ID"
@@ -111,7 +113,7 @@ For services that only write encrypted data:
 {
     "Effect": "Allow",
     "Action": [
-        "kms:Encrypt"
+        "kms:GenerateDataKey"
     ],
     "Resource": "arn:aws:kms:REGION:ACCOUNT:key/KEY_ID"
 }
@@ -158,7 +160,7 @@ A service that does CRUD, batch operations, and field encryption:
             "Sid": "KMSAccess",
             "Effect": "Allow",
             "Action": [
-                "kms:Encrypt",
+                "kms:GenerateDataKey",
                 "kms:Decrypt"
             ],
             "Resource": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"

--- a/python/pydynox/attributes/encrypted.py
+++ b/python/pydynox/attributes/encrypted.py
@@ -11,8 +11,8 @@ from pydynox.attributes.base import Attribute
 class EncryptedAttribute(Attribute[str]):
     """Attribute that encrypts values using AWS KMS.
 
-    Encrypts sensitive data like SSN or credit cards at the field level.
-    Encryption happens on save, decryption on load.
+    Uses envelope encryption: GenerateDataKey + local AES-256-GCM.
+    This removes the 4KB KMS limit and reduces API calls.
 
     Args:
         key_id: KMS key ID, ARN, or alias (e.g., "alias/my-key").

--- a/python/pydynox/pydynox_core.pyi
+++ b/python/pydynox/pydynox_core.pyi
@@ -304,7 +304,7 @@ def compress_string(
 ) -> str: ...
 def decompress_string(value: str) -> str: ...
 
-# Encryption
+# Encryption (uses envelope encryption with GenerateDataKey + local AES-256-GCM)
 class KmsEncryptor:
     key_id: str
 
@@ -313,9 +313,23 @@ class KmsEncryptor:
         key_id: str,
         region: str | None = None,
         context: dict[str, str] | None = None,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        session_token: str | None = None,
+        profile: str | None = None,
+        role_arn: str | None = None,
+        role_session_name: str | None = None,
+        external_id: str | None = None,
+        endpoint_url: str | None = None,
+        connect_timeout: float | None = None,
+        read_timeout: float | None = None,
+        max_retries: int | None = None,
+        proxy_url: str | None = None,
     ) -> None: ...
     def encrypt(self, plaintext: str) -> str: ...
     def decrypt(self, ciphertext: str) -> str: ...
+    def async_encrypt(self, plaintext: str) -> Coroutine[Any, Any, str]: ...
+    def async_decrypt(self, ciphertext: str) -> Coroutine[Any, Any, str]: ...
     @staticmethod
     def is_encrypted(value: str) -> bool: ...
 

--- a/src/kms/mod.rs
+++ b/src/kms/mod.rs
@@ -1,7 +1,14 @@
-//! KMS encryption module for field-level encryption.
+//! KMS envelope encryption module for field-level encryption.
 //!
-//! Provides per-field encryption using AWS KMS. The KMS client inherits
-//! all config from the DynamoDB client, only allowing region override.
+//! Uses envelope encryption pattern:
+//! 1. GenerateDataKey gets a plaintext + encrypted data key
+//! 2. Plaintext key encrypts data locally with AES-256-GCM
+//! 3. Encrypted key is stored alongside the encrypted data
+//!
+//! Benefits over direct KMS Encrypt/Decrypt:
+//! - No 4KB size limit (DynamoDB fields can be 400KB)
+//! - Fewer KMS calls (one per operation, not one per field)
+//! - Faster (AES in Rust is much faster than KMS API calls)
 
 mod client;
 mod operations;

--- a/src/kms/operations.rs
+++ b/src/kms/operations.rs
@@ -1,28 +1,140 @@
-//! KMS encrypt/decrypt operations.
+//! KMS envelope encryption operations.
+//!
+//! Uses GenerateDataKey for envelope encryption:
+//! 1. Generate a data key with KMS (one call)
+//! 2. Encrypt data locally with AES-GCM (fast, no size limit)
+//! 3. Store encrypted data + encrypted DEK together
+//!
+//! This solves two problems:
+//! - KMS Encrypt has 4KB limit, but DynamoDB fields can be 400KB
+//! - Reduces KMS calls (one per operation instead of one per field)
 
 use crate::errors::{map_kms_error, EncryptionError};
 use crate::kms::ENCRYPTED_PREFIX;
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Nonce,
+};
 use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::types::DataKeySpec;
 use aws_sdk_kms::Client;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use pyo3::prelude::*;
+use rand::RngCore;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
+/// Storage format version for future compatibility.
+const FORMAT_VERSION: u8 = 1;
+
+/// Nonce size for AES-GCM (96 bits = 12 bytes).
+const NONCE_SIZE: usize = 12;
+
+// ========== LOCAL AES OPERATIONS ==========
+
+/// Encrypt data locally using AES-256-GCM.
+///
+/// Returns: nonce (12 bytes) + ciphertext
+fn encrypt_local(plaintext: &[u8], key: &[u8]) -> Result<Vec<u8>, PyErr> {
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| EncryptionError::new_err(format!("Invalid key: {}", e)))?;
+
+    // Generate random nonce
+    let mut nonce_bytes = [0u8; NONCE_SIZE];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    // Encrypt
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|e| EncryptionError::new_err(format!("Encryption failed: {}", e)))?;
+
+    // Prepend nonce to ciphertext
+    let mut result = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+    result.extend_from_slice(&nonce_bytes);
+    result.extend_from_slice(&ciphertext);
+    Ok(result)
+}
+
+/// Decrypt data locally using AES-256-GCM.
+///
+/// Expects: nonce (12 bytes) + ciphertext
+fn decrypt_local(data: &[u8], key: &[u8]) -> Result<Vec<u8>, PyErr> {
+    if data.len() < NONCE_SIZE {
+        return Err(EncryptionError::new_err("Data too short for decryption"));
+    }
+
+    let cipher = Aes256Gcm::new_from_slice(key)
+        .map_err(|e| EncryptionError::new_err(format!("Invalid key: {}", e)))?;
+
+    let (nonce_bytes, ciphertext) = data.split_at(NONCE_SIZE);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|e| EncryptionError::new_err(format!("Decryption failed: {}", e)))
+}
+
+// ========== STORAGE FORMAT ==========
+
+/// Pack encrypted data for storage.
+///
+/// Format: version (1 byte) + dek_len (2 bytes) + encrypted_dek + encrypted_data
+fn pack_envelope(encrypted_dek: &[u8], encrypted_data: &[u8]) -> Vec<u8> {
+    let dek_len = encrypted_dek.len() as u16;
+    let mut result = Vec::with_capacity(3 + encrypted_dek.len() + encrypted_data.len());
+    result.push(FORMAT_VERSION);
+    result.extend_from_slice(&dek_len.to_be_bytes());
+    result.extend_from_slice(encrypted_dek);
+    result.extend_from_slice(encrypted_data);
+    result
+}
+
+/// Unpack encrypted data from storage.
+///
+/// Returns: (encrypted_dek, encrypted_data)
+fn unpack_envelope(data: &[u8]) -> Result<(&[u8], &[u8]), PyErr> {
+    if data.len() < 3 {
+        return Err(EncryptionError::new_err("Invalid envelope: too short"));
+    }
+
+    let version = data[0];
+    if version != FORMAT_VERSION {
+        return Err(EncryptionError::new_err(format!(
+            "Unsupported envelope version: {}",
+            version
+        )));
+    }
+
+    let dek_len = u16::from_be_bytes([data[1], data[2]]) as usize;
+    if data.len() < 3 + dek_len {
+        return Err(EncryptionError::new_err("Invalid envelope: truncated DEK"));
+    }
+
+    let encrypted_dek = &data[3..3 + dek_len];
+    let encrypted_data = &data[3 + dek_len..];
+    Ok((encrypted_dek, encrypted_data))
+}
+
 // ========== CORE ASYNC OPERATIONS ==========
 
-/// Core async encrypt operation.
+/// Encrypt using envelope encryption.
+///
+/// 1. Call KMS GenerateDataKey to get plaintext + encrypted DEK
+/// 2. Use plaintext DEK to AES encrypt locally
+/// 3. Pack encrypted DEK + encrypted data together
 pub async fn execute_encrypt(
     client: Client,
     key_id: String,
     context: HashMap<String, String>,
     plaintext: String,
 ) -> Result<String, PyErr> {
+    // Generate data key
     let mut req = client
-        .encrypt()
+        .generate_data_key()
         .key_id(&key_id)
-        .plaintext(Blob::new(plaintext.as_bytes()));
+        .key_spec(DataKeySpec::Aes256);
 
     for (k, v) in &context {
         req = req.encryption_context(k, v);
@@ -32,17 +144,35 @@ pub async fn execute_encrypt(
 
     match result {
         Ok(output) => {
-            let blob = output
+            // Get plaintext key (for local encryption)
+            let plaintext_key = output
+                .plaintext()
+                .ok_or_else(|| EncryptionError::new_err("No plaintext key from KMS"))?;
+
+            // Get encrypted key (to store with data)
+            let encrypted_key = output
                 .ciphertext_blob()
-                .ok_or_else(|| EncryptionError::new_err("No ciphertext returned from KMS"))?;
-            let encoded = BASE64.encode(blob.as_ref());
+                .ok_or_else(|| EncryptionError::new_err("No encrypted key from KMS"))?;
+
+            // Encrypt data locally with plaintext key
+            let encrypted_data = encrypt_local(plaintext.as_bytes(), plaintext_key.as_ref())?;
+
+            // Pack envelope: encrypted_dek + encrypted_data
+            let envelope = pack_envelope(encrypted_key.as_ref(), &encrypted_data);
+
+            // Encode and add prefix
+            let encoded = BASE64.encode(&envelope);
             Ok(format!("{}{}", ENCRYPTED_PREFIX, encoded))
         }
         Err(e) => Err(map_kms_error(e)),
     }
 }
 
-/// Core async decrypt operation.
+/// Decrypt using envelope encryption.
+///
+/// 1. Unpack encrypted DEK + encrypted data
+/// 2. Call KMS Decrypt to get plaintext DEK
+/// 3. Use plaintext DEK to AES decrypt locally
 pub async fn execute_decrypt(
     client: Client,
     context: HashMap<String, String>,
@@ -59,11 +189,17 @@ pub async fn execute_decrypt(
     };
 
     // Decode base64
-    let decoded = BASE64
+    let envelope = BASE64
         .decode(encoded)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid base64: {}", e)))?;
 
-    let mut req = client.decrypt().ciphertext_blob(Blob::new(decoded));
+    // Unpack envelope
+    let (encrypted_dek, encrypted_data) = unpack_envelope(&envelope)?;
+
+    // Decrypt DEK with KMS
+    let mut req = client
+        .decrypt()
+        .ciphertext_blob(Blob::new(encrypted_dek.to_vec()));
 
     for (k, v) in &context {
         req = req.encryption_context(k, v);
@@ -73,10 +209,14 @@ pub async fn execute_decrypt(
 
     match result {
         Ok(output) => {
-            let blob = output
+            let plaintext_key = output
                 .plaintext()
-                .ok_or_else(|| EncryptionError::new_err("No plaintext returned from KMS"))?;
-            String::from_utf8(blob.as_ref().to_vec()).map_err(|e| {
+                .ok_or_else(|| EncryptionError::new_err("No plaintext key from KMS"))?;
+
+            // Decrypt data locally
+            let plaintext_bytes = decrypt_local(encrypted_data, plaintext_key.as_ref())?;
+
+            String::from_utf8(plaintext_bytes).map_err(|e| {
                 pyo3::exceptions::PyValueError::new_err(format!("Invalid UTF-8: {}", e))
             })
         }

--- a/tests/integration/encryption/__init__.py
+++ b/tests/integration/encryption/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for KMS encryption."""


### PR DESCRIPTION
Closes #94

This PR Refactors KMS encryption to use envelope encryption pattern instead of direct `KMS:Encrypt/Decrypt`.

## Problem

The previous implementation called `KMS:Encrypt` and `KMS:Decrypt` directly for each field. This had two issues:

1. **4KB limit** - KMS Encrypt only accepts up to 4KB, but DynamoDB fields can be 400KB
2. **Too many API calls** - Batch write with 30 items × 3 encrypted fields = 90 KMS calls


We are now using the envelope encryption with `KMS:GenerateDataKey`:

**Encrypt:**
1. Call `KMS:GenerateDataKey` once → get plaintext key + encrypted key
2. Use plaintext key to AES-256-GCM encrypt locally (fast, in Rust)
3. Store encrypted key + encrypted data together in one field

**Decrypt:**
1. Unpack encrypted key + encrypted data
2. Call `KMS:Decrypt` on the encrypted key → get plaintext key
3. Use plaintext key to AES-256-GCM decrypt locally