### PR TITLE
feat: return existing item on ConditionalCheckFailedException

### DIFF
--- a/docs/examples/exceptions/return_item_on_failure.py
+++ b/docs/examples/exceptions/return_item_on_failure.py
@@ -1,0 +1,41 @@
+from pydynox import DynamoDBClient
+from pydynox.pydynox_core import ConditionalCheckFailedException
+
+
+def optimistic_lock_with_item_return():
+    """Update with version check, get existing item on failure."""
+    client = DynamoDBClient()
+
+    # Try to update with version check
+    try:
+        client.update_item(
+            "users",
+            {"pk": "USER#123"},
+            updates={"name": "Alice", "version": 2},
+            condition_expression="#v = :expected",
+            expression_attribute_names={"#v": "version"},
+            expression_attribute_values={":expected": 1},
+            return_values_on_condition_check_failure=True,
+        )
+        print("Updated successfully")
+    except ConditionalCheckFailedException as e:
+        # No extra GET needed - item is on the exception
+        print(f"Version conflict! Current item: {e.item}")
+        print(f"Current version: {e.item['version']}")
+
+
+def prevent_overwrite_with_item_return():
+    """Create new item, get existing on conflict."""
+    client = DynamoDBClient()
+
+    try:
+        client.put_item(
+            "users",
+            {"pk": "USER#123", "name": "Bob", "email": "bob@example.com"},
+            condition_expression="attribute_not_exists(pk)",
+            return_values_on_condition_check_failure=True,
+        )
+        print("Created new user")
+    except ConditionalCheckFailedException as e:
+        # See what's already there without extra GET
+        print(f"User already exists: {e.item['name']}")

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -157,14 +157,23 @@ Most of the time you'll use Models instead of these methods directly. But they'r
 |--------|-------------|
 | `ping()` | Check if the client can connect to DynamoDB. Returns `True` or `False`. |
 | `get_region()` | Get the AWS region this client is configured for. |
-| `put_item(table, item)` | Save an item to a table. Overwrites if the key exists. |
+| `put_item(table, item, ...)` | Save an item to a table. Overwrites if the key exists. |
 | `get_item(table, key)` | Get a single item by its primary key. Returns `None` if not found. |
-| `delete_item(table, key)` | Delete an item by its primary key. |
-| `update_item(table, key, updates)` | Update specific attributes without replacing the whole item. |
+| `delete_item(table, key, ...)` | Delete an item by its primary key. |
+| `update_item(table, key, updates, ...)` | Update specific attributes without replacing the whole item. |
 | `query(table, key_condition, ...)` | Find items by partition key. Supports filtering and pagination. |
 | `batch_write(table, put_items, delete_keys)` | Write up to 25 items in one request. Faster than individual puts. |
 | `batch_get(table, keys)` | Get up to 100 items in one request. Faster than individual gets. |
 | `transact_write(operations)` | Write multiple items atomically. All succeed or all fail. |
+
+Write methods (`put_item`, `update_item`, `delete_item`) support these optional parameters:
+
+| Parameter | Description |
+|-----------|-------------|
+| `condition_expression` | Condition that must be true for the write to succeed |
+| `expression_attribute_names` | Placeholders for reserved words |
+| `expression_attribute_values` | Placeholders for values |
+| `return_values_on_condition_check_failure` | If `True`, get the existing item on `ConditionalCheckFailedException` |
 
 ### Async methods
 

--- a/docs/guides/conditions.md
+++ b/docs/guides/conditions.md
@@ -144,6 +144,24 @@ except ConditionalCheckFailedException:
     print("User already exists")
 ```
 
+### Get the existing item on failure
+
+Use `return_values_on_condition_check_failure=True` to get the existing item without an extra GET call:
+
+```python
+try:
+    client.put_item(
+        "users",
+        {"pk": "USER#123", "name": "Bob"},
+        condition_expression="attribute_not_exists(pk)",
+        return_values_on_condition_check_failure=True,
+    )
+except ConditionalCheckFailedException as e:
+    print(f"User already exists: {e.item}")
+```
+
+This works with `put_item`, `update_item`, and `delete_item`.
+
 ## Type hints
 
 Use `Condition` for type hints:

--- a/docs/guides/exceptions.md
+++ b/docs/guides/exceptions.md
@@ -48,6 +48,17 @@ When using conditional writes, catch `ConditionalCheckFailedException`:
     --8<-- "docs/examples/exceptions/condition_check.py"
     ```
 
