### PR TITLE
feat: Add in-memory backend for testing

### DIFF
--- a/docs/examples/atomic/testing_atomic.py
+++ b/docs/examples/atomic/testing_atomic.py
@@ -1,0 +1,62 @@
+"""Testing atomic updates with pydynox_memory_backend."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import ListAttribute, NumberAttribute, StringAttribute
+
+
+class Counter(Model):
+    model_config = ModelConfig(table="counters")
+    pk = StringAttribute(hash_key=True)
+    count = NumberAttribute(default=0)
+    tags = ListAttribute(default=list)
+
+
+def test_atomic_increment(pydynox_memory_backend):
+    """Test atomic counter increment."""
+    counter = Counter(pk="views", count=0)
+    counter.save()
+
+    # Increment atomically
+    counter.update(atomic=[Counter.count.add(1)])
+    counter.update(atomic=[Counter.count.add(1)])
+    counter.update(atomic=[Counter.count.add(1)])
+
+    found = Counter.get(pk="views")
+    assert found.count == 3
+
+
+def test_atomic_decrement(pydynox_memory_backend):
+    """Test atomic counter decrement."""
+    counter = Counter(pk="stock", count=100)
+    counter.save()
+
+    # Decrement atomically
+    counter.update(atomic=[Counter.count.add(-10)])
+
+    found = Counter.get(pk="stock")
+    assert found.count == 90
+
+
+def test_atomic_append(pydynox_memory_backend):
+    """Test atomic list append."""
+    counter = Counter(pk="item", tags=["initial"])
+    counter.save()
+
+    # Append atomically
+    counter.update(atomic=[Counter.tags.append(["new_tag"])])
+
+    found = Counter.get(pk="item")
+    assert "initial" in found.tags
+    assert "new_tag" in found.tags
+
+
+def test_atomic_set(pydynox_memory_backend):
+    """Test atomic set operation."""
+    counter = Counter(pk="item", count=10)
+    counter.save()
+
+    # Set atomically
+    counter.update(atomic=[Counter.count.set(99)])
+
+    found = Counter.get(pk="item")
+    assert found.count == 99

--- a/docs/examples/batch/testing_batch.py
+++ b/docs/examples/batch/testing_batch.py
@@ -1,0 +1,57 @@
+"""Testing batch operations with pydynox_memory_backend."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(default=0)
+
+
+def test_batch_save(pydynox_memory_backend):
+    """Test saving multiple items."""
+    users = [User(pk=f"USER#{i}", name=f"User {i}", age=20 + i) for i in range(10)]
+
+    for user in users:
+        user.save()
+
+    # Verify all saved
+    for i in range(10):
+        found = User.get(pk=f"USER#{i}")
+        assert found is not None
+        assert found.name == f"User {i}"
+
+
+def test_batch_delete(pydynox_memory_backend):
+    """Test deleting multiple items."""
+    # Create users
+    for i in range(5):
+        User(pk=f"USER#{i}", name=f"User {i}").save()
+
+    # Delete some
+    for i in range(3):
+        user = User.get(pk=f"USER#{i}")
+        user.delete()
+
+    # Verify
+    assert User.get(pk="USER#0") is None
+    assert User.get(pk="USER#1") is None
+    assert User.get(pk="USER#2") is None
+    assert User.get(pk="USER#3") is not None
+    assert User.get(pk="USER#4") is not None
+
+
+def test_batch_get(pydynox_memory_backend):
+    """Test getting multiple items."""
+    # Create users
+    for i in range(5):
+        User(pk=f"USER#{i}", name=f"User {i}").save()
+
+    # Batch get
+    keys = [{"pk": f"USER#{i}"} for i in range(5)]
+    results = User.batch_get(keys)
+
+    assert len(results) == 5

--- a/docs/examples/conditions/testing_conditions.py
+++ b/docs/examples/conditions/testing_conditions.py
@@ -1,0 +1,70 @@
+"""Testing conditions with pydynox_memory_backend."""
+
+import pytest
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.exceptions import ConditionCheckFailedError
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    status = StringAttribute(default="active")
+    version = NumberAttribute(default=1)
+
+
+def test_prevent_overwrite(pydynox_memory_backend):
+    """Test condition to prevent overwriting existing items."""
+    user = User(pk="USER#1", name="John")
+    user.save(condition=User.pk.does_not_exist())
+
+    # Second save with same key should fail
+    user2 = User(pk="USER#1", name="Jane")
+    with pytest.raises(ConditionCheckFailedError):
+        user2.save(condition=User.pk.does_not_exist())
+
+
+def test_conditional_delete(pydynox_memory_backend):
+    """Test conditional delete."""
+    user = User(pk="USER#1", name="John", status="inactive")
+    user.save()
+
+    # Can only delete inactive users
+    user.delete(condition=User.status == "inactive")
+
+    assert User.get(pk="USER#1") is None
+
+
+def test_conditional_delete_fails(pydynox_memory_backend):
+    """Test that conditional delete fails when condition not met."""
+    user = User(pk="USER#1", name="John", status="active")
+    user.save()
+
+    # Cannot delete active users
+    with pytest.raises(ConditionCheckFailedError):
+        user.delete(condition=User.status == "inactive")
+
+    # User still exists
+    assert User.get(pk="USER#1") is not None
+
+
+def test_optimistic_locking(pydynox_memory_backend):
+    """Test optimistic locking with version field."""
+    user = User(pk="USER#1", name="John", version=1)
+    user.save()
+
+    # Simulate concurrent update
+    user1 = User.get(pk="USER#1")
+    user2 = User.get(pk="USER#1")
+
+    # First update succeeds
+    user1.name = "Jane"
+    user1.version = 2
+    user1.save(condition=User.version == 1)
+
+    # Second update fails (version already changed)
+    user2.name = "Bob"
+    user2.version = 2
+    with pytest.raises(ConditionCheckFailedError):
+        user2.save(condition=User.version == 1)

--- a/docs/examples/hooks/testing_hooks.py
+++ b/docs/examples/hooks/testing_hooks.py
@@ -1,0 +1,57 @@
+"""Testing lifecycle hooks with pydynox_memory_backend."""
+
+import pytest
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute
+from pydynox.hooks import after_save, before_save
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    email = StringAttribute()
+    name = StringAttribute()
+
+    @before_save
+    def validate_email(self):
+        if "@" not in self.email:
+            raise ValueError("Invalid email")
+
+    @before_save
+    def normalize_email(self):
+        self.email = self.email.lower().strip()
+
+    @after_save
+    def log_save(self):
+        print(f"Saved user: {self.pk}")
+
+
+def test_before_save_validation(pydynox_memory_backend):
+    """Test that before_save hook validates data."""
+    user = User(pk="USER#1", email="invalid-email", name="John")
+
+    with pytest.raises(ValueError, match="Invalid email"):
+        user.save()
+
+    # User was not saved
+    assert User.get(pk="USER#1") is None
+
+
+def test_before_save_normalization(pydynox_memory_backend):
+    """Test that before_save hook normalizes data."""
+    user = User(pk="USER#1", email="  JOHN@EXAMPLE.COM  ", name="John")
+    user.save()
+
+    found = User.get(pk="USER#1")
+    assert found.email == "john@example.com"
+
+
+def test_skip_hooks(pydynox_memory_backend):
+    """Test skipping hooks for special cases."""
+    # This would normally fail validation
+    user = User(pk="USER#1", email="invalid", name="John")
+    user.save(skip_hooks=True)
+
+    # But with skip_hooks=True, it saves anyway
+    found = User.get(pk="USER#1")
+    assert found.email == "invalid"

--- a/docs/examples/models/testing_models.py
+++ b/docs/examples/models/testing_models.py
@@ -1,0 +1,70 @@
+"""Testing models with pydynox_memory_backend."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(default=0)
+
+
+def test_create_and_get(pydynox_memory_backend):
+    """Test creating and getting a model."""
+    user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
+    user.save()
+
+    found = User.get(pk="USER#1", sk="PROFILE")
+    assert found is not None
+    assert found.name == "John"
+    assert found.age == 30
+
+
+def test_update(pydynox_memory_backend):
+    """Test updating a model."""
+    user = User(pk="USER#1", sk="PROFILE", name="John")
+    user.save()
+
+    user.update(name="Jane", age=25)
+
+    found = User.get(pk="USER#1", sk="PROFILE")
+    assert found.name == "Jane"
+    assert found.age == 25
+
+
+def test_delete(pydynox_memory_backend):
+    """Test deleting a model."""
+    user = User(pk="USER#1", sk="PROFILE", name="John")
+    user.save()
+
+    user.delete()
+
+    assert User.get(pk="USER#1", sk="PROFILE") is None
+
+
+def test_get_not_found(pydynox_memory_backend):
+    """Test getting a non-existent model."""
+    found = User.get(pk="USER#999", sk="PROFILE")
+    assert found is None
+
+
+def test_update_by_key(pydynox_memory_backend):
+    """Test updating by key without fetching first."""
+    User(pk="USER#1", sk="PROFILE", name="John").save()
+
+    User.update_by_key(pk="USER#1", sk="PROFILE", name="Jane")
+
+    found = User.get(pk="USER#1", sk="PROFILE")
+    assert found.name == "Jane"
+
+
+def test_delete_by_key(pydynox_memory_backend):
+    """Test deleting by key without fetching first."""
+    User(pk="USER#1", sk="PROFILE", name="John").save()
+
+    User.delete_by_key(pk="USER#1", sk="PROFILE")
+
+    assert User.get(pk="USER#1", sk="PROFILE") is None

--- a/docs/examples/query/testing_query.py
+++ b/docs/examples/query/testing_query.py
@@ -1,0 +1,58 @@
+"""Testing query operations with pydynox_memory_backend."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.conditions import Attr
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    status = StringAttribute()
+    total = NumberAttribute()
+
+
+def test_query_by_hash_key(pydynox_memory_backend):
+    """Test querying items by partition key."""
+    Order(pk="CUSTOMER#1", sk="ORDER#001", status="pending", total=100).save()
+    Order(pk="CUSTOMER#1", sk="ORDER#002", status="shipped", total=200).save()
+    Order(pk="CUSTOMER#2", sk="ORDER#001", status="pending", total=50).save()
+
+    results = list(Order.query(hash_key="CUSTOMER#1"))
+
+    assert len(results) == 2
+    assert all(r.pk == "CUSTOMER#1" for r in results)
+
+
+def test_query_with_range_key_condition(pydynox_memory_backend):
+    """Test query with range key condition."""
+    Order(pk="CUSTOMER#1", sk="ORDER#001", status="pending", total=100).save()
+    Order(pk="CUSTOMER#1", sk="ORDER#002", status="shipped", total=200).save()
+    Order(pk="CUSTOMER#1", sk="RETURN#001", status="pending", total=50).save()
+
+    results = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            range_key_condition=Order.sk.begins_with("ORDER#"),
+        )
+    )
+
+    assert len(results) == 2
+
+
+def test_query_with_filter(pydynox_memory_backend):
+    """Test query with filter condition."""
+    Order(pk="CUSTOMER#1", sk="ORDER#001", status="pending", total=100).save()
+    Order(pk="CUSTOMER#1", sk="ORDER#002", status="shipped", total=200).save()
+    Order(pk="CUSTOMER#1", sk="ORDER#003", status="pending", total=300).save()
+
+    results = list(
+        Order.query(
+            hash_key="CUSTOMER#1",
+            filter_condition=Attr("status").eq("pending"),
+        )
+    )
+
+    assert len(results) == 2
+    assert all(r.status == "pending" for r in results)

