### PR TITLE
feat: add batch_get and async batch operations

### DIFF
--- a/docs/examples/batch/async_batch.py
+++ b/docs/examples/batch/async_batch.py
@@ -1,0 +1,44 @@
+from pydynox import AsyncBatchWriter, DynamoDBClient, Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+client = DynamoDBClient()
+
+
+class User(Model):
+    model_config = ModelConfig(table="users", client=client)
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    name = StringAttribute()
+    age = NumberAttribute()
+
+
+async def main():
+    # Async batch write with context manager
+    async with AsyncBatchWriter(client, "users") as batch:
+        for i in range(100):
+            batch.put({"pk": f"USER#{i}", "sk": "PROFILE", "name": f"User {i}"})
+
+    # Mix puts and deletes
+    async with AsyncBatchWriter(client, "users") as batch:
+        batch.put({"pk": "USER#1", "sk": "PROFILE", "name": "John"})
+        batch.put({"pk": "USER#2", "sk": "PROFILE", "name": "Jane"})
+        batch.delete({"pk": "USER#3", "sk": "PROFILE"})
+
+    # Async batch get - client level
+    keys = [
+        {"pk": "USER#1", "sk": "PROFILE"},
+        {"pk": "USER#2", "sk": "PROFILE"},
+    ]
+    items = await client.async_batch_get("users", keys)
+    for item in items:
+        print(item["name"])
+
+    # Async batch get - model level
+    users = await User.async_batch_get(keys)
+    for user in users:
+        print(user.name, user.age)
+
+    # Return as dicts for better performance
+    users_dict = await User.async_batch_get(keys, as_dict=True)
+    for user in users_dict:
+        print(user["name"])

--- a/docs/examples/batch/batch_get.py
+++ b/docs/examples/batch/batch_get.py
@@ -1,0 +1,33 @@
+from pydynox import DynamoDBClient, Model, ModelConfig
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+client = DynamoDBClient()
+
+
+class User(Model):
+    model_config = ModelConfig(table="users", client=client)
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    name = StringAttribute()
+    age = NumberAttribute()
+
+
+# Client-level batch get
+keys = [
+    {"pk": "USER#1", "sk": "PROFILE"},
+    {"pk": "USER#2", "sk": "PROFILE"},
+    {"pk": "USER#3", "sk": "PROFILE"},
+]
+items = client.batch_get("users", keys)
+for item in items:
+    print(item["name"])
+
+# Model-level batch get - returns typed instances
+users = User.batch_get(keys)
+for user in users:
+    print(user.name, user.age)
+
+# Return as dicts for better performance
+users_dict = User.batch_get(keys, as_dict=True)
+for user in users_dict:
+    print(user["name"])

--- a/docs/guides/async.md
+++ b/docs/guides/async.md
@@ -82,6 +82,9 @@ Fetch user and their orders at the same time:
 | `model.save()` | `model.async_save()` |
 | `model.delete()` | `model.async_delete()` |
 | `model.update()` | `model.async_update()` |
+| `Model.batch_get()` | `Model.async_batch_get()` |
+| `Model.query()` | `Model.async_query()` |
+| `Model.scan()` | `Model.async_scan()` |
 
 ### DynamoDBClient
 
@@ -92,6 +95,14 @@ Fetch user and their orders at the same time:
 | `delete_item()` | `async_delete_item()` |
 | `update_item()` | `async_update_item()` |
 | `query()` | `async_query()` |
+| `batch_get()` | `async_batch_get()` |
+| `batch_write()` | `async_batch_write()` |
+
+### Batch operations
+
+| Sync | Async |
+|------|-------|
+| `BatchWriter` | `AsyncBatchWriter` |
 
 ## Notes
 

--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from pydynox import pydynox_core  # noqa: F401
 from pydynox._internal._logging import set_correlation_id, set_logger
 from pydynox._internal._tracing import disable_tracing, enable_tracing
