### PR TITLE
feat: Add Model table operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "pydynox"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes-gcm",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydynox"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["Leandro Cavalcante Damascena <leandro.damascena@gmail.com>"]
 description = "A fast DynamoDB ORM for Python with a Rust core"

--- a/benchmarks/src/pydynox/requirements.txt
+++ b/benchmarks/src/pydynox/requirements.txt
@@ -1,2 +1,2 @@
 aws-lambda-powertools>=3.0.0
-pydynox>=0.13.0
+pydynox>=0.16.0

--- a/docs/examples/partiql/select_columns.py
+++ b/docs/examples/partiql/select_columns.py
@@ -7,7 +7,7 @@ client = DynamoDBClient()
 # Select only name and age columns
 result = client.execute_statement(
     "SELECT name, age FROM users WHERE pk = ? AND sk = ?",
-    parameters=["USER#123", "PROFILE"],
+    parameters=["USER#1", "PROFILE"],
 )
 
 for item in result:

--- a/docs/examples/tables/create_table.py
+++ b/docs/examples/tables/create_table.py
@@ -1,24 +1,30 @@
+"""Example: Create tables with client."""
+
 from pydynox import DynamoDBClient
 
+client = DynamoDBClient()
 
-def create_users_table():
-    client = DynamoDBClient()
-
-    # Simple table with hash key only
+# Simple table with hash key only
+if not client.table_exists("example_users"):
     client.create_table(
-        "users",
+        "example_users",
         hash_key=("pk", "S"),
-        wait=True,  # Wait for table to be ready
+        wait=True,
     )
 
-
-def create_orders_table():
-    client = DynamoDBClient()
-
-    # Table with hash key and range key
+# Table with hash key and range key
+if not client.table_exists("example_orders"):
     client.create_table(
-        "orders",
+        "example_orders",
         hash_key=("pk", "S"),
         range_key=("sk", "S"),
         wait=True,
     )
+
+# Verify tables exist
+assert client.table_exists("example_users")
+assert client.table_exists("example_orders")
+
+# Cleanup
+client.delete_table("example_users")
+client.delete_table("example_orders")

--- a/docs/examples/tables/model_create_table.py
+++ b/docs/examples/tables/model_create_table.py
@@ -1,0 +1,47 @@
+"""Example: Create table from Model schema."""
+
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.indexes import GlobalSecondaryIndex
+
+# Setup client
+client = DynamoDBClient()
+set_default_client(client)
+
+
+class User(Model):
+    """User model with GSI for email lookup."""
+
+    model_config = ModelConfig(table="example_model_users")
+
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    email = StringAttribute()
+    status = StringAttribute()
+    age = NumberAttribute()
+
+    # GSI for querying by email
+    email_index = GlobalSecondaryIndex(
+        index_name="email-index",
+        hash_key="email",
+    )
+
+
+# Create table from model schema (includes hash key, range key, and GSIs)
+if not User.table_exists():
+    User.create_table(wait=True)
+
+# Verify table exists
+assert User.table_exists()
+
+# Save and query to verify GSI works
+user = User(pk="USER#1", sk="PROFILE", email="test@example.com", status="active", age=30)
+user.save()
+
+# Query by GSI
+results = list(User.email_index.query(email="test@example.com"))
+assert len(results) == 1
+assert results[0].pk == "USER#1"
+
+# Cleanup
+User.delete_table()

--- a/docs/examples/tables/table_options.py
+++ b/docs/examples/tables/table_options.py
@@ -1,40 +1,33 @@
+"""Example: Table creation with different options."""
+
 from pydynox import DynamoDBClient
 
+client = DynamoDBClient()
 
-def create_provisioned_table():
-    client = DynamoDBClient()
-
-    # Provisioned capacity (fixed cost, predictable performance)
+# Provisioned capacity (fixed cost, predictable performance)
+if not client.table_exists("example_provisioned"):
     client.create_table(
-        "high_traffic_table",
+        "example_provisioned",
         hash_key=("pk", "S"),
         billing_mode="PROVISIONED",
-        read_capacity=100,
-        write_capacity=50,
+        read_capacity=5,
+        write_capacity=5,
         wait=True,
     )
 