--- a/docs/examples/scan/testing_scan.py
+++ b/docs/examples/scan/testing_scan.py
@@ -1,0 +1,58 @@
+"""Testing scan operations with pydynox_memory_backend."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.conditions import Attr
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    age = NumberAttribute()
+    status = StringAttribute(default="active")
+
+
+def test_scan_all_items(pydynox_memory_backend):
+    """Test scanning all items in a table."""
+    User(pk="USER#1", name="Alice", age=30).save()
+    User(pk="USER#2", name="Bob", age=25).save()
+    User(pk="USER#3", name="Charlie", age=35).save()
+
+    results = list(User.scan())
+
+    assert len(results) == 3
+
+
+def test_scan_with_filter(pydynox_memory_backend):
+    """Test scan with filter condition."""
+    User(pk="USER#1", name="Alice", age=30, status="active").save()
+    User(pk="USER#2", name="Bob", age=25, status="inactive").save()
+    User(pk="USER#3", name="Charlie", age=35, status="active").save()
+
+    results = list(User.scan(filter_condition=Attr("status").eq("active")))
+
+    assert len(results) == 2
+    assert all(r.status == "active" for r in results)
+
+
+def test_scan_with_numeric_filter(pydynox_memory_backend):
+    """Test scan with numeric filter."""
+    User(pk="USER#1", name="Alice", age=30).save()
+    User(pk="USER#2", name="Bob", age=25).save()
+    User(pk="USER#3", name="Charlie", age=35).save()
+
+    results = list(User.scan(filter_condition=Attr("age").gt(28)))
+
+    assert len(results) == 2
+
+
+def test_count_items(pydynox_memory_backend):
+    """Test counting items."""
+    User(pk="USER#1", name="Alice", age=30).save()
+    User(pk="USER#2", name="Bob", age=25).save()
+    User(pk="USER#3", name="Charlie", age=35).save()
+
+    count, _ = User.count()
+
+    assert count == 3

--- a/docs/examples/testing/basic_fixture.py
+++ b/docs/examples/testing/basic_fixture.py
@@ -1,0 +1,44 @@
+"""Basic usage of pydynox_memory_backend fixture."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(default=0)
+
+
+def test_create_user(pydynox_memory_backend):
+    """Test creating a user - no DynamoDB needed!"""
+    user = User(pk="USER#1", name="John", age=30)
+    user.save()
+
+    found = User.get(pk="USER#1")
+    assert found is not None
+    assert found.name == "John"
+    assert found.age == 30
+
+
+def test_update_user(pydynox_memory_backend):
+    """Test updating a user."""
+    user = User(pk="USER#1", name="Jane")
+    user.save()
+
+    user.update(name="Janet", age=25)
+
+    found = User.get(pk="USER#1")
+    assert found.name == "Janet"
+    assert found.age == 25
+
+
+def test_delete_user(pydynox_memory_backend):
+    """Test deleting a user."""
+    user = User(pk="USER#1", name="Bob")
+    user.save()
+
+    user.delete()
+
+    assert User.get(pk="USER#1") is None

--- a/docs/examples/testing/context_manager.py
+++ b/docs/examples/testing/context_manager.py
@@ -1,0 +1,51 @@
+"""Using MemoryBackend as context manager (without pytest)."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute
+from pydynox.testing import MemoryBackend
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+
+
+# Use as context manager
+def main():
+    with MemoryBackend() as backend:
+        # All pydynox operations use in-memory storage
+        user = User(pk="USER#1", name="John")
+        user.save()
+
+        found = User.get(pk="USER#1")
+        print(f"Found: {found.name}")  # Output: Found: John
+
+        # Inspect the data
+        print(f"Tables: {list(backend.tables.keys())}")
+        print(f"Items: {len(backend.tables['users'])}")
+
+
+# Use as decorator
+@MemoryBackend()
+def test_function():
+    user = User(pk="USER#1", name="Jane")
+    user.save()
+
+    assert User.get(pk="USER#1") is not None
+
+
+# Use with seed data
+def test_with_seed():
+    seed = {"users": [{"pk": "USER#1", "name": "Seeded"}]}
+
+    with MemoryBackend(seed=seed):
+        user = User.get(pk="USER#1")
+        assert user.name == "Seeded"
+
+
+if __name__ == "__main__":
+    main()
+    test_function()
+    test_with_seed()
+    print("All tests passed!")

--- a/docs/examples/testing/inspect_data.py
+++ b/docs/examples/testing/inspect_data.py
@@ -1,0 +1,49 @@
+"""Inspecting data in the memory backend."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(default=0)
+
+
+def test_inspect_tables(pydynox_memory_backend):
+    """Access the backend to inspect stored data."""
+    User(pk="USER#1", name="Alice").save()
+    User(pk="USER#2", name="Bob").save()
+
+    # Access tables directly
+    assert "users" in pydynox_memory_backend.tables
+    assert len(pydynox_memory_backend.tables["users"]) == 2
+
+    # Check specific items
+    items = pydynox_memory_backend.tables["users"]
+    pks = [item["pk"] for item in items.values()]
+    assert "USER#1" in pks
+    assert "USER#2" in pks
+
+
+def test_clear_data(pydynox_memory_backend):
+    """Clear data mid-test for fresh state."""
+    User(pk="USER#1", name="Test").save()
+    assert User.get(pk="USER#1") is not None
+
+    # Clear all data
+    pydynox_memory_backend.clear()
+
+    # Now it's gone
+    assert User.get(pk="USER#1") is None
+
+
+def test_isolation_between_tests(pydynox_memory_backend):
+    """Each test starts with empty tables."""
+    # This test doesn't see data from other tests
+    assert User.get(pk="USER#1") is None
+
+    # Create data for this test only
+    User(pk="USER#1", name="Isolated").save()
+    assert User.get(pk="USER#1") is not None