-from pydynox.batch_operations import BatchWriter
+from pydynox.batch_operations import AsyncBatchWriter, BatchWriter
 from pydynox.client import DynamoDBClient
 from pydynox.conditions import Condition
 from pydynox.config import (
@@ -44,6 +44,7 @@ __all__ = [
     "Model",
     "ModelConfig",
     # Operations
+    "AsyncBatchWriter",
     "AsyncTransaction",
     "BatchWriter",
     "Condition",

--- a/python/pydynox/_internal/_model/_batch.py
+++ b/python/pydynox/_internal/_model/_batch.py
@@ -53,3 +53,46 @@ def batch_get(
             instance._run_hooks(HookType.AFTER_LOAD)
 
     return instances
+
+
+async def async_batch_get(
+    cls: type[M],
+    keys: list[dict[str, Any]],
+    consistent_read: bool | None = None,
+    as_dict: bool = False,
+) -> list[M] | list[dict[str, Any]]:
+    """Async batch get items by keys.
+
+    Args:
+        keys: List of key dicts (each with hash_key and optional range_key).
+        consistent_read: If True, use strongly consistent read.
+        as_dict: If True, return dicts instead of Model instances.
+
+    Returns:
+        List of model instances or dicts.
+    """
+    if not keys:
+        return []
+
+    client = cls._get_client()
+    table = cls._get_table()
+
+    # consistent_read is not yet supported by client.async_batch_get
+    # but we keep the parameter for future compatibility
+    _ = consistent_read
+
+    # Call client async_batch_get
+    items = await client.async_batch_get(table, keys)
+
+    if as_dict:
+        return items
+
+    # Convert to model instances
+    instances = [cls.from_dict(item) for item in items]
+
+    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
+    if not skip:
+        for instance in instances:
+            instance._run_hooks(HookType.AFTER_LOAD)
+
+    return instances

--- a/python/pydynox/batch_operations.py
+++ b/python/pydynox/batch_operations.py
@@ -79,3 +79,76 @@ class BatchWriter:
         # Clear the lists after successful write
         self._put_items = []
         self._delete_keys = []
+
+
+class AsyncBatchWriter:
+    """Async context manager for batch write operations.
+
+    Collects put and delete operations, then sends them all at once
+    when the context exits. Handles splitting into batches of 25 items
+    and retrying unprocessed items.
+
+    Example:
+        >>> async with AsyncBatchWriter(client, "users") as batch:
+        ...     batch.put({"pk": "USER#1", "sk": "PROFILE", "name": "Alice"})
+        ...     batch.put({"pk": "USER#2", "sk": "PROFILE", "name": "Bob"})
+        ...     batch.delete({"pk": "USER#3", "sk": "PROFILE"})
+    """
+
+    def __init__(self, client: DynamoDBClient, table: str):
+        """Create an AsyncBatchWriter.
+
+        Args:
+            client: The DynamoDBClient to use.
+            table: The table name.
+        """
+        self._client = client
+        self._table = table
+        self._put_items: list[dict[str, Any]] = []
+        self._delete_keys: list[dict[str, Any]] = []
+
+    async def __aenter__(self) -> AsyncBatchWriter:
+        """Enter the async context manager."""
+        return self
+
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
+        """Exit the async context manager and send all operations."""
+        if exc_type is None:
+            await self.flush()
+
+    def put(self, item: dict[str, Any]) -> None:
+        """Add an item to be put.
+
+        Args:
+            item: The item to put (as a dict).
+        """
+        self._put_items.append(item)
+
+    def delete(self, key: dict[str, Any]) -> None:
+        """Add a key to be deleted.
+
+        Args:
+            key: The key to delete (as a dict with pk and optional sk).
+        """
+        self._delete_keys.append(key)
+
+    async def flush(self) -> None:
+        """Send all collected operations to DynamoDB.
+
+        Called automatically when exiting the async context manager.
+        Can also be called manually to send operations early.
+        """
+        if not self._put_items and not self._delete_keys:
+            return
+
+        await self._client.async_batch_write(
+            self._table,
+            put_items=self._put_items,
+            delete_keys=self._delete_keys,
+        )
+
+        # Clear the lists after successful write
+        self._put_items = []
+        self._delete_keys = []

--- a/python/pydynox/client/_batch.py
+++ b/python/pydynox/client/_batch.py
@@ -106,3 +106,39 @@ class BatchOperations:
             List of items (or None for items that don't exist).
         """
         return await self._client.async_transact_get(gets)  # type: ignore[attr-defined, no-any-return]
+
+    # ========== ASYNC BATCH WRITE ==========
+
+    async def async_batch_write(
+        self,
+        table: str,
+        put_items: list[dict[str, Any]] | None = None,
+        delete_keys: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Async batch write items to a DynamoDB table.
+
+        Writes multiple items in a single request. Handles:
+        - Splitting requests to respect the 25-item limit per batch
+        - Retrying unprocessed items with exponential backoff
+        """
+        await self._client.async_batch_write(  # type: ignore[attr-defined]
+            table,
+            put_items or [],
+            delete_keys or [],
+        )
+
+    # ========== ASYNC BATCH GET ==========
+
+    async def async_batch_get(
+        self,
+        table: str,
+        keys: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Async batch get items from a DynamoDB table.
+
+        Gets multiple items in a single request. Handles:
+        - Splitting requests to respect the 100-item limit per batch
+        - Retrying unprocessed keys with exponential backoff
+        - Combining results from multiple requests
+        """
+        return await self._client.async_batch_get(table, keys)  # type: ignore[attr-defined, no-any-return]

--- a/python/pydynox/model.py
+++ b/python/pydynox/model.py
@@ -14,7 +14,7 @@ from pydynox._internal._model._async import (
     async_update_by_key,
 )
 from pydynox._internal._model._base import ModelBase, ModelMeta
-from pydynox._internal._model._batch import batch_get
+from pydynox._internal._model._batch import async_batch_get, batch_get
 from pydynox._internal._model._crud import (
     delete,
     delete_by_key,
@@ -243,6 +243,34 @@ class Model(ModelBase, metaclass=ModelMeta):
             >>> users = User.batch_get(keys, as_dict=True)
         """
         return batch_get(cls, keys, consistent_read, as_dict)
+
+    @classmethod
+    async def async_batch_get(
+        cls: type[M],
+        keys: list[dict[str, Any]],
+        consistent_read: bool | None = None,
+        as_dict: bool = False,
+    ) -> list[M] | list[dict[str, Any]]:
+        """Async batch get multiple items by their keys.
+
+        Args:
+            keys: List of key dicts (each with hash_key and optional range_key).
+            consistent_read: Use strongly consistent read.
+            as_dict: If True, return dicts instead of Model instances.
+
+        Returns:
+            List of model instances or dicts.
+
+        Example:
+            >>> keys = [
+            ...     {"pk": "USER#1", "sk": "PROFILE"},
+            ...     {"pk": "USER#2", "sk": "PROFILE"},
+            ... ]
+            >>> users = await User.async_batch_get(keys)
+            >>> for user in users:
+            ...     print(user.name)
+        """
+        return await async_batch_get(cls, keys, consistent_read, as_dict)
 
     # ========== ASYNC CRUD ==========
 

--- a/src/batch_operations/get.rs
+++ b/src/batch_operations/get.rs
@@ -1,0 +1,275 @@
+//! Batch get operations for DynamoDB.
+
+use aws_sdk_dynamodb::types::{AttributeValue, KeysAndAttributes};
+use aws_sdk_dynamodb::Client;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+use crate::conversions::{attribute_values_to_py_dict, py_dict_to_attribute_values};
+use crate::errors::map_sdk_error;
+
+/// Maximum items per batch get request (DynamoDB limit).
+const BATCH_GET_MAX_ITEMS: usize = 100;
+
+/// Maximum retry attempts for unprocessed items.
+const BATCH_MAX_RETRIES: usize = 5;
+
+/// Batch get items from a DynamoDB table.
+///
+/// Handles:
+/// - Splitting requests to respect the 100-item limit
+/// - Retrying unprocessed keys with exponential backoff
+/// - Combining results from multiple requests
+///
+/// # Arguments
+///
+/// * `py` - Python interpreter reference
+/// * `client` - DynamoDB client
+/// * `runtime` - Tokio runtime
+/// * `table` - Table name
+/// * `keys` - List of keys to get (as Python dicts)
+///
+/// # Returns
+///
+/// A list of items (as Python dicts) that were found.
+pub fn batch_get(
+    py: Python<'_>,
+    client: &Client,
+    runtime: &Arc<Runtime>,
+    table: &str,
+    keys: &Bound<'_, PyList>,
+) -> PyResult<Vec<Py<PyAny>>> {
+    let mut all_keys: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    for key in keys.iter() {
+        let key_dict = key.cast::<PyDict>()?;
+        let dynamo_key = py_dict_to_attribute_values(py, key_dict)?;
+        all_keys.push(dynamo_key);
+    }
+
+    if all_keys.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let table_name = table.to_string();
+    let client = client.clone();
+    let mut all_results: Vec<Py<PyAny>> = Vec::new();
+
+    for chunk in all_keys.chunks(BATCH_GET_MAX_ITEMS) {
+        let mut pending: Vec<HashMap<String, AttributeValue>> = chunk.to_vec();
+        let mut retries = 0;
+
+        while !pending.is_empty() && retries < BATCH_MAX_RETRIES {
+            let keys_and_attrs = KeysAndAttributes::builder()
+                .set_keys(Some(pending.clone()))
+                .build()
+                .map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                        "Failed to build keys and attributes: {}",
+                        e
+                    ))
+                })?;
+
+            let mut request_items = HashMap::new();
+            request_items.insert(table_name.clone(), keys_and_attrs);
+
+            let result = runtime.block_on(async {
+                client
+                    .batch_get_item()
+                    .set_request_items(Some(request_items))
+                    .send()
+                    .await
+            });
+
+            match result {
+                Ok(output) => {
+                    if let Some(responses) = output.responses {
+                        if let Some(items) = responses.get(&table_name) {
+                            for item in items {
+                                let py_item = attribute_values_to_py_dict(py, item.clone())?;
+                                all_results.push(py_item.into_any().unbind());
+                            }
+                        }
+                    }
+
+                    if let Some(unprocessed) = output.unprocessed_keys {
+                        if let Some(keys_and_attrs) = unprocessed.get(&table_name) {
+                            let keys = keys_and_attrs.keys();
+                            if !keys.is_empty() {
+                                pending = keys.to_vec();
+                                retries += 1;
+                                let delay = std::time::Duration::from_millis(50 * (1 << retries));
+                                std::thread::sleep(delay);
+                                continue;
+                            }
+                        }
+                    }
+                    pending.clear();
+                }
+                Err(e) => {
+                    return Err(map_sdk_error(e, Some(table)));
+                }
+            }
+        }
+
+        if !pending.is_empty() {
+            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                "Failed to get {} keys after {} retries",
+                pending.len(),
+                BATCH_MAX_RETRIES
+            )));
+        }
+    }
+
+    Ok(all_results)
+}
+
+// ========== ASYNC ==========
+
+/// Prepared batch get data (converted from Python before async).
+struct PreparedBatchGet {
+    table: String,
+    keys: Vec<HashMap<String, AttributeValue>>,
+}
+
+/// Prepare batch get - convert Python dicts to Rust types (needs GIL).
+fn prepare_batch_get(
+    py: Python<'_>,
+    table: &str,
+    keys: &Bound<'_, PyList>,
+) -> PyResult<PreparedBatchGet> {
+    let mut all_keys: Vec<HashMap<String, AttributeValue>> = Vec::new();
+    for key in keys.iter() {
+        let key_dict = key.cast::<PyDict>()?;
+        let dynamo_key = py_dict_to_attribute_values(py, key_dict)?;
+        all_keys.push(dynamo_key);
+    }
+
+    Ok(PreparedBatchGet {
+        table: table.to_string(),
+        keys: all_keys,
+    })
+}
+
+/// Raw batch get result (before Python conversion).
+struct RawBatchGetResult {
+    items: Vec<HashMap<String, AttributeValue>>,
+}
+
+/// Execute batch get asynchronously.
+async fn execute_batch_get(
+    client: Client,
+    prepared: PreparedBatchGet,
+) -> Result<
+    RawBatchGetResult,
+    (
+        aws_sdk_dynamodb::error::SdkError<
+            aws_sdk_dynamodb::operation::batch_get_item::BatchGetItemError,
+        >,
+        String,
+    ),
+> {
+    if prepared.keys.is_empty() {
+        return Ok(RawBatchGetResult { items: Vec::new() });
+    }
+
+    let mut all_results: Vec<HashMap<String, AttributeValue>> = Vec::new();
+
+    for chunk in prepared.keys.chunks(BATCH_GET_MAX_ITEMS) {
+        let mut pending: Vec<HashMap<String, AttributeValue>> = chunk.to_vec();
+        let mut retries = 0;
+
+        while !pending.is_empty() && retries < BATCH_MAX_RETRIES {
+            let keys_and_attrs = KeysAndAttributes::builder()
+                .set_keys(Some(pending.clone()))
+                .build()
+                .map_err(|e| {
+                    (
+                        aws_sdk_dynamodb::error::SdkError::construction_failure(format!(
+                            "Failed to build keys and attributes: {}",
+                            e
+                        )),
+                        prepared.table.clone(),
+                    )
+                })?;
+
+            let mut request_items = HashMap::new();
+            request_items.insert(prepared.table.clone(), keys_and_attrs);
+
+            let result = client
+                .batch_get_item()
+                .set_request_items(Some(request_items))
+                .send()
+                .await;
+
+            match result {
+                Ok(output) => {
+                    if let Some(responses) = output.responses {
+                        if let Some(items) = responses.get(&prepared.table) {
+                            all_results.extend(items.clone());
+                        }
+                    }
+
+                    if let Some(unprocessed) = output.unprocessed_keys {
+                        if let Some(keys_and_attrs) = unprocessed.get(&prepared.table) {
+                            let keys = keys_and_attrs.keys();
+                            if !keys.is_empty() {
+                                pending = keys.to_vec();
+                                retries += 1;
+                                let delay = std::time::Duration::from_millis(50 * (1 << retries));
+                                tokio::time::sleep(delay).await;
+                                continue;
+                            }
+                        }
+                    }
+                    pending.clear();
+                }
+                Err(e) => {
+                    return Err((e, prepared.table.clone()));
+                }
+            }
+        }
+
+        if !pending.is_empty() {
+            return Err((
+                aws_sdk_dynamodb::error::SdkError::construction_failure(format!(
+                    "Failed to get {} keys after {} retries",
+                    pending.len(),
+                    BATCH_MAX_RETRIES
+                )),
+                prepared.table.clone(),
+            ));
+        }
+    }
+
+    Ok(RawBatchGetResult { items: all_results })
+}
+
+/// Async batch get - returns a Python awaitable.
+pub fn async_batch_get<'py>(
+    py: Python<'py>,
+    client: Client,
+    table: &str,
+    keys: &Bound<'_, PyList>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let prepared = prepare_batch_get(py, table, keys)?;
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let result = execute_batch_get(client, prepared).await;
+
+        #[allow(deprecated)]
+        Python::with_gil(|py| match result {
+            Ok(raw) => {
+                let py_list = PyList::empty(py);
+                for item in raw.items {
+                    let py_dict = attribute_values_to_py_dict(py, item)?;
+                    py_list.append(py_dict)?;
+                }
+                Ok(py_list.into_any().unbind())
+            }
+            Err((e, tbl)) => Err(map_sdk_error(e, Some(&tbl))),
+        })
+    })
+}