-
-def create_encrypted_table():
-    client = DynamoDBClient()
-
-    # Customer managed KMS encryption
+# Infrequent access class (cheaper storage, higher read cost)
+if not client.table_exists("example_archive"):
     client.create_table(
-        "sensitive_data",
-        hash_key=("pk", "S"),
-        encryption="CUSTOMER_MANAGED",
-        kms_key_id="arn:aws:kms:us-east-1:123456789:key/abc-123",
-        wait=True,
-    )
-
-
-def create_infrequent_access_table():
-    client = DynamoDBClient()
-
-    # Infrequent access class (cheaper storage, higher read cost)
-    client.create_table(
-        "archive",
+        "example_archive",
         hash_key=("pk", "S"),
         table_class="STANDARD_INFREQUENT_ACCESS",
         wait=True,
     )
+
+# Verify tables exist
+assert client.table_exists("example_provisioned")
+assert client.table_exists("example_archive")
+
+# Cleanup
+client.delete_table("example_provisioned")
+client.delete_table("example_archive")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pydynox"
-version = "0.15.0"
+version = "0.16.0"
 description = "A fast DynamoDB ORM for Python with a Rust core"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -33,8 +33,10 @@ from pydynox.generators import AutoGenerate
 from pydynox.integrations.functions import dynamodb_model
 from pydynox.model import Model
 from pydynox.transaction import Transaction
+from pydynox.version import VERSION
 