+### Get the item that caused the failure
+
+When a condition fails, you often need to see what's in DynamoDB. Instead of making an extra GET call, use `return_values_on_condition_check_failure=True`. The existing item is attached to the exception:
+
+=== "return_item_on_failure.py"
+    ```python
+    --8<-- "docs/examples/exceptions/return_item_on_failure.py"
+    ```
+
+This works with `put_item`, `update_item`, and `delete_item`. The `item` attribute is `None` if you don't set the flag.
+
 ## Advanced
 
 ### Connection errors

--- a/python/pydynox/client/_crud.py
+++ b/python/pydynox/client/_crud.py
@@ -80,8 +80,28 @@ class CrudOperations:
         condition_expression: str | None = None,
         expression_attribute_names: dict[str, str] | None = None,
         expression_attribute_values: dict[str, Any] | None = None,
+        return_values_on_condition_check_failure: bool = False,
     ) -> OperationMetrics:
-        """Put an item into a DynamoDB table."""
+        """Put an item into a DynamoDB table.
+
+        Args:
+            table: Table name.
+            item: Item to put.
+            condition_expression: Condition that must be true for the write.
+            expression_attribute_names: Attribute name placeholders.
+            expression_attribute_values: Attribute value placeholders.
+            return_values_on_condition_check_failure: If True and condition fails,
+                the ConditionalCheckFailedException will have an 'item' attribute
+                with the existing item. Saves an extra GET call.
+
+        Returns:
+            Operation metrics.
+
+        Raises:
+            ConditionalCheckFailedException: If condition fails. When
+                return_values_on_condition_check_failure=True, the exception
+                has an 'item' attribute with the existing item.
+        """
         self._acquire_wcu(1.0)  # type: ignore[attr-defined]
         pk = _extract_pk(item)
         if pk:
@@ -94,6 +114,7 @@ class CrudOperations:
                 condition_expression=condition_expression,
                 expression_attribute_names=expression_attribute_names,
                 expression_attribute_values=expression_attribute_values,
+                return_values_on_condition_check_failure=return_values_on_condition_check_failure,
             )
             add_response_attributes(
                 span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
@@ -112,8 +133,22 @@ class CrudOperations:
         condition_expression: str | None = None,
         expression_attribute_names: dict[str, str] | None = None,
         expression_attribute_values: dict[str, Any] | None = None,
+        return_values_on_condition_check_failure: bool = False,
     ) -> OperationMetrics:
-        """Async version of put_item."""
+        """Async version of put_item.
+
+        Args:
+            table: Table name.
+            item: Item to put.
+            condition_expression: Condition that must be true for the write.
+            expression_attribute_names: Attribute name placeholders.
+            expression_attribute_values: Attribute value placeholders.
+            return_values_on_condition_check_failure: If True and condition fails,
+                the ConditionalCheckFailedException will have an 'item' attribute.
+
+        Returns:
+            Operation metrics.
+        """
         self._acquire_wcu(1.0)  # type: ignore[attr-defined]
         pk = _extract_pk(item)
         if pk:
@@ -126,6 +161,7 @@ class CrudOperations:
                 condition_expression=condition_expression,
                 expression_attribute_names=expression_attribute_names,
                 expression_attribute_values=expression_attribute_values,
+                return_values_on_condition_check_failure=return_values_on_condition_check_failure,
             )
             add_response_attributes(
                 span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
@@ -241,8 +277,22 @@ class CrudOperations:
         condition_expression: str | None = None,
         expression_attribute_names: dict[str, str] | None = None,
         expression_attribute_values: dict[str, Any] | None = None,
+        return_values_on_condition_check_failure: bool = False,
     ) -> OperationMetrics:
-        """Delete an item from a DynamoDB table."""
+        """Delete an item from a DynamoDB table.
+
+        Args:
+            table: Table name.
+            key: Key attributes.
+            condition_expression: Condition that must be true for the delete.
+            expression_attribute_names: Attribute name placeholders.
+            expression_attribute_values: Attribute value placeholders.
+            return_values_on_condition_check_failure: If True and condition fails,
+                the ConditionalCheckFailedException will have an 'item' attribute.
+
+        Returns:
+            Operation metrics.
+        """
         self._acquire_wcu(1.0)  # type: ignore[attr-defined]
         pk = _extract_pk(key)
         if pk:
@@ -255,6 +305,7 @@ class CrudOperations:
                 condition_expression=condition_expression,
                 expression_attribute_names=expression_attribute_names,
                 expression_attribute_values=expression_attribute_values,
+                return_values_on_condition_check_failure=return_values_on_condition_check_failure,
             )
             add_response_attributes(
                 span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
@@ -273,8 +324,22 @@ class CrudOperations:
         condition_expression: str | None = None,
         expression_attribute_names: dict[str, str] | None = None,
         expression_attribute_values: dict[str, Any] | None = None,
+        return_values_on_condition_check_failure: bool = False,
     ) -> OperationMetrics:
-        """Async version of delete_item."""
+        """Async version of delete_item.
+
+        Args:
+            table: Table name.
+            key: Key attributes.
+            condition_expression: Condition that must be true for the delete.
+            expression_attribute_names: Attribute name placeholders.
+            expression_attribute_values: Attribute value placeholders.
+            return_values_on_condition_check_failure: If True and condition fails,
+                the ConditionalCheckFailedException will have an 'item' attribute.
+
+        Returns:
+            Operation metrics.
+        """
         self._acquire_wcu(1.0)  # type: ignore[attr-defined]
         pk = _extract_pk(key)
         if pk:
@@ -287,6 +352,7 @@ class CrudOperations:
                 condition_expression=condition_expression,
                 expression_attribute_names=expression_attribute_names,
                 expression_attribute_values=expression_attribute_values,
+                return_values_on_condition_check_failure=return_values_on_condition_check_failure,
             )
             add_response_attributes(
                 span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
@@ -309,8 +375,24 @@ class CrudOperations:
         condition_expression: str | None = None,
         expression_attribute_names: dict[str, str] | None = None,
         expression_attribute_values: dict[str, Any] | None = None,
+        return_values_on_condition_check_failure: bool = False,
     ) -> OperationMetrics:
-        """Update an item in a DynamoDB table."""
+        """Update an item in a DynamoDB table.
+
+        Args:
+            table: Table name.
+            key: Key attributes.
+            updates: Dict of field:value pairs to update (simple mode).
+            update_expression: Raw update expression (advanced mode).
+            condition_expression: Condition that must be true for the update.
+            expression_attribute_names: Attribute name placeholders.
+            expression_attribute_values: Attribute value placeholders.
+            return_values_on_condition_check_failure: If True and condition fails,
+                the ConditionalCheckFailedException will have an 'item' attribute.
+
+        Returns:
+            Operation metrics.
+        """
         self._acquire_wcu(1.0)  # type: ignore[attr-defined]
         pk = _extract_pk(key)
         if pk:
@@ -325,6 +407,7 @@ class CrudOperations:
                 condition_expression=condition_expression,
                 expression_attribute_names=expression_attribute_names,
                 expression_attribute_values=expression_attribute_values,
+                return_values_on_condition_check_failure=return_values_on_condition_check_failure,
             )
             add_response_attributes(
                 span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
@@ -345,8 +428,24 @@ class CrudOperations:
         condition_expression: str | None = None,
         expression_attribute_names: dict[str, str] | None = None,
         expression_attribute_values: dict[str, Any] | None = None,
+        return_values_on_condition_check_failure: bool = False,
     ) -> OperationMetrics:
-        """Async version of update_item."""
+        """Async version of update_item.
+
+        Args:
+            table: Table name.
+            key: Key attributes.
+            updates: Dict of field:value pairs to update (simple mode).
+            update_expression: Raw update expression (advanced mode).
+            condition_expression: Condition that must be true for the update.
+            expression_attribute_names: Attribute name placeholders.
+            expression_attribute_values: Attribute value placeholders.
+            return_values_on_condition_check_failure: If True and condition fails,
+                the ConditionalCheckFailedException will have an 'item' attribute.
+
+        Returns:
+            Operation metrics.
+        """
         self._acquire_wcu(1.0)  # type: ignore[attr-defined]
         pk = _extract_pk(key)
         if pk:
@@ -361,6 +460,7 @@ class CrudOperations:
                 condition_expression=condition_expression,
                 expression_attribute_names=expression_attribute_names,
                 expression_attribute_values=expression_attribute_values,
+                return_values_on_condition_check_failure=return_values_on_condition_check_failure,
             )
             add_response_attributes(
                 span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id

--- a/src/client.rs
+++ b/src/client.rs
@@ -234,7 +234,8 @@ impl DynamoDBClient {
         }
     }
     /// Put an item into a DynamoDB table.
-    #[pyo3(signature = (table, item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None))]
+    #[pyo3(signature = (table, item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
+    #[allow(clippy::too_many_arguments)]
     pub fn put_item(
         &self,
         py: Python<'_>,
@@ -243,6 +244,7 @@ impl DynamoDBClient {
         condition_expression: Option<String>,
         expression_attribute_names: Option<&Bound<'_, PyDict>>,
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
     ) -> PyResult<OperationMetrics> {
         basic_operations::put_item(
             py,
@@ -253,6 +255,7 @@ impl DynamoDBClient {
             condition_expression,
             expression_attribute_names,
             expression_attribute_values,
+            return_values_on_condition_check_failure,
         )
     }
 
@@ -292,7 +295,8 @@ impl DynamoDBClient {
     }
 
     /// Delete an item from a DynamoDB table.
-    #[pyo3(signature = (table, key, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None))]
+    #[pyo3(signature = (table, key, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
+    #[allow(clippy::too_many_arguments)]
     pub fn delete_item(
         &self,
         py: Python<'_>,
@@ -301,6 +305,7 @@ impl DynamoDBClient {
         condition_expression: Option<String>,
         expression_attribute_names: Option<&Bound<'_, PyDict>>,
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
     ) -> PyResult<OperationMetrics> {
         basic_operations::delete_item(
             py,
@@ -311,11 +316,12 @@ impl DynamoDBClient {
             condition_expression,
             expression_attribute_names,
             expression_attribute_values,
+            return_values_on_condition_check_failure,
         )
     }
 
     /// Update an item in a DynamoDB table.
-    #[pyo3(signature = (table, key, updates=None, update_expression=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None))]
+    #[pyo3(signature = (table, key, updates=None, update_expression=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
     #[allow(clippy::too_many_arguments)]
     pub fn update_item(
         &self,
@@ -327,6 +333,7 @@ impl DynamoDBClient {
         condition_expression: Option<String>,
         expression_attribute_names: Option<&Bound<'_, PyDict>>,
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
     ) -> PyResult<OperationMetrics> {
         basic_operations::update_item(
             py,
@@ -339,6 +346,7 @@ impl DynamoDBClient {
             condition_expression,
             expression_attribute_names,
             expression_attribute_values,
+            return_values_on_condition_check_failure,
         )
     }
 
@@ -613,7 +621,8 @@ impl DynamoDBClient {
     }
 
     /// Async version of put_item.
-    #[pyo3(signature = (table, item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None))]
+    #[pyo3(signature = (table, item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
+    #[allow(clippy::too_many_arguments)]
     pub fn async_put_item<'py>(
         &self,
         py: Python<'py>,
@@ -622,6 +631,7 @@ impl DynamoDBClient {
         condition_expression: Option<String>,
         expression_attribute_names: Option<&Bound<'_, PyDict>>,
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         basic_operations::async_put_item(
             py,
@@ -631,11 +641,13 @@ impl DynamoDBClient {
             condition_expression,
             expression_attribute_names,
             expression_attribute_values,
+            return_values_on_condition_check_failure,
         )
     }
 
     /// Async version of delete_item.
-    #[pyo3(signature = (table, key, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None))]
+    #[pyo3(signature = (table, key, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
+    #[allow(clippy::too_many_arguments)]
     pub fn async_delete_item<'py>(
         &self,
         py: Python<'py>,
@@ -644,6 +656,7 @@ impl DynamoDBClient {
         condition_expression: Option<String>,
         expression_attribute_names: Option<&Bound<'_, PyDict>>,
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         basic_operations::async_delete_item(
             py,
@@ -653,11 +666,12 @@ impl DynamoDBClient {
             condition_expression,
             expression_attribute_names,
             expression_attribute_values,
+            return_values_on_condition_check_failure,
         )
     }
 
     /// Async version of update_item.
-    #[pyo3(signature = (table, key, updates=None, update_expression=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None))]
+    #[pyo3(signature = (table, key, updates=None, update_expression=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
     #[allow(clippy::too_many_arguments)]
     pub fn async_update_item<'py>(
         &self,
@@ -669,6 +683,7 @@ impl DynamoDBClient {
         condition_expression: Option<String>,
         expression_attribute_names: Option<&Bound<'_, PyDict>>,
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         basic_operations::async_update_item(
             py,
@@ -680,6 +695,7 @@ impl DynamoDBClient {
             condition_expression,
             expression_attribute_names,
             expression_attribute_values,
+            return_values_on_condition_check_failure,
         )
     }
 

--- a/tests/integration/operations/test_condition_check_failed.py
+++ b/tests/integration/operations/test_condition_check_failed.py
@@ -1,0 +1,148 @@
+"""Tests for ConditionalCheckFailedException with item return.
+
+When a conditional write fails, DynamoDB can return the existing item
+via ReturnValuesOnConditionCheckFailure. This avoids an extra GET call.
+"""
+
+import uuid
+
+import pytest
+from pydynox.exceptions import ConditionalCheckFailedException
+
+
+def test_put_item_condition_failed_returns_item(dynamo):
+    """put_item with condition failure returns the existing item."""
+    pk = f"test-{uuid.uuid4()}"
+    sk = "profile"
+
+    # Create initial item
+    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "version": 1})
+
+    # Try to put with condition that fails
+    with pytest.raises(ConditionalCheckFailedException) as exc_info:
+        dynamo.put_item(
+            "test_table",
+            {"pk": pk, "sk": sk, "name": "Bob", "version": 2},
+            condition_expression="attribute_not_exists(pk)",
+            return_values_on_condition_check_failure=True,
+        )
+
+    # Check that the exception has the item
+    exc = exc_info.value
+    assert hasattr(exc, "item"), "Exception should have 'item' attribute"
+    assert exc.item is not None, "item should not be None"
+    assert exc.item["pk"] == pk
+    assert exc.item["sk"] == sk
+    assert exc.item["name"] == "Alice"
+    assert exc.item["version"] == 1
+
+
+def test_put_item_condition_failed_no_item_by_default(dynamo):
+    """put_item without return flag does not return item."""
+    pk = f"test-{uuid.uuid4()}"
+    sk = "profile"
+
+    # Create initial item
+    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice"})
+
+    # Try to put with condition that fails (no return flag)
+    with pytest.raises(ConditionalCheckFailedException) as exc_info:
+        dynamo.put_item(
+            "test_table",
+            {"pk": pk, "sk": sk, "name": "Bob"},
+            condition_expression="attribute_not_exists(pk)",
+        )
+
+    # item attribute should be None or not set
+    exc = exc_info.value
+    item = getattr(exc, "item", None)
+    assert item is None, "item should be None when return flag is not set"
+
+
+def test_update_item_condition_failed_returns_item(dynamo):
+    """update_item with condition failure returns the existing item."""
+    pk = f"test-{uuid.uuid4()}"
+    sk = "profile"
+
+    # Create initial item
+    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "version": 1})
+
+    # Try to update with condition that fails
+    with pytest.raises(ConditionalCheckFailedException) as exc_info:
+        dynamo.update_item(
+            "test_table",
+            {"pk": pk, "sk": sk},
+            updates={"name": "Bob"},
+            condition_expression="#v = :expected",
+            expression_attribute_names={"#v": "version"},
+            expression_attribute_values={":expected": 999},
+            return_values_on_condition_check_failure=True,
+        )
+
+    exc = exc_info.value
+    assert hasattr(exc, "item"), "Exception should have 'item' attribute"
+    assert exc.item is not None
+    assert exc.item["pk"] == pk
+    assert exc.item["version"] == 1
+
+
+def test_delete_item_condition_failed_returns_item(dynamo):
+    """delete_item with condition failure returns the existing item."""
+    pk = f"test-{uuid.uuid4()}"
+    sk = "profile"
+
+    # Create initial item
+    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "status": "active"})
+
+    # Try to delete with condition that fails
+    with pytest.raises(ConditionalCheckFailedException) as exc_info:
+        dynamo.delete_item(
+            "test_table",
+            {"pk": pk, "sk": sk},
+            condition_expression="#s = :expected",
+            expression_attribute_names={"#s": "status"},
+            expression_attribute_values={":expected": "deleted"},
+            return_values_on_condition_check_failure=True,
+        )
+
+    exc = exc_info.value
+    assert hasattr(exc, "item"), "Exception should have 'item' attribute"
+    assert exc.item is not None
+    assert exc.item["pk"] == pk
+    assert exc.item["status"] == "active"
+
+
+def test_optimistic_locking_pattern(dynamo):
+    """Real-world pattern: optimistic locking with version check."""
+    pk = f"test-{uuid.uuid4()}"
+    sk = "counter"
+
+    # Create item with version
+    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "count": 0, "version": 1})
+
+    # Simulate concurrent update - first one succeeds
+    dynamo.update_item(
+        "test_table",
+        {"pk": pk, "sk": sk},
+        updates={"count": 1, "version": 2},
+        condition_expression="#v = :expected",
+        expression_attribute_names={"#v": "version"},
+        expression_attribute_values={":expected": 1},
+    )
+
+    # Second update with stale version fails
+    with pytest.raises(ConditionalCheckFailedException) as exc_info:
+        dynamo.update_item(
+            "test_table",
+            {"pk": pk, "sk": sk},
+            updates={"count": 100, "version": 2},
+            condition_expression="#v = :expected",
+            expression_attribute_names={"#v": "version"},
+            expression_attribute_values={":expected": 1},
+            return_values_on_condition_check_failure=True,
+        )
+
+    # Can see current state without extra GET
+    exc = exc_info.value
+    assert exc.item["version"] == 2, "Should see updated version"
+    assert exc.item["count"] == 1, "Should see updated count"


### PR DESCRIPTION
Closes #129

Optimistic locking is a common pattern. When a version check fails, you want to know the current state. Making an extra GET call is wasteful - DynamoDB already has the item and can return it in the error response.

This saves one round trip per conflict, which adds up in high-concurrency scenarios.

## Usage

```python
try:
    client.update_item(
        "users",
        {"pk": "USER#123"},
        updates={"name": "Alice", "version": 2},
        condition_expression="#v = :expected",
        expression_attribute_names={"#v": "version"},
        expression_attribute_values={":expected": 1},
        return_values_on_condition_check_failure=True,  # new!
    )
except ConditionalCheckFailedException as e:
    print(f"Current version: {e.item['version']}")  # no extra GET needed
```