--- a/src/batch_operations/mod.rs
+++ b/src/batch_operations/mod.rs
@@ -1,0 +1,19 @@
+//! Batch operations module for DynamoDB.
+//!
+//! This module provides batch operations:
+//! - `batch_write` - Write multiple items in a single request
+//! - `batch_get` - Get multiple items in a single request
+//!
+//! Both handle automatic splitting to respect DynamoDB limits and
+//! retry unprocessed items with exponential backoff.
+
+mod get;
+mod write;
+
+// Re-export sync operations
+pub use get::batch_get;
+pub use write::batch_write;
+
+// Re-export async operations
+pub use get::async_batch_get;
+pub use write::async_batch_write;

--- a/src/batch_operations/write.rs
+++ b/src/batch_operations/write.rs
@@ -1,10 +1,6 @@
-//! Batch operations module for DynamoDB.
-//!
-//! Handles batch write and batch get operations with:
-//! - Automatic splitting to respect DynamoDB limits (25 items for write, 100 for get)
-//! - Automatic retry of unprocessed items with exponential backoff
+//! Batch write operations for DynamoDB.
 
-use aws_sdk_dynamodb::types::{DeleteRequest, KeysAndAttributes, PutRequest, WriteRequest};
+use aws_sdk_dynamodb::types::{DeleteRequest, PutRequest, WriteRequest};
 use aws_sdk_dynamodb::Client;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -12,14 +8,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