-__version__ = "0.15.0"
+__version__ = VERSION
+
 
 __all__ = [
     # Core

--- a/python/pydynox/model.py
+++ b/python/pydynox/model.py
@@ -700,3 +700,112 @@ class Model(ModelBase, metaclass=ModelMeta):
     async def _async_delete_s3_files(self) -> None:
         """Async delete S3 files associated with this model."""
         await _async_delete_s3_files(self)
+
+    # ========== TABLE OPERATIONS ==========
+
+    @classmethod
+    def create_table(
+        cls,
+        billing_mode: str = "PAY_PER_REQUEST",
+        read_capacity: int | None = None,
+        write_capacity: int | None = None,
+        table_class: str | None = None,
+        encryption: str | None = None,
+        kms_key_id: str | None = None,
+        wait: bool = False,
+    ) -> None:
+        """Create the DynamoDB table for this model.
+
+        Uses the model's schema to build the table definition, including
+        hash key, range key, and any GSIs defined on the model.
+
+        Args:
+            billing_mode: "PAY_PER_REQUEST" (default) or "PROVISIONED".
+            read_capacity: Read capacity units (only for PROVISIONED).
+            write_capacity: Write capacity units (only for PROVISIONED).
+            table_class: "STANDARD" (default) or "STANDARD_INFREQUENT_ACCESS".
+            encryption: "AWS_OWNED", "AWS_MANAGED", or "CUSTOMER_MANAGED".
+            kms_key_id: KMS key ARN (required for CUSTOMER_MANAGED).
+            wait: If True, wait for table to become active.
+
+        Raises:
+            ValueError: If model has no hash_key defined.
+            TableAlreadyExistsError: If table already exists.
+
+        Example:
+            >>> class User(Model):
+            ...     model_config = ModelConfig(table="users")
+            ...     pk = StringAttribute(hash_key=True)
+            ...     sk = StringAttribute(range_key=True)
+            ...     email = StringAttribute()
+            ...
+            ...     email_index = GlobalSecondaryIndex(
+            ...         index_name="email-index",
+            ...         hash_key="email",
+            ...     )
+            >>>
+            >>> User.create_table(wait=True)
+        """
+        if cls._hash_key is None:
+            raise ValueError(f"Model {cls.__name__} has no hash_key defined")
+
+        client = cls._get_client()
+        table = cls._get_table()
+
+        # Get hash key type
+        hash_key_attr = cls._attributes[cls._hash_key]
+        hash_key = (cls._hash_key, hash_key_attr.attr_type)
+
+        # Get range key type if defined
+        range_key = None
+        if cls._range_key:
+            range_key_attr = cls._attributes[cls._range_key]
+            range_key = (cls._range_key, range_key_attr.attr_type)
+
+        # Build GSI definitions
+        gsis = None
+        if cls._indexes:
+            gsis = [idx.to_create_table_definition(cls) for idx in cls._indexes.values()]
+
+        client.create_table(
+            table,
+            hash_key=hash_key,
+            range_key=range_key,
+            billing_mode=billing_mode,
+            read_capacity=read_capacity,
+            write_capacity=write_capacity,
+            table_class=table_class,
+            encryption=encryption,
+            kms_key_id=kms_key_id,
+            global_secondary_indexes=gsis,
+            wait=wait,
+        )
+
+    @classmethod
+    def table_exists(cls) -> bool:
+        """Check if the table for this model exists.
+
+        Returns:
+            True if table exists, False otherwise.
+
+        Example:
+            >>> if not User.table_exists():
+            ...     User.create_table(wait=True)
+        """
+        client = cls._get_client()
+        table = cls._get_table()
+        return client.table_exists(table)
+
+    @classmethod
+    def delete_table(cls) -> None:
+        """Delete the table for this model.
+
+        Warning:
+            This permanently deletes the table and all its data.
+
+        Example:
+            >>> User.delete_table()
+        """
+        client = cls._get_client()
+        table = cls._get_table()
+        client.delete_table(table)

--- a/python/pydynox/version.py
+++ b/python/pydynox/version.py
@@ -1,0 +1,40 @@
+"""Version information for pydynox."""
+
+from __future__ import annotations
+
+import platform
+import sys
+from importlib.metadata import version
+
+__all__ = ["VERSION", "version_info"]
+
+VERSION = version("pydynox")
+
+
+def version_info() -> str:
+    """Return complete version information for pydynox and its dependencies."""
+    import importlib.metadata
+
+    # Packages related to pydynox usage
+    package_names = {
+        "boto3",
+        "botocore",
+        "pydantic",
+        "typing_extensions",
+    }
+    related_packages = []
+
+    for dist in importlib.metadata.distributions():
+        name = dist.metadata["Name"]
+        if name in package_names:
+            related_packages.append(f"{name}-{dist.version}")
+
+    info = {
+        "pydynox version": VERSION,
+        "python version": sys.version,
+        "platform": platform.platform(),
+        "related packages": " ".join(sorted(related_packages)) or "none",
+    }
+    return "\n".join(
+        "{:>30} {}".format(k + ":", str(v).replace("\n", " ")) for k, v in info.items()
+    )

--- a/tests/integration/operations/test_model_table.py
+++ b/tests/integration/operations/test_model_table.py
@@ -1,0 +1,292 @@
+"""Integration tests for Model.create_table(), table_exists(), delete_table()."""
+
+import uuid
+
+import pytest
+from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.indexes import GlobalSecondaryIndex
+
+
+@pytest.fixture
+def model_table_client(dynamodb_endpoint):
+    """Create a pydynox client for table operations testing."""
+    client = DynamoDBClient(
+        region="us-east-1",
+        endpoint_url=dynamodb_endpoint,
+        access_key="testing",
+        secret_key="testing",
+    )
+    set_default_client(client)
+    return client
+
+
+def unique_table_name() -> str:
+    """Generate a unique table name for each test."""
+    return f"test_table_{uuid.uuid4().hex[:8]}"
+
+
+def test_create_table_basic(model_table_client):
+    """Test Model.create_table() with basic model."""
+    table_name = unique_table_name()
+
+    class SimpleUser(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+        name = StringAttribute()
+
+    # Create table
+    SimpleUser.create_table(wait=True)
+
+    # Verify table exists
+    assert model_table_client.table_exists(table_name)
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_create_table_with_range_key(model_table_client):
+    """Test Model.create_table() with hash and range key."""
+    table_name = unique_table_name()
+
+    class UserWithRange(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+        sk = StringAttribute(range_key=True)
+        name = StringAttribute()
+
+    UserWithRange.create_table(wait=True)
+
+    # Verify by saving and getting an item
+    user = UserWithRange(pk="USER#1", sk="PROFILE", name="John")
+    user.save()
+
+    fetched = UserWithRange.get(pk="USER#1", sk="PROFILE")
+    assert fetched is not None
+    assert fetched.name == "John"
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_create_table_with_gsi(model_table_client):
+    """Test Model.create_table() with GSI."""
+    table_name = unique_table_name()
+
+    class UserWithGSI(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+        sk = StringAttribute(range_key=True)
+        email = StringAttribute()
+        status = StringAttribute()
+
+        email_index = GlobalSecondaryIndex(
+            index_name="email-index",
+            hash_key="email",
+        )
+
+    UserWithGSI.create_table(wait=True)
+
+    # Save some users
+    UserWithGSI(pk="USER#1", sk="PROFILE", email="john@example.com", status="active").save()
+    UserWithGSI(pk="USER#2", sk="PROFILE", email="jane@example.com", status="active").save()
+
+    # Query by GSI
+    results = list(UserWithGSI.email_index.query(email="john@example.com"))
+    assert len(results) == 1
+    assert results[0].pk == "USER#1"
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_create_table_with_gsi_and_range_key(model_table_client):
+    """Test Model.create_table() with GSI that has range key."""
+    table_name = unique_table_name()
+
+    class UserWithGSIRange(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+        sk = StringAttribute(range_key=True)
+        status = StringAttribute()
+        age = NumberAttribute()
+
+        status_index = GlobalSecondaryIndex(
+            index_name="status-index",
+            hash_key="status",
+            range_key="age",
+        )
+
+    UserWithGSIRange.create_table(wait=True)
+
+    # Save users with different ages
+    UserWithGSIRange(pk="USER#1", sk="PROFILE", status="active", age=30).save()
+    UserWithGSIRange(pk="USER#2", sk="PROFILE", status="active", age=25).save()
+    UserWithGSIRange(pk="USER#3", sk="PROFILE", status="inactive", age=35).save()
+
+    # Query by status, ordered by age
+    results = list(UserWithGSIRange.status_index.query(status="active"))
+    assert len(results) == 2
+
+    # Should be ordered by age (ascending by default)
+    assert results[0].age == 25
+    assert results[1].age == 30
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_create_table_with_multiple_gsis(model_table_client):
+    """Test Model.create_table() with multiple GSIs."""
+    table_name = unique_table_name()
+
+    class UserMultiGSI(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+        sk = StringAttribute(range_key=True)
+        email = StringAttribute()
+        status = StringAttribute()
+
+        email_index = GlobalSecondaryIndex(
+            index_name="email-index",
+            hash_key="email",
+        )
+
+        status_index = GlobalSecondaryIndex(
+            index_name="status-index",
+            hash_key="status",
+        )
+
+    UserMultiGSI.create_table(wait=True)
+
+    # Save a user
+    UserMultiGSI(pk="USER#1", sk="PROFILE", email="john@example.com", status="active").save()
+
+    # Query by email
+    by_email = list(UserMultiGSI.email_index.query(email="john@example.com"))
+    assert len(by_email) == 1
+
+    # Query by status
+    by_status = list(UserMultiGSI.status_index.query(status="active"))
+    assert len(by_status) == 1
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_table_exists_true(model_table_client):
+    """Test Model.table_exists() returns True when table exists."""
+    table_name = unique_table_name()
+
+    class ExistsModel(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+
+    # Create table
+    ExistsModel.create_table(wait=True)
+
+    # Check exists
+    assert ExistsModel.table_exists() is True
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_table_exists_false(model_table_client):
+    """Test Model.table_exists() returns False when table doesn't exist."""
+    table_name = unique_table_name()
+
+    class NotExistsModel(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+
+    # Should not exist
+    assert NotExistsModel.table_exists() is False
+
+
+def test_delete_table(model_table_client):
+    """Test Model.delete_table()."""
+    table_name = unique_table_name()
+
+    class DeleteModel(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+
+    # Create and verify
+    DeleteModel.create_table(wait=True)
+    assert DeleteModel.table_exists() is True
+
+    # Delete
+    DeleteModel.delete_table()
+
+    # Verify deleted
+    assert DeleteModel.table_exists() is False
+
+
+def test_create_table_provisioned(model_table_client):
+    """Test Model.create_table() with provisioned capacity."""
+    table_name = unique_table_name()
+
+    class ProvisionedModel(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+
+    ProvisionedModel.create_table(
+        billing_mode="PROVISIONED",
+        read_capacity=5,
+        write_capacity=5,
+        wait=True,
+    )
+
+    assert ProvisionedModel.table_exists() is True
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_create_table_idempotent_check(model_table_client):
+    """Test checking table_exists before create_table."""
+    table_name = unique_table_name()
+
+    class IdempotentModel(Model):
+        model_config = ModelConfig(table=table_name)
+        pk = StringAttribute(hash_key=True)
+
+    # Pattern: check before create
+    if not IdempotentModel.table_exists():
+        IdempotentModel.create_table(wait=True)
+
+    assert IdempotentModel.table_exists() is True
+
+    # Second check should not create again
+    if not IdempotentModel.table_exists():
+        IdempotentModel.create_table(wait=True)
+
+    # Still exists
+    assert IdempotentModel.table_exists() is True
+
+    # Cleanup
+    model_table_client.delete_table(table_name)
+
+
+def test_create_table_with_number_hash_key(model_table_client):
+    """Test Model.create_table() with number hash key."""
+    table_name = unique_table_name()
+
+    class NumberKeyModel(Model):
+        model_config = ModelConfig(table=table_name)
+        id = NumberAttribute(hash_key=True)
+        name = StringAttribute()
+
+    NumberKeyModel.create_table(wait=True)
+
+    # Save and get
+    item = NumberKeyModel(id=123, name="Test")
+    item.save()
+
+    fetched = NumberKeyModel.get(id=123)
+    assert fetched is not None
+    assert fetched.name == "Test"
+
+    # Cleanup
+    model_table_client.delete_table(table_name)

--- a/tests/unit/test_model_table.py
+++ b/tests/unit/test_model_table.py
@@ -1,0 +1,279 @@
+"""Unit tests for Model table operations (create_table, table_exists, delete_table)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydynox import DynamoDBClient, Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.indexes import GlobalSecondaryIndex
+
+
+class User(Model):
+    """Test model with GSIs."""
+
+    model_config = ModelConfig(table="users")
+
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    email = StringAttribute()
+    status = StringAttribute()
+    age = NumberAttribute()
+    tenant_id = StringAttribute()
+    region = StringAttribute()
+
+    email_index = GlobalSecondaryIndex(
+        index_name="email-index",
+        hash_key="email",
+    )
+
+    status_age_index = GlobalSecondaryIndex(
+        index_name="status-age-index",
+        hash_key="status",
+        range_key="age",
+    )
+
+    location_index = GlobalSecondaryIndex(
+        index_name="location-index",
+        hash_key=["tenant_id", "region"],
+    )
+
+
+class SimpleModel(Model):
+    """Model with only hash key."""
+
+    model_config = ModelConfig(table="simple")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+
+
+class NoKeyModel(Model):
+    """Model without hash key (invalid)."""
+
+    model_config = ModelConfig(table="nokey")
+    name = StringAttribute()
+
+
+@pytest.fixture
+def mock_client() -> MagicMock:
+    """Create a mock DynamoDB client."""
+    client = MagicMock(spec=DynamoDBClient)
+    return client
+
+
+def test_create_table_basic(mock_client: MagicMock) -> None:
+    """Test create_table with basic model."""
+    with patch.object(SimpleModel, "_get_client", return_value=mock_client):
+        SimpleModel.create_table()
+
+    mock_client.create_table.assert_called_once_with(
+        "simple",
+        hash_key=("pk", "S"),
+        range_key=None,
+        billing_mode="PAY_PER_REQUEST",
+        read_capacity=None,
+        write_capacity=None,
+        table_class=None,
+        encryption=None,
+        kms_key_id=None,
+        global_secondary_indexes=None,
+        wait=False,
+    )
+
+
+def test_create_table_with_range_key(mock_client: MagicMock) -> None:
+    """Test create_table with hash and range key."""
+
+    class WithRange(Model):
+        model_config = ModelConfig(table="with_range")
+        pk = StringAttribute(hash_key=True)
+        sk = NumberAttribute(range_key=True)
+
+    with patch.object(WithRange, "_get_client", return_value=mock_client):
+        WithRange.create_table()
+
+    mock_client.create_table.assert_called_once()
+    call_args = mock_client.create_table.call_args
+    assert call_args[0][0] == "with_range"
+    assert call_args[1]["hash_key"] == ("pk", "S")
+    assert call_args[1]["range_key"] == ("sk", "N")
+
+
+def test_create_table_with_gsis(mock_client: MagicMock) -> None:
+    """Test create_table includes GSI definitions."""
+    with patch.object(User, "_get_client", return_value=mock_client):
+        User.create_table()
+
+    mock_client.create_table.assert_called_once()
+    call_args = mock_client.create_table.call_args
+
+    gsis = call_args[1]["global_secondary_indexes"]
+    assert gsis is not None
+    assert len(gsis) == 3
+
+    # Find each GSI by name
+    gsi_by_name = {g["index_name"]: g for g in gsis}
+
+    # Single-attribute GSI
+    email_gsi = gsi_by_name["email-index"]
+    assert email_gsi["hash_key"] == ("email", "S")
+    assert "range_key" not in email_gsi
+
+    # GSI with range key
+    status_gsi = gsi_by_name["status-age-index"]
+    assert status_gsi["hash_key"] == ("status", "S")
+    assert status_gsi["range_key"] == ("age", "N")
+
+    # Multi-attribute GSI
+    location_gsi = gsi_by_name["location-index"]
+    assert location_gsi["hash_keys"] == [("tenant_id", "S"), ("region", "S")]
+
+
+def test_create_table_with_options(mock_client: MagicMock) -> None:
+    """Test create_table with all options."""
+    with patch.object(SimpleModel, "_get_client", return_value=mock_client):
+        SimpleModel.create_table(
+            billing_mode="PROVISIONED",
+            read_capacity=10,
+            write_capacity=5,
+            table_class="STANDARD_INFREQUENT_ACCESS",
+            encryption="CUSTOMER_MANAGED",
+            kms_key_id="arn:aws:kms:us-east-1:123456789012:key/abc",
+            wait=True,
+        )
+
+    mock_client.create_table.assert_called_once_with(
+        "simple",
+        hash_key=("pk", "S"),
+        range_key=None,
+        billing_mode="PROVISIONED",
+        read_capacity=10,
+        write_capacity=5,
+        table_class="STANDARD_INFREQUENT_ACCESS",
+        encryption="CUSTOMER_MANAGED",
+        kms_key_id="arn:aws:kms:us-east-1:123456789012:key/abc",
+        global_secondary_indexes=None,
+        wait=True,
+    )
+
+
+def test_create_table_no_hash_key_raises() -> None:
+    """Test create_table raises error if no hash key defined."""
+    mock_client = MagicMock(spec=DynamoDBClient)
+
+    with patch.object(NoKeyModel, "_get_client", return_value=mock_client):
+        with pytest.raises(ValueError, match="has no hash_key defined"):
+            NoKeyModel.create_table()
+
+
+def test_table_exists(mock_client: MagicMock) -> None:
+    """Test table_exists calls client correctly."""
+    mock_client.table_exists.return_value = True
+
+    with patch.object(SimpleModel, "_get_client", return_value=mock_client):
+        result = SimpleModel.table_exists()
+
+    assert result is True
+    mock_client.table_exists.assert_called_once_with("simple")
+
+
+def test_table_exists_false(mock_client: MagicMock) -> None:
+    """Test table_exists returns False when table doesn't exist."""
+    mock_client.table_exists.return_value = False
+
+    with patch.object(SimpleModel, "_get_client", return_value=mock_client):
+        result = SimpleModel.table_exists()
+
+    assert result is False
+
+
+def test_delete_table(mock_client: MagicMock) -> None:
+    """Test delete_table calls client correctly."""
+    with patch.object(SimpleModel, "_get_client", return_value=mock_client):
+        SimpleModel.delete_table()
+
+    mock_client.delete_table.assert_called_once_with("simple")
+
+
+def test_gsi_to_create_table_definition_single_attr() -> None:
+    """Test GSI to_create_table_definition with single attribute keys."""
+    definition = User.email_index.to_create_table_definition(User)
+
+    assert definition["index_name"] == "email-index"
+    assert definition["hash_key"] == ("email", "S")
+    assert "range_key" not in definition
+    assert definition["projection"] == "ALL"
+
+
+def test_gsi_to_create_table_definition_with_range() -> None:
+    """Test GSI to_create_table_definition with range key."""
+    definition = User.status_age_index.to_create_table_definition(User)
+
+    assert definition["index_name"] == "status-age-index"
+    assert definition["hash_key"] == ("status", "S")
+    assert definition["range_key"] == ("age", "N")
+
+
+def test_gsi_to_create_table_definition_multi_attr() -> None:
+    """Test GSI to_create_table_definition with multi-attribute keys."""
+    definition = User.location_index.to_create_table_definition(User)
+
+    assert definition["index_name"] == "location-index"
+    assert definition["hash_keys"] == [("tenant_id", "S"), ("region", "S")]
+    assert "hash_key" not in definition
+
+
+def test_gsi_to_create_table_definition_keys_only_projection() -> None:
+    """Test GSI to_create_table_definition with KEYS_ONLY projection."""
+
+    class ModelWithKeysOnly(Model):
+        model_config = ModelConfig(table="test")
+        pk = StringAttribute(hash_key=True)
+        email = StringAttribute()
+
+        email_index = GlobalSecondaryIndex(
+            index_name="email-index",
+            hash_key="email",
+            projection="KEYS_ONLY",
+        )
+
+    definition = ModelWithKeysOnly.email_index.to_create_table_definition(ModelWithKeysOnly)
+    assert definition["projection"] == "KEYS_ONLY"
+
+
+def test_gsi_to_create_table_definition_include_projection() -> None:
+    """Test GSI to_create_table_definition with INCLUDE projection."""
+
+    class ModelWithInclude(Model):
+        model_config = ModelConfig(table="test")
+        pk = StringAttribute(hash_key=True)
+        email = StringAttribute()
+        name = StringAttribute()
+        age = NumberAttribute()
+
+        email_index = GlobalSecondaryIndex(
+            index_name="email-index",
+            hash_key="email",
+            projection=["name", "age"],
+        )
+
+    definition = ModelWithInclude.email_index.to_create_table_definition(ModelWithInclude)
+    assert definition["projection"] == "INCLUDE"
+    assert definition["non_key_attributes"] == ["name", "age"]
+
+
+def test_gsi_to_create_table_definition_missing_attr_raises() -> None:
+    """Test GSI to_create_table_definition raises if attribute not on model."""
+
+    class BadModel(Model):
+        model_config = ModelConfig(table="test")
+        pk = StringAttribute(hash_key=True)
+
+        bad_index = GlobalSecondaryIndex(
+            index_name="bad-index",
+            hash_key="nonexistent",
+        )
+
+    with pytest.raises(ValueError, match="references attribute 'nonexistent'"):
+        BadModel.bad_index.to_create_table_definition(BadModel)

--- a/uv.lock
+++ b/uv.lock
@@ -738,7 +738,7 @@ wheels = [
 
 [[package]]
 name = "pydynox"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #86

This PR adds table operations to the Model class:

- `Model.create_table()` - creates table using model schema (hash key, range key, GSIs)
- `Model.table_exists()` - checks if table exists
- `Model.delete_table()` - deletes the table

## Example

```python
class User(Model):
    model_config = ModelConfig(table="users")
    pk = StringAttribute(hash_key=True)
    sk = StringAttribute(range_key=True)
    email = StringAttribute()

    email_index = GlobalSecondaryIndex(
        index_name="email-index",
        hash_key="email",
    )

# Create table from model schema (includes GSIs)
if not User.table_exists():
    User.create_table(wait=True)
```