--- a/docs/examples/testing/lambda_handler.py
+++ b/docs/examples/testing/lambda_handler.py
@@ -1,0 +1,69 @@
+"""Testing AWS Lambda handlers with pydynox."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+
+
+# Your Lambda handler
+def create_user_handler(event, context):
+    """Lambda handler that creates a user."""
+    user_id = event["user_id"]
+    name = event["name"]
+
+    user = User(pk=f"USER#{user_id}", name=name)
+    user.save()
+
+    return {"statusCode": 201, "body": f"Created user {user_id}"}
+
+
+def get_user_handler(event, context):
+    """Lambda handler that gets a user."""
+    user_id = event["user_id"]
+
+    user = User.get(pk=f"USER#{user_id}")
+    if not user:
+        return {"statusCode": 404, "body": "User not found"}
+
+    return {"statusCode": 200, "body": {"name": user.name}}
+
+
+# Tests - no moto, no localstack, no DynamoDB Local!
+def test_create_user_handler(pydynox_memory_backend):
+    """Test the create user Lambda handler."""
+    event = {"user_id": "123", "name": "John"}
+
+    response = create_user_handler(event, None)
+
+    assert response["statusCode"] == 201
+
+    # Verify user was created
+    user = User.get(pk="USER#123")
+    assert user is not None
+    assert user.name == "John"
+
+
+def test_get_user_handler(pydynox_memory_backend):
+    """Test the get user Lambda handler."""
+    # Setup: create a user first
+    User(pk="USER#123", name="Jane").save()
+
+    event = {"user_id": "123"}
+    response = get_user_handler(event, None)
+
+    assert response["statusCode"] == 200
+    assert response["body"]["name"] == "Jane"
+
+
+def test_get_user_not_found(pydynox_memory_backend):
+    """Test getting a non-existent user."""
+    event = {"user_id": "999"}
+
+    response = get_user_handler(event, None)
+
+    assert response["statusCode"] == 404

--- a/docs/examples/testing/query_scan.py
+++ b/docs/examples/testing/query_scan.py
@@ -1,0 +1,61 @@
+"""Testing query and scan operations."""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.conditions import Attr
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    status = StringAttribute()
+    total = NumberAttribute()
+
+
+def test_query_by_hash_key(pydynox_memory_backend):
+    """Test querying items by partition key."""
+    Order(pk="USER#1", sk="ORDER#001", status="pending", total=100).save()
+    Order(pk="USER#1", sk="ORDER#002", status="shipped", total=200).save()
+    Order(pk="USER#2", sk="ORDER#001", status="pending", total=50).save()
+
+    # Query returns only USER#1's orders
+    results = list(Order.query(hash_key="USER#1"))
+    assert len(results) == 2
+
+
+def test_query_with_filter(pydynox_memory_backend):
+    """Test query with filter condition."""
+    Order(pk="USER#1", sk="ORDER#001", status="pending", total=100).save()
+    Order(pk="USER#1", sk="ORDER#002", status="shipped", total=200).save()
+    Order(pk="USER#1", sk="ORDER#003", status="pending", total=300).save()
+
+    # Filter by status
+    results = list(
+        Order.query(
+            hash_key="USER#1",
+            filter_condition=Attr("status").eq("pending"),
+        )
+    )
+    assert len(results) == 2
+
+
+def test_scan_all_items(pydynox_memory_backend):
+    """Test scanning all items in a table."""
+    Order(pk="USER#1", sk="ORDER#001", status="pending", total=100).save()
+    Order(pk="USER#2", sk="ORDER#001", status="shipped", total=200).save()
+    Order(pk="USER#3", sk="ORDER#001", status="pending", total=300).save()
+
+    results = list(Order.scan())
+    assert len(results) == 3
+
+
+def test_scan_with_filter(pydynox_memory_backend):
+    """Test scan with filter condition."""
+    Order(pk="USER#1", sk="ORDER#001", status="pending", total=100).save()
+    Order(pk="USER#2", sk="ORDER#001", status="shipped", total=200).save()
+    Order(pk="USER#3", sk="ORDER#001", status="pending", total=300).save()
+
+    # Filter by total > 150
+    results = list(Order.scan(filter_condition=Attr("total").gt(150)))
+    assert len(results) == 2

--- a/docs/examples/testing/seed_data.py
+++ b/docs/examples/testing/seed_data.py
@@ -1,0 +1,72 @@
+"""Using seed data with pydynox_memory_backend_factory."""
+
+import pytest
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class User(Model):
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(default=0)
+
+
+class Order(Model):
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+
+
+def test_with_seed_data(pydynox_memory_backend_factory):
+    """Test with pre-populated data."""
+    seed = {
+        "users": [
+            {"pk": "USER#1", "name": "Alice", "age": 30},
+            {"pk": "USER#2", "name": "Bob", "age": 25},
+        ]
+    }
+
+    with pydynox_memory_backend_factory(seed=seed):
+        # Data is already there!
+        alice = User.get(pk="USER#1")
+        assert alice.name == "Alice"
+
+        bob = User.get(pk="USER#2")
+        assert bob.name == "Bob"
+
+
+def test_with_multiple_tables(pydynox_memory_backend_factory):
+    """Seed multiple tables at once."""
+    seed = {
+        "users": [{"pk": "USER#1", "name": "John", "age": 30}],
+        "orders": [
+            {"pk": "USER#1", "sk": "ORDER#001", "total": 100},
+            {"pk": "USER#1", "sk": "ORDER#002", "total": 200},
+        ],
+    }
+
+    with pydynox_memory_backend_factory(seed=seed):
+        user = User.get(pk="USER#1")
+        assert user is not None
+
+        orders = list(Order.query(hash_key="USER#1"))
+        assert len(orders) == 2
+
+
+# Alternative: use pydynox_seed fixture in conftest.py
+@pytest.fixture
+def pydynox_seed():
+    """Override this in conftest.py to provide default seed data."""
+    return {
+        "users": [
+            {"pk": "ADMIN#1", "name": "Admin", "age": 99},
+        ]
+    }
+
+
+def test_with_seeded_fixture(pydynox_memory_backend_seeded):
+    """Uses seed data from pydynox_seed fixture."""
+    admin = User.get(pk="ADMIN#1")
+    assert admin.name == "Admin"

--- a/docs/examples/ttl/testing_ttl.py
+++ b/docs/examples/ttl/testing_ttl.py
@@ -1,0 +1,69 @@
+"""Testing TTL with pydynox_memory_backend."""
+
+from datetime import datetime, timedelta, timezone
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute
+from pydynox.ttl import ExpiresIn, TTLAttribute
+
+
+class Session(Model):
+    model_config = ModelConfig(table="sessions")
+    pk = StringAttribute(hash_key=True)
+    user_id = StringAttribute()
+    expires_at = TTLAttribute()
+
+
+def test_create_session_with_ttl(pydynox_memory_backend):
+    """Test creating a session with TTL."""
+    session = Session(
+        pk="SESSION#123",
+        user_id="USER#1",
+        expires_at=ExpiresIn.hours(1),
+    )
+    session.save()
+
+    found = Session.get(pk="SESSION#123")
+    assert found is not None
+    assert found.user_id == "USER#1"
+    assert found.expires_at is not None
+
+
+def test_session_not_expired(pydynox_memory_backend):
+    """Test that session is not expired."""
+    session = Session(
+        pk="SESSION#123",
+        user_id="USER#1",
+        expires_at=ExpiresIn.hours(1),
+    )
+    session.save()
+
+    found = Session.get(pk="SESSION#123")
+    assert not found.is_expired
+
+
+def test_session_expired(pydynox_memory_backend):
+    """Test that session is expired."""
+    # Create session that expired 1 hour ago
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    session = Session(
+        pk="SESSION#123",
+        user_id="USER#1",
+        expires_at=past,
+    )
+    session.save()
+
+    found = Session.get(pk="SESSION#123")
+    assert found.is_expired
+
+
+def test_expires_in_helper(pydynox_memory_backend):
+    """Test ExpiresIn helper methods."""
+    now = datetime.now(timezone.utc)
+
+    # Test various durations
+    assert ExpiresIn.seconds(30) > now
+    assert ExpiresIn.minutes(5) > now
+    assert ExpiresIn.hours(1) > now
+    assert ExpiresIn.days(7) > now
+    assert ExpiresIn.weeks(2) > now

--- a/docs/guides/atomic-updates.md
+++ b/docs/guides/atomic-updates.md
@@ -167,6 +167,17 @@ Use regular `update()` with kwargs when:
 - You're doing a simple field update
 
 
+## Testing your code
+
+Test atomic updates without DynamoDB using the built-in memory backend:
+
+=== "testing_atomic.py"
+    ```python
+    --8<-- "docs/examples/atomic/testing_atomic.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Next steps
 
 - [Observability](observability.md) - Track metrics on every operation

--- a/docs/guides/batch.md
+++ b/docs/guides/batch.md
@@ -71,6 +71,17 @@ except Exception as e:
 3. **Consider rate limiting** - If you're writing a lot of data, combine batch operations with rate limiting to avoid throttling.
 
 
+## Testing your code
+
+Test batch operations without DynamoDB using the built-in memory backend:
+
+=== "testing_batch.py"
+    ```python
+    --8<-- "docs/examples/batch/testing_batch.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Next steps
 
 - [Transactions](transactions.md) - All-or-nothing operations

--- a/docs/guides/conditions.md
+++ b/docs/guides/conditions.md
@@ -156,6 +156,17 @@ def apply_filter(cond: Condition) -> None:
 ```
 
 
+## Testing your code
+
+Test conditions without DynamoDB using the built-in memory backend:
+
+=== "testing_conditions.py"
+    ```python
+    --8<-- "docs/examples/conditions/testing_conditions.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Next steps
 
 - [Query](query.md) - Query items with conditions

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -112,6 +112,17 @@ Hooks run for each item in a transaction. If you're saving 10 items in a transac
 If a hook raises an exception, the entire transaction fails and nothing is saved.
 
 
+## Testing your code
+
+Test hooks without DynamoDB using the built-in memory backend:
+
+=== "testing_hooks.py"
+    ```python
+    --8<-- "docs/examples/hooks/testing_hooks.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Next steps
 
 - [Auto-generate](auto-generate.md) - Generate IDs and timestamps

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -303,6 +303,17 @@ except ThrottlingError:
     print("Rate limited, try again")
 ```
 
+## Testing your code
+
+Test models without DynamoDB using the built-in memory backend:
+
+=== "testing_models.py"
+    ```python
+    --8<-- "docs/examples/models/testing_models.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Next steps
 
 - [Query](query.md) - Query items by hash key with conditions

--- a/docs/guides/query.md
+++ b/docs/guides/query.md
@@ -202,6 +202,17 @@ for order in Order.status_index.query(status="shipped"):
     print(order.pk)
 ```
 
+## Testing your code
+
+Test queries without DynamoDB using the built-in memory backend:
+
+=== "testing_query.py"
+    ```python
+    --8<-- "docs/examples/query/testing_query.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Next steps
 
 - [Atomic updates](atomic-updates.md) - Increment, append, and other atomic operations

--- a/docs/guides/scan.md
+++ b/docs/guides/scan.md
@@ -229,6 +229,17 @@ Use `as_dict=True` to skip Model instantiation and get plain dicts:
 | `filter_condition` | Condition | None | Filter on any attribute |
 | `consistent_read` | bool | None | Strongly consistent read |
 
+## Testing your code
+
+Test scans without DynamoDB using the built-in memory backend:
+
+=== "testing_scan.py"
+    ```python
+    --8<-- "docs/examples/scan/testing_scan.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Anti-patterns
 
 ### Scan in API endpoints

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,232 @@
+# Testing
+
+Testing DynamoDB code is hard. You need a real database, or moto, or localstack, or Docker. Setup takes time. Tests are slow. CI/CD pipelines get complicated.
+
+pydynox solves this with a built-in in-memory backend. No extra dependencies. No setup. Just pytest fixtures that work out of the box.
+
+## Why use this?
+
+- **Zero dependencies** - Already included in pydynox. No extra packages to install.
+- **No cold start impact** - Only loads when you import it. Your Lambda stays fast.
+- **Auto-registered fixtures** - pytest finds them automatically. No conftest.py needed.
+- **Fast** - In-memory storage. No network, no Docker.
+
+## Key features
+
+- In-memory backend that mimics DynamoDB
+- Auto-registered pytest fixtures
+- Seed data support
+- Test isolation (each test starts fresh)
+- Works with all pydynox operations
+
+## Getting started
+
+### Basic usage
+
+Just add `pydynox_memory_backend` to your test function. That's it.
+
+=== "basic_fixture.py"
+    ```python
+    --8<-- "docs/examples/testing/basic_fixture.py"
+    ```
+
+The fixture is auto-discovered by pytest. No imports needed, no conftest.py setup.
+
+### How it works
+
+When you use `pydynox_memory_backend`:
+
+1. pydynox switches to an in-memory storage
+2. All `save()`, `get()`, `query()`, etc. use this storage
+3. After the test, storage is cleared
+4. The original client is restored
+
+Each test is isolated. Data from one test doesn't leak to another.
+
+## Fixtures
+
+pydynox provides three fixtures:
+
+| Fixture | Use case |
+|---------|----------|
+| `pydynox_memory_backend` | Most tests - empty database per test |
+| `pydynox_memory_backend_factory` | Tests that need custom seed data |
+| `pydynox_memory_backend_seeded` | Tests that share common seed data |
+
+### pydynox_memory_backend
+
+The simplest option. Each test starts with empty tables.
+
+```python
+def test_create_user(pydynox_memory_backend):
+    user = User(pk="USER#1", name="John")
+    user.save()
+    assert User.get(pk="USER#1") is not None
+```
+
+### pydynox_memory_backend_factory
+
+Use when you need pre-populated data:
+
+=== "seed_data.py"
+    ```python
+    --8<-- "docs/examples/testing/seed_data.py"
+    ```
+
+### pydynox_memory_backend_seeded
+
+For shared seed data across many tests, override `pydynox_seed` in your `conftest.py`:
+
+```python
+# conftest.py
+import pytest
+
+@pytest.fixture
+def pydynox_seed():
+    return {
+        "users": [
+            {"pk": "ADMIN#1", "name": "Admin", "role": "admin"},
+            {"pk": "USER#1", "name": "Test User", "role": "user"},
+        ]
+    }
+```
+
+Then use `pydynox_memory_backend_seeded` in your tests:
+
+```python
+def test_admin_exists(pydynox_memory_backend_seeded):
+    admin = User.get(pk="ADMIN#1")
+    assert admin.role == "admin"
+```
+
+## Inspecting data
+
+Access the backend to inspect stored data:
+
+=== "inspect_data.py"
+    ```python
+    --8<-- "docs/examples/testing/inspect_data.py"
+    ```
+
+## Query and scan
+
+The memory backend supports query and scan with filters:
+
+=== "query_scan.py"
+    ```python
+    --8<-- "docs/examples/testing/query_scan.py"
+    ```
+
+## Testing Lambda handlers
+
+Perfect for testing AWS Lambda functions:
+
+=== "lambda_handler.py"
+    ```python
+    --8<-- "docs/examples/testing/lambda_handler.py"
+    ```
+
+No mocking needed. Your handler code runs exactly as it would in production, just with in-memory storage.
+
+## Without pytest
+
+You can use `MemoryBackend` directly as a context manager or decorator:
+
+=== "context_manager.py"
+    ```python
+    --8<-- "docs/examples/testing/context_manager.py"
+    ```
+
+## Supported operations
+
+The memory backend supports:
+
+| Operation | Supported |
+|-----------|-----------|
+| `save()` | ✓ |
+| `get()` | ✓ |
+| `delete()` | ✓ |
+| `update()` | ✓ |
+| `query()` | ✓ |
+| `scan()` | ✓ |
+| `batch_write()` | ✓ |
+| `batch_get()` | ✓ |
+| Conditions | ✓ |
+| Atomic updates | ✓ |
+
+!!! note
+    Some advanced features like transactions and GSI queries are not yet supported in the memory backend. Use localstack for those cases.
+
+## Comparison with alternatives
+
+| Feature | pydynox fixture | moto | localstack |
+|---------|-----------------|------|------------|
+| Setup | None | Decorator | Docker |
+| Speed | Fastest | Fast | Slow |
+| Accuracy | Good | Good | Best |
+| Dependencies | None | moto | Docker |
+| GSI support | No | Yes | Yes |
+| Transactions | No | Yes | Yes |
+
+Use pydynox fixtures for:
+
+- Unit tests
+- Fast feedback loops
+- CI/CD pipelines
+- Simple CRUD tests
+
+Use localstack for:
+
+- Integration tests
+- GSI queries
+- Transactions
+- Full DynamoDB compatibility
+
+## Tips
+
+### Run tests in parallel
+
+The memory backend is isolated per test, so parallel execution works:
+
+```bash
+pytest -n auto  # with pytest-xdist
+```
+
+### Combine with parametrize
+
+```python
+import pytest
+
+@pytest.mark.parametrize("name,age", [
+    ("Alice", 30),
+    ("Bob", 25),
+    ("Charlie", 35),
+])
+def test_create_users(pydynox_memory_backend, name, age):
+    user = User(pk=f"USER#{name}", name=name, age=age)
+    user.save()
+    
+    found = User.get(pk=f"USER#{name}")
+    assert found.age == age
+```
+
+### Use autouse for all tests
+
+If you want all tests to use the memory backend:
+
+```python
+# conftest.py
+import pytest
+
+@pytest.fixture(autouse=True)
+def use_memory_backend(pydynox_memory_backend):
+    yield
+```
+
+Now every test automatically uses in-memory storage.
+
+## Next steps
+
+- [Models](models.md) - Define your data models
+- [Query](query.md) - Query items by key
+- [Conditions](conditions.md) - Conditional operations

--- a/docs/guides/ttl.md
+++ b/docs/guides/ttl.md
@@ -127,6 +127,17 @@ Session management with TTL:
 3. **Enable TTL on table** - TTL won't work without table-level configuration
 4. **Choose the right duration** - Too short = bad UX, too long = wasted storage
 
+## Testing your code
+
+Test TTL without DynamoDB using the built-in memory backend:
+
+=== "testing_ttl.py"
+    ```python
+    --8<-- "docs/examples/ttl/testing_ttl.py"
+    ```
+
+No setup needed. Just add `pydynox_memory_backend` to your test function. See [Testing](testing.md) for more details.
+
 ## Next steps
 
 - [Attributes](attributes.md) - All attribute types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Homepage = "https://github.com/leandrodamascena/pydynox"
 pydantic = ["pydantic>=2.0"]
 opentelemetry = ["opentelemetry-api>=1.0"]
 
+[project.entry-points.pytest11]
+pydynox = "pydynox.testing.pytest_plugin"
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/python/pydynox/testing/__init__.py
+++ b/python/pydynox/testing/__init__.py
@@ -1,0 +1,32 @@
+"""Testing utilities for pydynox.
+
+This module provides tools for testing pydynox code without needing
+DynamoDB Local, LocalStack, or moto.
+
+Example:
+    >>> from pydynox.testing import MemoryBackend
+    >>>
+    >>> # As context manager
+    >>> with MemoryBackend():
+    ...     user = User(pk="USER#1", name="John")
+    ...     user.save()
+    ...     assert User.get(pk="USER#1") is not None
+    >>>
+    >>> # As decorator
+    >>> @MemoryBackend()
+    ... def test_create_user():
+    ...     user = User(pk="USER#1", name="John")
+    ...     user.save()
+    ...     assert User.get(pk="USER#1") is not None
+    >>>
+    >>> # As pytest fixture
+    >>> import pytest
+    >>> @pytest.fixture(autouse=True)
+    ... def memory_db():
+    ...     with MemoryBackend():
+    ...         yield
+"""
+
+from pydynox.testing.memory import MemoryBackend
+
+__all__ = ["MemoryBackend"]

--- a/python/pydynox/testing/memory.py
+++ b/python/pydynox/testing/memory.py
@@ -1,0 +1,799 @@
+"""In-memory backend for testing pydynox without DynamoDB."""
+
+from __future__ import annotations
+
+import copy
+import re
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Callable, Iterator, TypeVar
+
+from pydynox.config import clear_default_client, get_default_client, set_default_client
+
+
+@dataclass
+class FakeMetrics:
+    """Fake metrics for in-memory backend."""
+
+    duration_ms: float = 0.0
+    consumed_rcu: float = 0.0
+    consumed_wcu: float = 0.0
+    request_id: str = "memory-backend"
+    scanned_count: int = 0
+    count: int = 0
+    items_count: int = 0
+
+
+class FakeDictWithMetrics(dict):
+    """Fake DictWithMetrics for in-memory backend."""
+
+    def __init__(self, data: dict[str, Any], metrics: FakeMetrics):
+        super().__init__(data)
+        self.metrics = metrics
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class MemoryBackend:
+    """In-memory backend for testing pydynox code.
+
+    Stores data in Python dicts. No external dependencies needed.
+    Supports basic CRUD operations, queries, and scans.
+
+    Example:
+        >>> from pydynox.testing import MemoryBackend
+        >>>
+        >>> # As context manager
+        >>> with MemoryBackend():
+        ...     user = User(pk="USER#1", name="John")
+        ...     user.save()
+        ...     found = User.get(pk="USER#1")
+        ...     assert found.name == "John"
+        >>>
+        >>> # As decorator
+        >>> @MemoryBackend()
+        ... def test_user_crud():
+        ...     user = User(pk="USER#1", name="John")
+        ...     user.save()
+        ...     assert User.get(pk="USER#1") is not None
+        >>>
+        >>> # With seed data
+        >>> with MemoryBackend(seed={"users": [{"pk": "USER#1", "name": "John"}]}):
+        ...     user = User.get(pk="USER#1")
+        ...     assert user.name == "John"
+    """
+
+    def __init__(self, seed: dict[str, list[dict[str, Any]]] | None = None) -> None:
+        """Initialize the memory backend.
+
+        Args:
+            seed: Optional dict of table_name -> list of items to pre-populate.
+        """
+        self._seed = seed or {}
+        self._previous_client: Any = None
+        self._client: MemoryClient | None = None
+
+    def __enter__(self) -> "MemoryBackend":
+        """Enter context manager."""
+        self._previous_client = get_default_client()
+        self._client = MemoryClient(seed=self._seed)
+        # Clear cached clients so models use the new MemoryClient
+        self._clear_model_caches()
+        set_default_client(self._client)  # type: ignore[arg-type]
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit context manager and restore previous client."""
+        # Clear cached clients from all Model subclasses
+        self._clear_model_caches()
+
+        if self._previous_client is not None:
+            set_default_client(self._previous_client)
+        else:
+            clear_default_client()
+        self._client = None
+
+    def _clear_model_caches(self) -> None:
+        """Clear _client_instance cache from all Model subclasses."""
+        from pydynox.model import Model
+
+        for subclass in Model.__subclasses__():
+            if hasattr(subclass, "_client_instance"):
+                subclass._client_instance = None
+            # Also clear nested subclasses
+            for nested in subclass.__subclasses__():
+                if hasattr(nested, "_client_instance"):
+                    nested._client_instance = None
+
+    def __call__(self, func: F) -> F:
+        """Use as decorator."""
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with self:
+                return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    @property
+    def tables(self) -> dict[str, dict[str, dict[str, Any]]]:
+        """Access the in-memory tables for inspection.
+
+        Returns:
+            Dict of table_name -> {key -> item}.
+        """
+        if self._client is None:
+            return {}
+        return self._client._tables
+
+    def clear(self) -> None:
+        """Clear all data from all tables."""
+        if self._client is not None:
+            self._client._tables.clear()
+
+
+@contextmanager
+def memory_backend(
+    seed: dict[str, list[dict[str, Any]]] | None = None,
+) -> Iterator[MemoryBackend]:
+    """Context manager for in-memory testing.
+
+    Args:
+        seed: Optional dict of table_name -> list of items to pre-populate.
+
+    Yields:
+        MemoryBackend instance.
+
+    Example:
+        >>> with memory_backend() as backend:
+        ...     user = User(pk="USER#1", name="John")
+        ...     user.save()
+        ...     assert "users" in backend.tables
+    """
+    backend = MemoryBackend(seed=seed)
+    with backend:
+        yield backend
+
+
+class MemoryClient:
+    """In-memory client that mimics DynamoDBClient interface."""
+
+    def __init__(self, seed: dict[str, list[dict[str, Any]]] | None = None) -> None:
+        # tables[table_name][key_string] = item
+        self._tables: dict[str, dict[str, dict[str, Any]]] = {}
+        self._table_schemas: dict[str, dict[str, str]] = {}  # table -> {hash_key, range_key}
+        self._rate_limit = None
+        self._diagnostics = None
+        # For compatibility with code that accesses _client directly
+        self._client = self
+
+        # Load seed data
+        if seed:
+            for table_name, items in seed.items():
+                self._tables[table_name] = {}
+                for item in items:
+                    # Infer key from first item
+                    key_str = self._make_key_string(item)
+                    self._tables[table_name][key_str] = copy.deepcopy(item)
+
+    @property
+    def diagnostics(self) -> None:
+        """Return None - no diagnostics for memory backend."""
+        return self._diagnostics
+
+    @property
+    def rate_limit(self) -> None:
+        """Return None - no rate limiting for memory backend."""
+        return self._rate_limit
+
+    def _acquire_rcu(self, rcu: float = 1.0) -> None:
+        """No-op for memory backend."""
+        pass
+
+    def _acquire_wcu(self, wcu: float = 1.0) -> None:
+        """No-op for memory backend."""
+        pass
+
+    def _on_throttle(self) -> None:
+        """No-op for memory backend."""
+        pass
+
+    def _record_write(self, table: str, pk: str) -> None:
+        """No-op for memory backend."""
+        pass
+
+    def _record_read(self, table: str, pk: str) -> None:
+        """No-op for memory backend."""
+        pass
+
+    def _make_key_string(self, item_or_key: dict[str, Any]) -> str:
+        """Create a unique key string from item or key dict.
+
+        Uses only pk and sk fields (if present) to create consistent keys.
+        """
+        pk = item_or_key.get("pk", "")
+        sk = item_or_key.get("sk", "")
+
+        # Also check for common key patterns
+        if not pk:
+            # Try to find hash_key by looking for common patterns
+            for key in ["pk", "PK", "hash_key", "id", "short_code"]:
+                if key in item_or_key:
+                    pk = item_or_key[key]
+                    break
+
+        if pk and sk:
+            return f"{pk}|{sk}"
+        return str(pk)
+
+    def _get_table(self, table: str) -> dict[str, dict[str, Any]]:
+        """Get or create table storage."""
+        if table not in self._tables:
+            self._tables[table] = {}
+        return self._tables[table]
+
+    def _make_metrics(self, start: float, rcu: float = 0, wcu: float = 0) -> FakeMetrics:
+        """Create metrics object."""
+        return FakeMetrics(
+            duration_ms=(time.time() - start) * 1000,
+            consumed_rcu=rcu,
+            consumed_wcu=wcu,
+            request_id="memory-backend",
+        )
+
+    # ========== CRUD ==========
+
+    def put_item(
+        self,
+        table: str,
+        item: dict[str, Any],
+        condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+    ) -> FakeMetrics:
+        """Put an item into the in-memory table."""
+        start = time.time()
+        tbl = self._get_table(table)
+        key_str = self._make_key_string(item)
+
+        # Check condition if provided
+        if condition_expression:
+            existing = tbl.get(key_str)
+            if not self._check_condition(
+                existing,
+                condition_expression,
+                expression_attribute_names,
+                expression_attribute_values,
+            ):
+                from pydynox.exceptions import ConditionCheckFailedError
+
+                raise ConditionCheckFailedError("Condition check failed")
+
+        tbl[key_str] = copy.deepcopy(item)
+        return self._make_metrics(start, wcu=1)
+
+    def get_item(
+        self, table: str, key: dict[str, Any], consistent_read: bool = False
+    ) -> FakeDictWithMetrics | None:
+        """Get an item from the in-memory table."""
+        start = time.time()
+        tbl = self._get_table(table)
+        key_str = self._make_key_string(key)
+        item = tbl.get(key_str)
+        if item is None:
+            return None
+        return FakeDictWithMetrics(copy.deepcopy(item), self._make_metrics(start, rcu=1))
+
+    def delete_item(
+        self,
+        table: str,
+        key: dict[str, Any],
+        condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+    ) -> FakeMetrics:
+        """Delete an item from the in-memory table."""
+        start = time.time()
+        tbl = self._get_table(table)
+        key_str = self._make_key_string(key)
+
+        # Check condition if provided
+        if condition_expression:
+            existing = tbl.get(key_str)
+            if not self._check_condition(
+                existing,
+                condition_expression,
+                expression_attribute_names,
+                expression_attribute_values,
+            ):
+                from pydynox.exceptions import ConditionCheckFailedError
+
+                raise ConditionCheckFailedError("Condition check failed")
+
+        tbl.pop(key_str, None)
+        return self._make_metrics(start, wcu=1)
+
+    def update_item(
+        self,
+        table: str,
+        key: dict[str, Any],
+        updates: dict[str, Any] | None = None,
+        update_expression: str | None = None,
+        condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+    ) -> FakeMetrics:
+        """Update an item in the in-memory table."""
+        start = time.time()
+        tbl = self._get_table(table)
+        key_str = self._make_key_string(key)
+
+        existing = tbl.get(key_str)
+
+        # Check condition if provided
+        if condition_expression:
+            if not self._check_condition(
+                existing,
+                condition_expression,
+                expression_attribute_names,
+                expression_attribute_values,
+            ):
+                from pydynox.exceptions import ConditionCheckFailedError
+
+                raise ConditionCheckFailedError("Condition check failed")
+
+        # Create item if not exists
+        if existing is None:
+            existing = copy.deepcopy(key)
+            tbl[key_str] = existing
+
+        # Apply updates
+        if updates:
+            for attr, value in updates.items():
+                existing[attr] = value
+
+        # Apply update expression
+        if update_expression:
+            self._apply_update_expression(
+                existing, update_expression, expression_attribute_names, expression_attribute_values
+            )
+
+        return self._make_metrics(start, wcu=1)
+
+    # ========== QUERY/SCAN ==========
+
+    def query_page(
+        self,
+        table: str,
+        key_condition_expression: str,
+        filter_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        limit: int | None = None,
+        scan_index_forward: bool = True,
+        consistent_read: bool = False,
+        exclusive_start_key: dict[str, Any] | None = None,
+        index_name: str | None = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None, FakeMetrics]:
+        """Query a page of items from the in-memory table."""
+        result = self.query(
+            table,
+            key_condition_expression,
+            filter_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            limit,
+            scan_index_forward,
+            consistent_read,
+            exclusive_start_key,
+            index_name,
+        )
+        metrics = result["metrics"]
+        metrics.items_count = len(result["items"])
+        return result["items"], result["last_evaluated_key"], metrics
+
+    def scan_page(
+        self,
+        table: str,
+        filter_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        limit: int | None = None,
+        consistent_read: bool = False,
+        exclusive_start_key: dict[str, Any] | None = None,
+        segment: int | None = None,
+        total_segments: int | None = None,
+        index_name: str | None = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None, FakeMetrics]:
+        """Scan a page of items from the in-memory table."""
+        result = self.scan(
+            table,
+            filter_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            limit,
+            consistent_read,
+            exclusive_start_key,
+            segment,
+            total_segments,
+            index_name,
+        )
+        metrics = result["metrics"]
+        metrics.items_count = len(result["items"])
+        return result["items"], result["last_evaluated_key"], metrics
+
+    def query(
+        self,
+        table: str,
+        key_condition_expression: str,
+        filter_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        limit: int | None = None,
+        scan_index_forward: bool = True,
+        consistent_read: bool = False,
+        exclusive_start_key: dict[str, Any] | None = None,
+        index_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Query items from the in-memory table."""
+        start = time.time()
+        tbl = self._get_table(table)
+
+        # Parse key condition to get hash key value
+        items = []
+        for item in tbl.values():
+            if self._matches_key_condition(
+                item,
+                key_condition_expression,
+                expression_attribute_names,
+                expression_attribute_values,
+            ):
+                if filter_expression is None or self._check_condition(
+                    item, filter_expression, expression_attribute_names, expression_attribute_values
+                ):
+                    items.append(copy.deepcopy(item))
+
+        # Sort (simplified - just by first key)
+        if not scan_index_forward:
+            items.reverse()
+
+        # Apply limit
+        if limit and len(items) > limit:
+            items = items[:limit]
+
+        return {
+            "items": items,
+            "count": len(items),
+            "scanned_count": len(items),
+            "last_evaluated_key": None,
+            "metrics": self._make_metrics(start, rcu=len(items) * 0.5),
+        }
+
+    def scan(
+        self,
+        table: str,
+        filter_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        limit: int | None = None,
+        consistent_read: bool = False,
+        exclusive_start_key: dict[str, Any] | None = None,
+        segment: int | None = None,
+        total_segments: int | None = None,
+        index_name: str | None = None,
+    ) -> dict[str, Any]:
+        """Scan all items from the in-memory table."""
+        start = time.time()
+        tbl = self._get_table(table)
+
+        items = []
+        for item in tbl.values():
+            if filter_expression is None or self._check_condition(
+                item, filter_expression, expression_attribute_names, expression_attribute_values
+            ):
+                items.append(copy.deepcopy(item))
+
+        # Apply limit
+        if limit and len(items) > limit:
+            items = items[:limit]
+
+        return {
+            "items": items,
+            "count": len(items),
+            "scanned_count": len(tbl),
+            "last_evaluated_key": None,
+            "metrics": self._make_metrics(start, rcu=len(tbl) * 0.5),
+        }
+
+    # ========== BATCH ==========
+
+    def batch_get_item(
+        self,
+        request_items: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Batch get items from multiple tables."""
+        start = time.time()
+        responses: dict[str, list[dict[str, Any]]] = {}
+        total_rcu = 0.0
+
+        for table_name, request in request_items.items():
+            keys = request.get("Keys", [])
+            tbl = self._get_table(table_name)
+            responses[table_name] = []
+
+            for key in keys:
+                key_str = self._make_key_string(key)
+                item = tbl.get(key_str)
+                if item:
+                    responses[table_name].append(copy.deepcopy(item))
+                    total_rcu += 1
+
+        return {
+            "Responses": responses,
+            "UnprocessedKeys": {},
+            "metrics": self._make_metrics(start, rcu=total_rcu),
+        }
+
+    def batch_write_item(
+        self,
+        request_items: dict[str, list[dict[str, Any]]],
+    ) -> dict[str, Any]:
+        """Batch write items to multiple tables."""
+        start = time.time()
+        total_wcu = 0.0
+
+        for table_name, requests in request_items.items():
+            tbl = self._get_table(table_name)
+
+            for request in requests:
+                if "PutRequest" in request:
+                    item = request["PutRequest"]["Item"]
+                    key_str = self._make_key_string(item)
+                    tbl[key_str] = copy.deepcopy(item)
+                    total_wcu += 1
+                elif "DeleteRequest" in request:
+                    key = request["DeleteRequest"]["Key"]
+                    key_str = self._make_key_string(key)
+                    tbl.pop(key_str, None)
+                    total_wcu += 1
+
+        return {
+            "UnprocessedItems": {},
+            "metrics": self._make_metrics(start, wcu=total_wcu),
+        }
+
+    # ========== TABLE ==========
+
+    def table_exists(self, table: str) -> bool:
+        """Check if table exists (always True for memory backend)."""
+        return table in self._tables
+
+    def create_table(self, table: str, **kwargs: Any) -> None:
+        """Create a table (just initializes empty dict)."""
+        if table not in self._tables:
+            self._tables[table] = {}
+
+    def delete_table(self, table: str) -> None:
+        """Delete a table."""
+        self._tables.pop(table, None)
+
+    # ========== HELPERS ==========
+
+    def get_region(self) -> str:
+        """Return fake region."""
+        return "us-east-1"
+
+    def ping(self) -> bool:
+        """Always returns True for memory backend."""
+        return True
+
+    def _check_condition(
+        self,
+        item: dict[str, Any] | None,
+        condition: str,
+        attr_names: dict[str, str] | None,
+        attr_values: dict[str, Any] | None,
+    ) -> bool:
+        """Check if item matches condition expression.
+
+        Supports basic conditions:
+        - attribute_exists(attr)
+        - attribute_not_exists(attr)
+        - attr = :value
+        - attr <> :value
+        - attr < :value
+        - attr <= :value
+        - attr > :value
+        - attr >= :value
+        """
+        if item is None:
+            # For attribute_not_exists, None item means condition passes
+            if "attribute_not_exists" in condition:
+                return True
+            return False
+
+        # Resolve attribute names
+        resolved_condition = condition
+        if attr_names:
+            for placeholder, real_name in attr_names.items():
+                resolved_condition = resolved_condition.replace(placeholder, real_name)
+
+        # Check attribute_exists
+        match = re.search(r"attribute_exists\((\w+)\)", resolved_condition)
+        if match:
+            attr = match.group(1)
+            return attr in item
+
+        # Check attribute_not_exists
+        match = re.search(r"attribute_not_exists\((\w+)\)", resolved_condition)
+        if match:
+            attr = match.group(1)
+            return attr not in item
+
+        # Check comparisons
+        for op, func in [
+            ("=", lambda a, b: a == b),
+            ("<>", lambda a, b: a != b),
+            ("<=", lambda a, b: a <= b),
+            (">=", lambda a, b: a >= b),
+            ("<", lambda a, b: a < b),
+            (">", lambda a, b: a > b),
+        ]:
+            match = re.search(rf"(\w+)\s*{re.escape(op)}\s*(:?\w+)", resolved_condition)
+            if match:
+                attr = match.group(1)
+                value_key = match.group(2)
+                if attr_values and value_key in attr_values:
+                    expected = attr_values[value_key]
+                    actual = item.get(attr)
+                    return func(actual, expected)
+
+        # Default: pass
+        return True
+
+    def _matches_key_condition(
+        self,
+        item: dict[str, Any],
+        condition: str,
+        attr_names: dict[str, str] | None,
+        attr_values: dict[str, Any] | None,
+    ) -> bool:
+        """Check if item matches key condition expression.
+
+        Supports:
+        - pk = :value
+        - pk = :value AND sk begins_with :prefix
+        - pk = :value AND sk BETWEEN :start AND :end
+        """
+        # Resolve attribute names
+        resolved = condition
+        if attr_names:
+            for placeholder, real_name in attr_names.items():
+                resolved = resolved.replace(placeholder, real_name)
+
+        # Split by AND
+        parts = re.split(r"\s+AND\s+", resolved, flags=re.IGNORECASE)
+
+        for part in parts:
+            part = part.strip()
+
+            # Check equality
+            match = re.search(r"(\w+)\s*=\s*(:?\w+)", part)
+            if match:
+                attr = match.group(1)
+                value_key = match.group(2)
+                if attr_values and value_key in attr_values:
+                    if item.get(attr) != attr_values[value_key]:
+                        return False
+                continue
+
+            # Check begins_with
+            match = re.search(r"begins_with\s*\(\s*(\w+)\s*,\s*(:?\w+)\s*\)", part, re.IGNORECASE)
+            if match:
+                attr = match.group(1)
+                value_key = match.group(2)
+                if attr_values and value_key in attr_values:
+                    prefix = attr_values[value_key]
+                    actual = item.get(attr, "")
+                    if not str(actual).startswith(str(prefix)):
+                        return False
+                continue
+
+            # Check BETWEEN
+            match = re.search(r"(\w+)\s+BETWEEN\s+(:?\w+)\s+AND\s+(:?\w+)", part, re.IGNORECASE)
+            if match:
+                attr = match.group(1)
+                start_key = match.group(2)
+                end_key = match.group(3)
+                if attr_values:
+                    start_val = attr_values.get(start_key)
+                    end_val = attr_values.get(end_key)
+                    actual = item.get(attr)
+                    if actual is None or not (start_val <= actual <= end_val):
+                        return False
+                continue
+
+        return True
+
+    def _apply_update_expression(
+        self,
+        item: dict[str, Any],
+        expression: str,
+        attr_names: dict[str, str] | None,
+        attr_values: dict[str, Any] | None,
+    ) -> None:
+        """Apply update expression to item.
+
+        Supports:
+        - SET attr = :value
+        - SET attr = attr + :value (ADD)
+        - REMOVE attr
+        """
+        # Resolve attribute names
+        resolved = expression
+        if attr_names:
+            for placeholder, real_name in attr_names.items():
+                resolved = resolved.replace(placeholder, real_name)
+
+        # Handle SET
+        set_match = re.search(r"SET\s+(.+?)(?:REMOVE|ADD|DELETE|$)", resolved, re.IGNORECASE)
+        if set_match:
+            set_clause = set_match.group(1).strip()
+            # Split by comma
+            for assignment in set_clause.split(","):
+                assignment = assignment.strip()
+                if not assignment:
+                    continue
+
+                # Check for attr = attr + :value (increment)
+                match = re.search(r"(\w+)\s*=\s*(\w+)\s*\+\s*(:?\w+)", assignment)
+                if match:
+                    attr = match.group(1)
+                    value_key = match.group(3)
+                    if attr_values and value_key in attr_values:
+                        current = item.get(attr, 0)
+                        item[attr] = current + attr_values[value_key]
+                    continue
+
+                # Check for attr = attr - :value (decrement)
+                match = re.search(r"(\w+)\s*=\s*(\w+)\s*-\s*(:?\w+)", assignment)
+                if match:
+                    attr = match.group(1)
+                    value_key = match.group(3)
+                    if attr_values and value_key in attr_values:
+                        current = item.get(attr, 0)
+                        item[attr] = current - attr_values[value_key]
+                    continue
+
+                # Simple assignment: attr = :value
+                match = re.search(r"(\w+)\s*=\s*(:?\w+)", assignment)
+                if match:
+                    attr = match.group(1)
+                    value_key = match.group(2)
+                    if attr_values and value_key in attr_values:
+                        item[attr] = attr_values[value_key]
+
+        # Handle REMOVE
+        remove_match = re.search(r"REMOVE\s+(.+?)(?:SET|ADD|DELETE|$)", resolved, re.IGNORECASE)
+        if remove_match:
+            remove_clause = remove_match.group(1).strip()
+            for attr in remove_clause.split(","):
+                attr = attr.strip()
+                if attr in item:
+                    del item[attr]
+
+        # Handle ADD (for numbers and sets)
+        add_match = re.search(r"ADD\s+(\w+)\s+(:?\w+)", resolved, re.IGNORECASE)
+        if add_match:
+            attr = add_match.group(1)
+            value_key = add_match.group(2)
+            if attr_values and value_key in attr_values:
+                add_value = attr_values[value_key]
+                if isinstance(add_value, (int, float)):
+                    item[attr] = item.get(attr, 0) + add_value
+                elif isinstance(add_value, set):
+                    current = item.get(attr, set())
+                    item[attr] = current | add_value

--- a/python/pydynox/testing/pytest_plugin.py
+++ b/python/pydynox/testing/pytest_plugin.py
@@ -1,0 +1,111 @@
+"""Pytest plugin for pydynox.
+
+This module is auto-discovered by pytest when pydynox is installed.
+It provides fixtures for testing with in-memory backend.
+
+Usage:
+    # Just use the fixture - no conftest.py needed!
+    def test_user(pydynox_memory_backend):
+        user = User(pk="USER#1", name="John")
+        user.save()
+        assert User.get(pk="USER#1") is not None
+
+    # Or use autouse in pyproject.toml:
+    # [tool.pytest.ini_options]
+    # usefixtures = ["pydynox_memory_backend"]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterator
+
+import pytest
+
+from pydynox.testing.memory import MemoryBackend
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.fixture
+def pydynox_memory_backend() -> Iterator[MemoryBackend]:
+    """Fixture that provides an in-memory DynamoDB backend.
+
+    All pydynox operations will use in-memory storage instead of
+    real DynamoDB. Data is isolated per test.
+
+    Example:
+        def test_create_user(pydynox_memory_backend):
+            user = User(pk="USER#1", name="John")
+            user.save()
+            found = User.get(pk="USER#1")
+            assert found.name == "John"
+
+        def test_with_seed_data(pydynox_memory_backend):
+            # Access the backend to inspect data
+            user = User(pk="USER#1", name="Test")
+            user.save()
+            assert "users" in pydynox_memory_backend.tables
+    """
+    with MemoryBackend() as backend:
+        yield backend
+
+
+@pytest.fixture
+def pydynox_memory_backend_factory() -> Iterator[type[MemoryBackend]]:
+    """Factory fixture for creating MemoryBackend with custom seed data.
+
+    Example:
+        def test_with_seed(pydynox_memory_backend_factory):
+            seed = {"users": [{"pk": "USER#1", "name": "Seeded"}]}
+            with pydynox_memory_backend_factory(seed=seed):
+                user = User.get(pk="USER#1")
+                assert user.name == "Seeded"
+    """
+    yield MemoryBackend
+
+
+@pytest.fixture
+def pydynox_seed() -> dict[str, list[dict[str, Any]]]:
+    """Override this fixture to provide seed data for pydynox_memory_backend_seeded.
+
+    Example:
+        # In conftest.py
+        @pytest.fixture
+        def pydynox_seed():
+            return {
+                "users": [
+                    {"pk": "USER#1", "name": "Admin", "role": "admin"},
+                    {"pk": "USER#2", "name": "User", "role": "user"},
+                ]
+            }
+
+        # In test file
+        def test_with_seed(pydynox_memory_backend_seeded):
+            admin = User.get(pk="USER#1")
+            assert admin.role == "admin"
+    """
+    return {}
+
+
+@pytest.fixture
+def pydynox_memory_backend_seeded(
+    pydynox_seed: dict[str, list[dict[str, Any]]],
+) -> Iterator[MemoryBackend]:
+    """Fixture with seed data from pydynox_seed fixture.
+
+    Override pydynox_seed in conftest.py to provide seed data.
+
+    Example:
+        # conftest.py
+        @pytest.fixture
+        def pydynox_seed():
+            return {"users": [{"pk": "USER#1", "name": "Test"}]}
+
+        # test_file.py
+        def test_seeded(pydynox_memory_backend_seeded):
+            user = User.get(pk="USER#1")
+            assert user.name == "Test"
+    """
+    with MemoryBackend(seed=pydynox_seed) as backend:
+        yield backend

--- a/tests/integration/testing/__init__.py
+++ b/tests/integration/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for pydynox testing module."""

--- a/tests/integration/testing/test_pytest_fixtures.py
+++ b/tests/integration/testing/test_pytest_fixtures.py
@@ -1,0 +1,157 @@
+"""Integration tests for pytest fixtures.
+
+These tests verify that the pytest plugin fixtures work correctly.
+The fixtures are auto-registered via entry points in pyproject.toml.
+"""
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+
+class User(Model):
+    """Test model for fixture tests."""
+
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(default=0)
+
+
+class Order(Model):
+    """Test model with composite key."""
+
+    model_config = ModelConfig(table="orders")
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    total = NumberAttribute()
+
+
+# ========== Tests using pydynox_memory_backend fixture ==========
+
+
+def test_pydynox_memory_backend_basic_crud(pydynox_memory_backend):
+    """Test basic CRUD with pydynox_memory_backend fixture."""
+    user = User(pk="USER#1", name="John", age=30)
+    user.save()
+
+    found = User.get(pk="USER#1")
+    assert found is not None
+    assert found.name == "John"
+    assert found.age == 30
+
+
+def test_pydynox_memory_backend_update(pydynox_memory_backend):
+    """Test update with pydynox_memory_backend fixture."""
+    user = User(pk="USER#1", name="Jane")
+    user.save()
+
+    user.update(name="Janet", age=25)
+
+    found = User.get(pk="USER#1")
+    assert found.name == "Janet"
+    assert found.age == 25
+
+
+def test_pydynox_memory_backend_delete(pydynox_memory_backend):
+    """Test delete with pydynox_memory_backend fixture."""
+    user = User(pk="USER#1", name="Bob")
+    user.save()
+
+    user.delete()
+
+    assert User.get(pk="USER#1") is None
+
+
+def test_pydynox_memory_backend_query(pydynox_memory_backend):
+    """Test query with pydynox_memory_backend fixture."""
+    Order(pk="USER#1", sk="ORDER#001", total=100).save()
+    Order(pk="USER#1", sk="ORDER#002", total=200).save()
+    Order(pk="USER#2", sk="ORDER#001", total=50).save()
+
+    results = list(Order.query(hash_key="USER#1"))
+    assert len(results) == 2
+
+
+def test_pydynox_memory_backend_scan(pydynox_memory_backend):
+    """Test scan with pydynox_memory_backend fixture."""
+    User(pk="USER#1", name="Alice").save()
+    User(pk="USER#2", name="Bob").save()
+    User(pk="USER#3", name="Charlie").save()
+
+    results = list(User.scan())
+    assert len(results) == 3
+
+
+def test_pydynox_memory_backend_isolation(pydynox_memory_backend):
+    """Test that each test has isolated data."""
+    # This test should not see data from other tests
+    assert User.get(pk="USER#1") is None
+
+    User(pk="USER#1", name="Isolated").save()
+    assert User.get(pk="USER#1") is not None
+
+
+def test_pydynox_memory_backend_tables_access(pydynox_memory_backend):
+    """Test accessing tables for inspection."""
+    User(pk="USER#1", name="Test").save()
+
+    # Can inspect the backend
+    assert "users" in pydynox_memory_backend.tables
+    assert len(pydynox_memory_backend.tables["users"]) == 1
+
+
+def test_pydynox_memory_backend_clear(pydynox_memory_backend):
+    """Test clearing data mid-test."""
+    User(pk="USER#1", name="Test").save()
+    assert User.get(pk="USER#1") is not None
+
+    pydynox_memory_backend.clear()
+
+    assert User.get(pk="USER#1") is None
+
+
+# ========== Tests using pydynox_memory_backend_seeded fixture ==========
+
+
+def test_pydynox_memory_backend_seeded_basic(pydynox_memory_backend_seeded):
+    """Test seeded fixture (no seed data by default)."""
+    # Default pydynox_seed returns empty dict
+    assert User.get(pk="USER#1") is None
+
+
+# ========== Tests using pydynox_memory_backend_factory fixture ==========
+
+
+def test_pydynox_memory_backend_factory_custom_seed(pydynox_memory_backend_factory):
+    """Test factory fixture with custom seed."""
+    seed = {
+        "users": [
+            {"pk": "USER#1", "name": "Seeded User", "age": 99},
+            {"pk": "USER#2", "name": "Another User", "age": 50},
+        ]
+    }
+
+    with pydynox_memory_backend_factory(seed=seed):
+        user1 = User.get(pk="USER#1")
+        assert user1 is not None
+        assert user1.name == "Seeded User"
+
+        user2 = User.get(pk="USER#2")
+        assert user2 is not None
+        assert user2.name == "Another User"
+
+
+def test_pydynox_memory_backend_factory_multiple_tables(pydynox_memory_backend_factory):
+    """Test factory with multiple tables seeded."""
+    seed = {
+        "users": [{"pk": "USER#1", "name": "John", "age": 30}],
+        "orders": [{"pk": "USER#1", "sk": "ORDER#1", "total": 100}],
+    }
+
+    with pydynox_memory_backend_factory(seed=seed):
+        user = User.get(pk="USER#1")
+        assert user is not None
+
+        order = Order.get(pk="USER#1", sk="ORDER#1")
+        assert order is not None
+        assert order.total == 100

--- a/tests/unit/test_memory_backend.py
+++ b/tests/unit/test_memory_backend.py
@@ -1,0 +1,252 @@
+"""Unit tests for MemoryBackend."""
+
+import pytest
+from pydynox import Model, ModelConfig, get_default_client
+from pydynox.attributes import NumberAttribute, StringAttribute
+from pydynox.testing import MemoryBackend
+
+
+class User(Model):
+    """Test model."""
+
+    model_config = ModelConfig(table="users")
+    pk = StringAttribute(hash_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(default=0)
+
+
+def test_memory_backend_context_manager():
+    """Test MemoryBackend as context manager."""
+    with MemoryBackend():
+        user = User(pk="USER#1", name="John")
+        user.save()
+
+        found = User.get(pk="USER#1")
+        assert found is not None
+        assert found.name == "John"
+
+
+def test_memory_backend_decorator():
+    """Test MemoryBackend as decorator."""
+
+    @MemoryBackend()
+    def inner():
+        user = User(pk="USER#1", name="Jane")
+        user.save()
+        return User.get(pk="USER#1")
+
+    result = inner()
+    assert result is not None
+    assert result.name == "Jane"
+
+
+def test_memory_backend_restores_client():
+    """Test that MemoryBackend restores previous client."""
+    original = get_default_client()
+
+    with MemoryBackend():
+        # Inside context, client is MemoryClient
+        pass
+
+    # After context, client is restored
+    assert get_default_client() == original
+
+
+def test_put_and_get():
+    """Test basic put and get operations."""
+    with MemoryBackend():
+        user = User(pk="USER#1", name="Alice", age=30)
+        user.save()
+
+        found = User.get(pk="USER#1")
+        assert found is not None
+        assert found.pk == "USER#1"
+        assert found.name == "Alice"
+        assert found.age == 30
+
+
+def test_get_not_found():
+    """Test get returns None for missing item."""
+    with MemoryBackend():
+        found = User.get(pk="NONEXISTENT")
+        assert found is None
+
+
+def test_delete():
+    """Test delete operation."""
+    with MemoryBackend():
+        user = User(pk="USER#1", name="Bob")
+        user.save()
+
+        # Verify exists
+        assert User.get(pk="USER#1") is not None
+
+        # Delete
+        user.delete()
+
+        # Verify gone
+        assert User.get(pk="USER#1") is None
+
+
+def test_update():
+    """Test update operation."""
+    with MemoryBackend():
+        user = User(pk="USER#1", name="Charlie", age=25)
+        user.save()
+
+        # Update
+        user.update(name="Charles", age=26)
+
+        # Verify
+        found = User.get(pk="USER#1")
+        assert found is not None
+        assert found.name == "Charles"
+        assert found.age == 26
+
+
+def test_atomic_increment():
+    """Test atomic increment operation."""
+    with MemoryBackend():
+        user = User(pk="USER#1", name="Dave", age=0)
+        user.save()
+
+        # Atomic increment
+        user.update(atomic=[User.age.add(5)])
+
+        found = User.get(pk="USER#1")
+        assert found is not None
+        assert found.age == 5
+
+
+def test_scan():
+    """Test scan operation."""
+    with MemoryBackend():
+        User(pk="USER#1", name="Eve").save()
+        User(pk="USER#2", name="Frank").save()
+        User(pk="USER#3", name="Grace").save()
+
+        results = list(User.scan())
+        assert len(results) == 3
+
+
+def test_query():
+    """Test query operation."""
+
+    class Order(Model):
+        model_config = ModelConfig(table="orders")
+        pk = StringAttribute(hash_key=True)
+        sk = StringAttribute(range_key=True)
+        total = NumberAttribute()
+
+    with MemoryBackend():
+        Order(pk="USER#1", sk="ORDER#001", total=100).save()
+        Order(pk="USER#1", sk="ORDER#002", total=200).save()
+        Order(pk="USER#2", sk="ORDER#001", total=50).save()
+
+        results = list(Order.query(hash_key="USER#1"))
+        assert len(results) == 2
+
+
+def test_seed_data():
+    """Test MemoryBackend with seed data."""
+    seed = {
+        "users": [
+            {"pk": "USER#1", "name": "Seeded User", "age": 99},
+        ]
+    }
+
+    with MemoryBackend(seed=seed):
+        found = User.get(pk="USER#1")
+        assert found is not None
+        assert found.name == "Seeded User"
+        assert found.age == 99
+
+
+def test_clear():
+    """Test clearing all data."""
+    with MemoryBackend() as backend:
+        User(pk="USER#1", name="Test").save()
+        assert len(backend.tables.get("users", {})) == 1
+
+        backend.clear()
+        assert len(backend.tables) == 0
+
+
+def test_tables_property():
+    """Test accessing tables for inspection."""
+    with MemoryBackend() as backend:
+        User(pk="USER#1", name="Test").save()
+
+        assert "users" in backend.tables
+        assert len(backend.tables["users"]) == 1
+
+
+def test_condition_attribute_not_exists():
+    """Test condition with attribute_not_exists."""
+    with MemoryBackend():
+        user = User(pk="USER#1", name="Test")
+        user.save(condition=User.pk.does_not_exist())
+
+        # Second save should fail
+        user2 = User(pk="USER#1", name="Test2")
+        with pytest.raises(Exception):  # ConditionCheckFailedError
+            user2.save(condition=User.pk.does_not_exist())
+
+
+def test_multiple_tables():
+    """Test operations on multiple tables."""
+
+    class Product(Model):
+        model_config = ModelConfig(table="products")
+        pk = StringAttribute(hash_key=True)
+        name = StringAttribute()
+
+    with MemoryBackend():
+        User(pk="USER#1", name="User").save()
+        Product(pk="PROD#1", name="Product").save()
+
+        assert User.get(pk="USER#1") is not None
+        assert Product.get(pk="PROD#1") is not None
+
+
+def test_isolation_between_contexts():
+    """Test that data is isolated between contexts."""
+    with MemoryBackend():
+        User(pk="USER#1", name="First").save()
+
+    with MemoryBackend():
+        # Should not find user from previous context
+        assert User.get(pk="USER#1") is None
+
+
+def test_table_exists():
+    """Test table_exists method."""
+    with MemoryBackend() as backend:
+        # Table doesn't exist yet
+        assert not backend._client.table_exists("users")
+
+        # After save, table exists
+        User(pk="USER#1", name="Test").save()
+        assert backend._client.table_exists("users")
+
+
+def test_delete_by_key():
+    """Test delete_by_key operation."""
+    with MemoryBackend():
+        User(pk="USER#1", name="Test").save()
+        assert User.get(pk="USER#1") is not None
+
+        User.delete_by_key(pk="USER#1")
+        assert User.get(pk="USER#1") is None
+
+
+def test_update_by_key():
+    """Test update_by_key operation."""
+    with MemoryBackend():
+        User(pk="USER#1", name="Original", age=20).save()
+
+        User.update_by_key(pk="USER#1", name="Updated")
+
+        found = User.get(pk="USER#1")
+        assert found is not None
+        assert found.name == "Updated"

--- a/zensical.toml
+++ b/zensical.toml
@@ -42,6 +42,9 @@ nav = [
         "guides/pydantic.md",
         "guides/dataclass.md",
     ] },
+    { "Testing" = [
+        "guides/testing.md",
+    ] },
     { "Diagnostics" = [
         "guides/diagnostics/hot-partition.md",
     ] },


### PR DESCRIPTION
closes #114

This PR add built-in in-memory backend for testing pydynox code without DynamoDB. No extra dependencies needed. No imports, no conftest.py, no setup. Just add the fixture.

- `pydynox_memory_backend` - Empty database per test
- `pydynox_memory_backend_factory` - Custom seed data
- `pydynox_memory_backend_seeded` - Shared seed data via `pydynox_seed` fixture

## Usage

```python
def test_create_user(pydynox_memory_backend):
    user = User(pk="USER#1", name="John")
    user.save()
    assert User.get(pk="USER#1") is not None
```

