### PR TITLE
docs: async-first examples for s3 operations

### DIFF
--- a/docs/examples/s3/async_operations.py
+++ b/docs/examples/s3/async_operations.py
@@ -1,4 +1,4 @@
-"""Async S3 operations."""
+"""Async S3 operations (S3Value methods are async-first)."""
 
 import asyncio
 
@@ -20,27 +20,25 @@ class Document(Model):
 
 
 async def main():
-    # Async upload (default)
+    # Upload (Model uses async_save)
     doc = Document(pk="DOC#async", sk="v1", name="async.txt")
     doc.content = S3File(b"Async content", name="async.txt")
     await doc.async_save()
     print(f"Uploaded: {doc.content.key}")
 
-    # Async get
+    # Get (Model uses async_get)
     loaded = await Document.async_get(pk="DOC#async", sk="v1")
     if loaded and loaded.content:
-        # Async download (default, no prefix)
+        # S3Value methods are async-first (no prefix = async)
         data = await loaded.content.get_bytes()
         print(f"Downloaded: {len(data)} bytes")
 
-        # Async save to file (default, no prefix)
         await loaded.content.save_to("/tmp/async_download.txt")
 
-        # Async presigned URL (default, no prefix)
         url = await loaded.content.presigned_url(3600)
         print(f"URL: {url}")
 
-    # Async delete
+    # Delete (Model uses async_delete)
     await doc.async_delete()
     print("Deleted")
 

--- a/docs/examples/s3/download.py
+++ b/docs/examples/s3/download.py
@@ -1,4 +1,4 @@
-"""Download S3 content."""
+"""Sync S3 download operations (with sync_ prefix)."""
 
 from pydynox import Model, ModelConfig
 from pydynox.attributes import S3Attribute, S3File, StringAttribute
@@ -15,20 +15,20 @@ class Document(Model):
 # First create a document with S3 content
 doc = Document(pk="DOC#DOWNLOAD", name="report.pdf")
 doc.content = S3File(b"PDF content here", name="report.pdf", content_type="application/pdf")
-doc.save()
+doc.save()  # Model.save() is sync
 
-# Get document
+# Get document (sync)
 doc = Document.get(pk="DOC#DOWNLOAD")
 
 if doc and doc.content:
-    # Download to memory (careful with large files)
+    # Download to memory (sync, with prefix)
     data = doc.content.sync_get_bytes()
     print(f"Downloaded {len(data)} bytes")
 
-    # Stream to file (memory efficient for large files)
+    # Stream to file (sync, with prefix)
     doc.content.sync_save_to("/tmp/downloaded.pdf")
     print("Saved to /tmp/downloaded.pdf")
 
-    # Get presigned URL for sharing
+    # Get presigned URL (sync, with prefix)
     url = doc.content.sync_presigned_url(expires=3600)  # 1 hour
     print(f"Presigned URL: {url}")


### PR DESCRIPTION
closes #199 

Updated docs and examples to show async as the default pattern for s3 operations.