-use crate::conversions::{attribute_values_to_py_dict, py_dict_to_attribute_values};
+use crate::conversions::py_dict_to_attribute_values;
 use crate::errors::map_sdk_error;
 
 /// Maximum items per batch write request (DynamoDB limit).
 const BATCH_WRITE_MAX_ITEMS: usize = 25;
-
-/// Maximum items per batch get request (DynamoDB limit).
-const BATCH_GET_MAX_ITEMS: usize = 100;
 
 /// Maximum retry attempts for unprocessed items.
 const BATCH_MAX_RETRIES: usize = 5;
@@ -50,7 +43,6 @@ pub fn batch_write(
     put_items: &Bound<'_, PyList>,
     delete_keys: &Bound<'_, PyList>,
 ) -> PyResult<()> {
-    // Convert put items to WriteRequests
     let mut put_requests: Vec<WriteRequest> = Vec::new();
     for item in put_items.iter() {
         let item_dict = item.cast::<PyDict>()?;
@@ -67,7 +59,6 @@ pub fn batch_write(
         put_requests.push(WriteRequest::builder().put_request(put_request).build());
     }
 
-    // Convert delete keys to WriteRequests
     let mut delete_requests: Vec<WriteRequest> = Vec::new();
     for key in delete_keys.iter() {
         let key_dict = key.cast::<PyDict>()?;
@@ -88,7 +79,6 @@ pub fn batch_write(
         );
     }
 
-    // Combine all requests
     let mut all_requests: Vec<WriteRequest> = Vec::new();
     all_requests.extend(put_requests);
     all_requests.extend(delete_requests);
@@ -100,7 +90,6 @@ pub fn batch_write(
     let table_name = table.to_string();
     let client = client.clone();
 
-    // Process in batches of 25
     for chunk in all_requests.chunks(BATCH_WRITE_MAX_ITEMS) {
         let mut pending: Vec<WriteRequest> = chunk.to_vec();
         let mut retries = 0;
@@ -119,20 +108,17 @@ pub fn batch_write(
 
             match result {
                 Ok(output) => {
-                    // Check for unprocessed items
                     if let Some(unprocessed) = output.unprocessed_items {
                         if let Some(items) = unprocessed.get(&table_name) {
                             if !items.is_empty() {
                                 pending = items.clone();
                                 retries += 1;
-                                // Exponential backoff
                                 let delay = std::time::Duration::from_millis(50 * (1 << retries));
                                 std::thread::sleep(delay);
                                 continue;
                             }
                         }
                     }
-                    // All items processed
                     pending.clear();
                 }
                 Err(e) => {
@@ -141,7 +127,6 @@ pub fn batch_write(
             }
         }
 
-        // If we still have pending items after max retries, fail
         if !pending.is_empty() {
             return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
                 "Failed to process {} items after {} retries",
@@ -154,120 +139,153 @@ pub fn batch_write(
     Ok(())
 }
 
-/// Batch get items from a DynamoDB table.
-///
-/// Handles:
-/// - Splitting requests to respect the 100-item limit
-/// - Retrying unprocessed keys with exponential backoff
-/// - Combining results from multiple requests
-///
-/// # Arguments
-///
-/// * `py` - Python interpreter reference
-/// * `client` - DynamoDB client
-/// * `runtime` - Tokio runtime
-/// * `table` - Table name
-/// * `keys` - List of keys to get (as Python dicts)
-///
-/// # Returns
-///
-/// A list of items (as Python dicts) that were found.
-pub fn batch_get(
-    py: Python<'_>,
-    client: &Client,
-    runtime: &Arc<Runtime>,
-    table: &str,
-    keys: &Bound<'_, PyList>,
-) -> PyResult<Vec<Py<PyAny>>> {
-    use aws_sdk_dynamodb::types::AttributeValue;
+// ========== ASYNC ==========
 
-    // Convert Python keys to DynamoDB format
-    let mut all_keys: Vec<HashMap<String, AttributeValue>> = Vec::new();
-    for key in keys.iter() {
+/// Prepared batch write data (converted from Python before async).
+struct PreparedBatchWrite {
+    table: String,
+    put_requests: Vec<WriteRequest>,
+    delete_requests: Vec<WriteRequest>,
+}
+
+/// Prepare batch write - convert Python dicts to Rust types (needs GIL).
+fn prepare_batch_write(
+    py: Python<'_>,
+    table: &str,
+    put_items: &Bound<'_, PyList>,
+    delete_keys: &Bound<'_, PyList>,
+) -> PyResult<PreparedBatchWrite> {
+    let mut put_requests: Vec<WriteRequest> = Vec::new();
+    for item in put_items.iter() {
+        let item_dict = item.cast::<PyDict>()?;
+        let dynamo_item = py_dict_to_attribute_values(py, item_dict)?;
+        let put_request = PutRequest::builder()
+            .set_item(Some(dynamo_item))
+            .build()
+            .map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Failed to build put request: {}",
+                    e
+                ))
+            })?;
+        put_requests.push(WriteRequest::builder().put_request(put_request).build());
+    }
+
+    let mut delete_requests: Vec<WriteRequest> = Vec::new();
+    for key in delete_keys.iter() {
         let key_dict = key.cast::<PyDict>()?;
         let dynamo_key = py_dict_to_attribute_values(py, key_dict)?;
-        all_keys.push(dynamo_key);
+        let delete_request = DeleteRequest::builder()
+            .set_key(Some(dynamo_key))
+            .build()
+            .map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Failed to build delete request: {}",
+                    e
+                ))
+            })?;
+        delete_requests.push(
+            WriteRequest::builder()
+                .delete_request(delete_request)
+                .build(),
+        );
     }
 
-    if all_keys.is_empty() {
-        return Ok(Vec::new());
+    Ok(PreparedBatchWrite {
+        table: table.to_string(),
+        put_requests,
+        delete_requests,
+    })
+}
+
+/// Execute batch write asynchronously.
+async fn execute_batch_write(
+    client: Client,
+    prepared: PreparedBatchWrite,
+) -> Result<
+    (),
+    (
+        aws_sdk_dynamodb::error::SdkError<
+            aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemError,
+        >,
+        String,
+    ),
+> {
+    let mut all_requests: Vec<WriteRequest> = Vec::new();
+    all_requests.extend(prepared.put_requests);
+    all_requests.extend(prepared.delete_requests);
+
+    if all_requests.is_empty() {
+        return Ok(());
     }
 
-    let table_name = table.to_string();
-    let client = client.clone();
-    let mut all_results: Vec<Py<PyAny>> = Vec::new();
-
-    // Process in batches of 100
-    for chunk in all_keys.chunks(BATCH_GET_MAX_ITEMS) {
-        let mut pending: Vec<HashMap<String, AttributeValue>> = chunk.to_vec();
+    for chunk in all_requests.chunks(BATCH_WRITE_MAX_ITEMS) {
+        let mut pending: Vec<WriteRequest> = chunk.to_vec();
         let mut retries = 0;
 
         while !pending.is_empty() && retries < BATCH_MAX_RETRIES {
-            let keys_and_attrs = KeysAndAttributes::builder()
-                .set_keys(Some(pending.clone()))
-                .build()
-                .map_err(|e| {
-                    PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                        "Failed to build keys and attributes: {}",
-                        e
-                    ))
-                })?;
-
             let mut request_items = HashMap::new();
-            request_items.insert(table_name.clone(), keys_and_attrs);
+            request_items.insert(prepared.table.clone(), pending.clone());
 
-            let result = runtime.block_on(async {
-                client
-                    .batch_get_item()
-                    .set_request_items(Some(request_items))
-                    .send()
-                    .await
-            });
+            let result = client
+                .batch_write_item()
+                .set_request_items(Some(request_items))
+                .send()
+                .await;
 
             match result {
                 Ok(output) => {
-                    // Collect results
-                    if let Some(responses) = output.responses {
-                        if let Some(items) = responses.get(&table_name) {
-                            for item in items {
-                                let py_item = attribute_values_to_py_dict(py, item.clone())?;
-                                all_results.push(py_item.into_any().unbind());
-                            }
-                        }
-                    }
-
-                    // Check for unprocessed keys
-                    if let Some(unprocessed) = output.unprocessed_keys {
-                        if let Some(keys_and_attrs) = unprocessed.get(&table_name) {
-                            let keys = keys_and_attrs.keys();
-                            if !keys.is_empty() {
-                                pending = keys.to_vec();
+                    if let Some(unprocessed) = output.unprocessed_items {
+                        if let Some(items) = unprocessed.get(&prepared.table) {
+                            if !items.is_empty() {
+                                pending = items.clone();
                                 retries += 1;
-                                // Exponential backoff
                                 let delay = std::time::Duration::from_millis(50 * (1 << retries));
-                                std::thread::sleep(delay);
+                                tokio::time::sleep(delay).await;
                                 continue;
                             }
                         }
                     }
-                    // All keys processed
                     pending.clear();
                 }
                 Err(e) => {
-                    return Err(map_sdk_error(e, Some(table)));
+                    return Err((e, prepared.table.clone()));
                 }
             }
         }
 
-        // If we still have pending keys after max retries, fail
         if !pending.is_empty() {
-            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                "Failed to get {} keys after {} retries",
-                pending.len(),
-                BATCH_MAX_RETRIES
-            )));
+            return Err((
+                aws_sdk_dynamodb::error::SdkError::construction_failure(format!(
+                    "Failed to process {} items after {} retries",
+                    pending.len(),
+                    BATCH_MAX_RETRIES
+                )),
+                prepared.table.clone(),
+            ));
         }
     }
 
-    Ok(all_results)
+    Ok(())
+}
+
+/// Async batch write - returns a Python awaitable.
+pub fn async_batch_write<'py>(
+    py: Python<'py>,
+    client: Client,
+    table: &str,
+    put_items: &Bound<'_, PyList>,
+    delete_keys: &Bound<'_, PyList>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let prepared = prepare_batch_write(py, table, put_items, delete_keys)?;
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let result = execute_batch_write(client, prepared).await;
+
+        #[allow(deprecated)]
+        Python::with_gil(|_py| match result {
+            Ok(()) => Ok(()),
+            Err((e, tbl)) => Err(map_sdk_error(e, Some(&tbl))),
+        })
+    })
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -565,6 +565,31 @@ impl DynamoDBClient {
         transaction_operations::async_transact_get(py, self.client.clone(), gets)
     }
 
+    /// Async version of batch_write.
+    ///
+    /// Returns a Python awaitable that writes items in batch.
+    pub fn async_batch_write<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        put_items: &Bound<'_, pyo3::types::PyList>,
+        delete_keys: &Bound<'_, pyo3::types::PyList>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        batch_operations::async_batch_write(py, self.client.clone(), table, put_items, delete_keys)
+    }
+
+    /// Async version of batch_get.
+    ///
+    /// Returns a Python awaitable that gets items in batch.
+    pub fn async_batch_get<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        keys: &Bound<'_, pyo3::types::PyList>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        batch_operations::async_batch_get(py, self.client.clone(), table, keys)
+    }
+
     /// Create a new DynamoDB table.
     #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, wait=false))]
     #[allow(clippy::too_many_arguments)]

--- a/tests/integration/async_ops/test_async_batch.py
+++ b/tests/integration/async_ops/test_async_batch.py
@@ -1,0 +1,324 @@
+"""Tests for async batch operations."""
+
+import uuid
+
+import pytest
+from pydynox import AsyncBatchWriter, DynamoDBClient, Model, ModelConfig, set_default_client
+from pydynox.attributes import NumberAttribute, StringAttribute
+
+TABLE_NAME = "async_test_users"
+
+
+@pytest.fixture
+def async_table(dynamo: DynamoDBClient):
+    """Create a test table for async tests."""
+    set_default_client(dynamo)
+    if not dynamo.table_exists(TABLE_NAME):
+        dynamo.create_table(
+            TABLE_NAME,
+            hash_key=("pk", "S"),
+            range_key=("sk", "S"),
+            wait=True,
+        )
+    yield dynamo
+
+
+class AsyncUser(Model):
+    model_config = ModelConfig(table=TABLE_NAME)
+    pk = StringAttribute(hash_key=True)
+    sk = StringAttribute(range_key=True)
+    name = StringAttribute()
+    age = NumberAttribute(null=True)
+
+
+# ========== Client async_batch_get tests ==========
+
+
+@pytest.mark.asyncio
+async def test_async_batch_get_returns_items(async_table: DynamoDBClient):
+    """Test async batch get with a few items."""
+    uid = str(uuid.uuid4())[:8]
+    items = [
+        {"pk": f"ABGET#{uid}", "sk": "ITEM#1", "name": "Alice"},
+        {"pk": f"ABGET#{uid}", "sk": "ITEM#2", "name": "Bob"},
+        {"pk": f"ABGET#{uid}", "sk": "ITEM#3", "name": "Charlie"},
+    ]
+    for item in items:
+        await async_table.async_put_item(TABLE_NAME, item)
+
+    keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
+    results = await async_table.async_batch_get(TABLE_NAME, keys)
+
+    assert len(results) == 3
+    names = {r["name"] for r in results}
+    assert names == {"Alice", "Bob", "Charlie"}
+
+
+@pytest.mark.asyncio
+async def test_async_batch_get_missing_items(async_table: DynamoDBClient):
+    """Test async batch get with some missing items."""
+    uid = str(uuid.uuid4())[:8]
+    await async_table.async_put_item(
+        TABLE_NAME, {"pk": f"AMISS#{uid}", "sk": "EXISTS", "name": "Found"}
+    )
+
+    keys = [
+        {"pk": f"AMISS#{uid}", "sk": "EXISTS"},
+        {"pk": f"AMISS#{uid}", "sk": "NOTEXISTS"},
+    ]
+    results = await async_table.async_batch_get(TABLE_NAME, keys)
+
+    assert len(results) == 1
+    assert results[0]["name"] == "Found"
+
+
+@pytest.mark.asyncio
+async def test_async_batch_get_empty_keys(async_table: DynamoDBClient):
+    """Test async batch get with empty keys list."""
+    results = await async_table.async_batch_get(TABLE_NAME, [])
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_async_batch_get_more_than_100_items(async_table: DynamoDBClient):
+    """Test async batch get with more than 100 items."""
+    uid = str(uuid.uuid4())[:8]
+    items = [{"pk": f"ALARGE#{uid}", "sk": f"ITEM#{i:03d}", "index": i} for i in range(120)]
+    # Use sync batch_write for setup (faster)
+    async_table.batch_write(TABLE_NAME, put_items=items)
+
+    keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
+    results = await async_table.async_batch_get(TABLE_NAME, keys)
+
+    assert len(results) == 120
+    indices = {r["index"] for r in results}
+    assert indices == set(range(120))
+
+
+# ========== Client async_batch_write tests ==========
+
+
+@pytest.mark.asyncio
+async def test_async_batch_write_puts_items(async_table: DynamoDBClient):
+    """Test async batch write with a few items."""
+    uid = str(uuid.uuid4())[:8]
+    items = [
+        {"pk": f"ABATCH#{uid}", "sk": "ITEM#1", "name": "Alice"},
+        {"pk": f"ABATCH#{uid}", "sk": "ITEM#2", "name": "Bob"},
+        {"pk": f"ABATCH#{uid}", "sk": "ITEM#3", "name": "Charlie"},
+    ]
+
+    await async_table.async_batch_write(TABLE_NAME, put_items=items)
+
+    for item in items:
+        key = {"pk": item["pk"], "sk": item["sk"]}
+        result = await async_table.async_get_item(TABLE_NAME, key)
+        assert result is not None
+        assert result["name"] == item["name"]
+
+
+@pytest.mark.asyncio
+async def test_async_batch_write_deletes_items(async_table: DynamoDBClient):
+    """Test async batch write with delete operations."""
+    uid = str(uuid.uuid4())[:8]
+    items = [
+        {"pk": f"ADEL#{uid}", "sk": "ITEM#1", "name": "ToDelete1"},
+        {"pk": f"ADEL#{uid}", "sk": "ITEM#2", "name": "ToDelete2"},
+    ]
+    for item in items:
+        await async_table.async_put_item(TABLE_NAME, item)
+
+    delete_keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
+    await async_table.async_batch_write(TABLE_NAME, delete_keys=delete_keys)
+
+    for key in delete_keys:
+        result = await async_table.async_get_item(TABLE_NAME, key)
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_async_batch_write_mixed_operations(async_table: DynamoDBClient):
+    """Test async batch write with both puts and deletes."""
+    uid = str(uuid.uuid4())[:8]
+    to_delete = {"pk": f"AMIX#{uid}", "sk": "DELETE", "name": "WillBeDeleted"}
+    await async_table.async_put_item(TABLE_NAME, to_delete)
+
+    new_items = [
+        {"pk": f"AMIX#{uid}", "sk": "NEW#1", "name": "NewItem1"},
+        {"pk": f"AMIX#{uid}", "sk": "NEW#2", "name": "NewItem2"},
+    ]
+    delete_keys = [{"pk": f"AMIX#{uid}", "sk": "DELETE"}]
+    await async_table.async_batch_write(TABLE_NAME, put_items=new_items, delete_keys=delete_keys)
+
+    for item in new_items:
+        key = {"pk": item["pk"], "sk": item["sk"]}
+        result = await async_table.async_get_item(TABLE_NAME, key)
+        assert result is not None
+
+    result = await async_table.async_get_item(TABLE_NAME, {"pk": f"AMIX#{uid}", "sk": "DELETE"})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_async_batch_write_more_than_25_items(async_table: DynamoDBClient):
+    """Test async batch write with more than 25 items."""
+    uid = str(uuid.uuid4())[:8]
+    items = [{"pk": f"A25#{uid}", "sk": f"ITEM#{i:03d}", "index": i} for i in range(30)]
+
+    await async_table.async_batch_write(TABLE_NAME, put_items=items)
+
+    for item in items:
+        key = {"pk": item["pk"], "sk": item["sk"]}
+        result = await async_table.async_get_item(TABLE_NAME, key)
+        assert result is not None
+        assert result["index"] == item["index"]
+
+
+# ========== AsyncBatchWriter tests ==========
+
+
+@pytest.mark.asyncio
+async def test_async_batch_writer_puts_items(async_table: DynamoDBClient):
+    """Test AsyncBatchWriter with put operations."""
+    uid = str(uuid.uuid4())[:8]
+
+    async with AsyncBatchWriter(async_table, TABLE_NAME) as batch:
+        for i in range(5):
+            batch.put({"pk": f"ABW#{uid}", "sk": f"ITEM#{i}", "name": f"User {i}"})
+
+    for i in range(5):
+        result = await async_table.async_get_item(
+            TABLE_NAME, {"pk": f"ABW#{uid}", "sk": f"ITEM#{i}"}
+        )
+        assert result is not None
+        assert result["name"] == f"User {i}"
+
+
+@pytest.mark.asyncio
+async def test_async_batch_writer_deletes_items(async_table: DynamoDBClient):
+    """Test AsyncBatchWriter with delete operations."""
+    uid = str(uuid.uuid4())[:8]
+    for i in range(3):
+        await async_table.async_put_item(
+            TABLE_NAME, {"pk": f"ABWD#{uid}", "sk": f"ITEM#{i}", "name": f"User {i}"}
+        )
+
+    async with AsyncBatchWriter(async_table, TABLE_NAME) as batch:
+        for i in range(3):
+            batch.delete({"pk": f"ABWD#{uid}", "sk": f"ITEM#{i}"})
+
+    for i in range(3):
+        result = await async_table.async_get_item(
+            TABLE_NAME, {"pk": f"ABWD#{uid}", "sk": f"ITEM#{i}"}
+        )
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_async_batch_writer_mixed_operations(async_table: DynamoDBClient):
+    """Test AsyncBatchWriter with mixed put and delete."""
+    uid = str(uuid.uuid4())[:8]
+    await async_table.async_put_item(
+        TABLE_NAME, {"pk": f"ABWM#{uid}", "sk": "OLD", "name": "ToDelete"}
+    )
+
+    async with AsyncBatchWriter(async_table, TABLE_NAME) as batch:
+        batch.put({"pk": f"ABWM#{uid}", "sk": "NEW#1", "name": "New1"})
+        batch.put({"pk": f"ABWM#{uid}", "sk": "NEW#2", "name": "New2"})
+        batch.delete({"pk": f"ABWM#{uid}", "sk": "OLD"})
+
+    assert await async_table.async_get_item(TABLE_NAME, {"pk": f"ABWM#{uid}", "sk": "NEW#1"})
+    assert await async_table.async_get_item(TABLE_NAME, {"pk": f"ABWM#{uid}", "sk": "NEW#2"})
+    assert await async_table.async_get_item(TABLE_NAME, {"pk": f"ABWM#{uid}", "sk": "OLD"}) is None
+
+
+@pytest.mark.asyncio
+async def test_async_batch_writer_manual_flush(async_table: DynamoDBClient):
+    """Test AsyncBatchWriter manual flush."""
+    uid = str(uuid.uuid4())[:8]
+
+    async with AsyncBatchWriter(async_table, TABLE_NAME) as batch:
+        batch.put({"pk": f"ABWF#{uid}", "sk": "ITEM#1", "name": "First"})
+        await batch.flush()
+
+        # Item should exist after flush
+        result = await async_table.async_get_item(TABLE_NAME, {"pk": f"ABWF#{uid}", "sk": "ITEM#1"})
+        assert result is not None
+
+        batch.put({"pk": f"ABWF#{uid}", "sk": "ITEM#2", "name": "Second"})
+
+    # Both items should exist
+    result = await async_table.async_get_item(TABLE_NAME, {"pk": f"ABWF#{uid}", "sk": "ITEM#2"})
+    assert result is not None
+
+
+# ========== Model.async_batch_get tests ==========
+
+
+@pytest.mark.asyncio
+async def test_model_async_batch_get_returns_instances(async_table: DynamoDBClient):
+    """Model.async_batch_get returns Model instances by default."""
+    uid = str(uuid.uuid4())[:8]
+    items = [
+        {"pk": f"MABG#{uid}", "sk": "USER#1", "name": "Alice", "age": 25},
+        {"pk": f"MABG#{uid}", "sk": "USER#2", "name": "Bob", "age": 30},
+        {"pk": f"MABG#{uid}", "sk": "USER#3", "name": "Charlie", "age": 35},
+    ]
+    for item in items:
+        await async_table.async_put_item(TABLE_NAME, item)
+
+    keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
+    users = await AsyncUser.async_batch_get(keys)
+
+    assert len(users) == 3
+    for user in users:
+        assert isinstance(user, AsyncUser)
+    names = {u.name for u in users}
+    assert names == {"Alice", "Bob", "Charlie"}
+
+
+@pytest.mark.asyncio
+async def test_model_async_batch_get_as_dict(async_table: DynamoDBClient):
+    """Model.async_batch_get(as_dict=True) returns plain dicts."""
+    uid = str(uuid.uuid4())[:8]
+    items = [
+        {"pk": f"MABGD#{uid}", "sk": "USER#1", "name": "Alice", "age": 25},
+        {"pk": f"MABGD#{uid}", "sk": "USER#2", "name": "Bob", "age": 30},
+    ]
+    for item in items:
+        await async_table.async_put_item(TABLE_NAME, item)
+
+    keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
+    users = await AsyncUser.async_batch_get(keys, as_dict=True)
+
+    assert len(users) == 2
+    for user in users:
+        assert isinstance(user, dict)
+    names = {u["name"] for u in users}
+    assert names == {"Alice", "Bob"}
+
+
+@pytest.mark.asyncio
+async def test_model_async_batch_get_empty_keys(async_table: DynamoDBClient):
+    """Model.async_batch_get with empty keys returns empty list."""
+    users = await AsyncUser.async_batch_get([])
+    assert users == []
+
+
+@pytest.mark.asyncio
+async def test_model_async_batch_get_missing_items(async_table: DynamoDBClient):
+    """Model.async_batch_get only returns existing items."""
+    uid = str(uuid.uuid4())[:8]
+    await async_table.async_put_item(
+        TABLE_NAME,
+        {"pk": f"MABGM#{uid}", "sk": "EXISTS", "name": "Found", "age": 20},
+    )
+
+    keys = [
+        {"pk": f"MABGM#{uid}", "sk": "EXISTS"},
+        {"pk": f"MABGM#{uid}", "sk": "NOTEXISTS"},
+    ]
+    users = await AsyncUser.async_batch_get(keys)
+
+    assert len(users) == 1
+    assert users[0].name == "Found"

--- a/uv.lock
+++ b/uv.lock
@@ -738,7 +738,7 @@ wheels = [
 
 [[package]]
 name = "pydynox"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #187

### Usage

```py
# Sync batch get
users = User.batch_get([
    {"pk": "USER#1", "sk": "PROFILE"},
    {"pk": "USER#2", "sk": "PROFILE"},
])

# Async batch get
users = await User.async_batch_get(keys)

# Async batch write
async with AsyncBatchWriter(client, "users") as batch:
    batch.put({"pk": "USER#1", "name": "John"})
    batch.delete({"pk": "USER#2"})
```