### PR TITLE
refactor: refactoring model/client operations async first

### DIFF
--- a/python/pydynox/_internal/_indexes.py
+++ b/python/pydynox/_internal/_indexes.py
@@ -105,7 +105,7 @@ class GlobalSecondaryIndex(Generic[M]):
             )
         return self._model_class
 
-    def query(
+    def sync_query(
         self,
         range_key_condition: Condition | None = None,
         filter_condition: Condition | None = None,
@@ -115,13 +115,13 @@ class GlobalSecondaryIndex(Generic[M]):
         last_evaluated_key: dict[str, Any] | None = None,
         **key_values: Any,
     ) -> GSIQueryResult[M]:
-        """Query the GSI."""
+        """Sync query the GSI."""
         model_class = self._get_model_class()
 
         missing_hash_keys = [k for k in self.hash_keys if k not in key_values]
         if missing_hash_keys:
             raise ValueError(
-                f"GSI query requires all hash key attributes: {self.hash_keys}. "
+                f"GSI sync_query requires all hash key attributes: {self.hash_keys}. "
                 f"Missing: {missing_hash_keys}"
             )
 
@@ -139,7 +139,7 @@ class GlobalSecondaryIndex(Generic[M]):
             last_evaluated_key=last_evaluated_key,
         )
 
-    def async_query(
+    def query(
         self,
         range_key_condition: Condition | None = None,
         filter_condition: Condition | None = None,
@@ -149,13 +149,13 @@ class GlobalSecondaryIndex(Generic[M]):
         last_evaluated_key: dict[str, Any] | None = None,
         **key_values: Any,
     ) -> AsyncGSIQueryResult[M]:
-        """Async version of query."""
+        """Query the GSI (async)."""
         model_class = self._get_model_class()
 
         missing_hash_keys = [k for k in self.hash_keys if k not in key_values]
         if missing_hash_keys:
             raise ValueError(
-                f"GSI async_query requires all hash key attributes: {self.hash_keys}. "
+                f"GSI query requires all hash key attributes: {self.hash_keys}. "
                 f"Missing: {missing_hash_keys}"
             )
 
@@ -549,7 +549,7 @@ class LocalSecondaryIndex(Generic[M]):
             )
         return self._model_class
 
-    def query(
+    def sync_query(
         self,
         range_key_condition: Condition | None = None,
         filter_condition: Condition | None = None,
@@ -560,7 +560,7 @@ class LocalSecondaryIndex(Generic[M]):
         last_evaluated_key: dict[str, Any] | None = None,
         **key_values: Any,
     ) -> LSIQueryResult[M]:
-        """Query the LSI."""
+        """Sync query the LSI."""
         model_class = self._get_model_class()
 
         hash_key_name = model_class._hash_key
@@ -569,7 +569,7 @@ class LocalSecondaryIndex(Generic[M]):
 
         if hash_key_name not in key_values:
             raise ValueError(
-                f"LSI query requires the table's hash key '{hash_key_name}'. "
+                f"LSI sync_query requires the table's hash key '{hash_key_name}'. "
                 f"Got: {list(key_values.keys())}"
             )
 
@@ -588,7 +588,7 @@ class LocalSecondaryIndex(Generic[M]):
             last_evaluated_key=last_evaluated_key,
         )
 
-    def async_query(
+    def query(
         self,
         range_key_condition: Condition | None = None,
         filter_condition: Condition | None = None,
@@ -599,7 +599,7 @@ class LocalSecondaryIndex(Generic[M]):
         last_evaluated_key: dict[str, Any] | None = None,
         **key_values: Any,
     ) -> AsyncLSIQueryResult[M]:
-        """Async version of query."""
+        """Query the LSI (async)."""
         model_class = self._get_model_class()
 
         hash_key_name = model_class._hash_key
@@ -608,7 +608,7 @@ class LocalSecondaryIndex(Generic[M]):
 
         if hash_key_name not in key_values:
             raise ValueError(
-                f"LSI async_query requires the table's hash key '{hash_key_name}'. "
+                f"LSI query requires the table's hash key '{hash_key_name}'. "
                 f"Got: {list(key_values.keys())}"
             )
 

--- a/python/pydynox/_internal/_model/_async.py
+++ b/python/pydynox/_internal/_model/_async.py
@@ -1,4 +1,4 @@
-"""Async CRUD operations: async_get, async_save, async_delete, async_update."""
+"""Async CRUD operations (default): get, save, delete, update."""
 
 from __future__ import annotations
 
@@ -29,15 +29,13 @@ if TYPE_CHECKING:
 M = TypeVar("M", bound="Model")
 
 
-async def async_get(
+async def get(
     cls: type[M], consistent_read: bool | None = None, as_dict: bool = False, **keys: Any
 ) -> M | dict[str, Any] | None:
-    """Async get item by key. Returns model instance, dict, or None."""
-    # prepare: get client, table, resolve consistent_read
+    """Async get item by key (default). Returns model instance, dict, or None."""
     client, table, keys_dict, use_consistent = prepare_get(cls, consistent_read, keys)
-    item = await client.async_get_item(table, keys_dict, consistent_read=use_consistent)
+    item = await client.get_item(table, keys_dict, consistent_read=use_consistent)
 
-    # Record metrics from client
     if client._last_metrics is not None:
         cls._record_metrics(client._last_metrics, "get")
 
@@ -45,30 +43,23 @@ async def async_get(
         return None
     if as_dict:
         return item
-    # finalize: convert to model, run AFTER_LOAD hooks
     return finalize_get(cls, item)
 
 
-async def async_save(
+async def save(
     self: Model, condition: Condition | None = None, skip_hooks: bool | None = None
 ) -> None:
-    """Async save model to DynamoDB."""
-    # Start S3 metrics collection for uploads
+    """Async save model to DynamoDB (default)."""
     _start_s3_metrics_collection()
-
-    # S3 upload before prepare (needs to happen before to_dict)
     await self._upload_s3_files()
-
-    # Collect S3 metrics from uploads
     s3_duration, s3_calls, s3_uploaded, s3_downloaded = _stop_s3_metrics_collection()
 
-    # prepare: run BEFORE_SAVE hooks, auto-generate, version condition, size check
     client, table, item, cond_expr, attr_names, attr_values, skip = prepare_save(
         self, condition, skip_hooks
     )
 
     if cond_expr is not None:
-        await client.async_put_item(
+        await client.put_item(
             table,
             item,
             condition_expression=cond_expr,
@@ -76,33 +67,29 @@ async def async_save(
             expression_attribute_values=attr_values,
         )
     else:
-        await client.async_put_item(table, item)
+        await client.put_item(table, item)
 
-    # Record metrics from client
     if client._last_metrics is not None:
         self.__class__._record_metrics(client._last_metrics, "put")
 
-    # Record S3 metrics
     if s3_calls > 0:
         self.__class__._metrics_storage.total.add_s3(
             s3_duration, s3_calls, s3_uploaded, s3_downloaded
         )
 
-    # finalize: run AFTER_SAVE hooks
     finalize_save(self, skip)
 
 
-async def async_delete(
+async def delete(
     self: Model, condition: Condition | None = None, skip_hooks: bool | None = None
 ) -> None:
-    """Async delete model from DynamoDB."""
-    # prepare: run BEFORE_DELETE hooks, version condition
+    """Async delete model from DynamoDB (default)."""
     client, table, key, cond_expr, attr_names, attr_values, skip = prepare_delete(
         self, condition, skip_hooks
     )
 
     if cond_expr is not None:
-        await client.async_delete_item(
+        await client.delete_item(
             table,
             key,
             condition_expression=cond_expr,
@@ -110,46 +97,37 @@ async def async_delete(
             expression_attribute_values=attr_values,
         )
     else:
-        await client.async_delete_item(table, key)
+        await client.delete_item(table, key)
 
-    # Record metrics from client
     if client._last_metrics is not None:
         self.__class__._record_metrics(client._last_metrics, "delete")
 
-    # Start S3 metrics collection for deletes
     _start_s3_metrics_collection()
-
-    # S3 cleanup after successful delete
     await self._delete_s3_files()
-
-    # Collect S3 metrics from deletes
     s3_duration, s3_calls, s3_uploaded, s3_downloaded = _stop_s3_metrics_collection()
 
-    # Record S3 metrics
     if s3_calls > 0:
         self.__class__._metrics_storage.total.add_s3(
             s3_duration, s3_calls, s3_uploaded, s3_downloaded
         )
 
-    # finalize: run AFTER_DELETE hooks
     finalize_delete(self, skip)
 
 
-async def async_update(
+async def update(
     self: Model,
     atomic: list[AtomicOp] | None = None,
     condition: Condition | None = None,
     skip_hooks: bool | None = None,
     **kwargs: Any,
 ) -> None:
-    """Async update specific attributes."""
-    # prepare: run BEFORE_UPDATE hooks, build expressions
+    """Async update specific attributes (default)."""
     client, table, key, update_expr, cond_expr, attr_names, attr_values, updates, skip = (
         prepare_update(self, atomic, condition, skip_hooks, kwargs)
     )
 
     if update_expr is not None:
-        await client.async_update_item(
+        await client.update_item(
             table,
             key,
             update_expression=update_expr,
@@ -159,7 +137,7 @@ async def async_update(
         )
     elif updates is not None:
         if cond_expr is not None:
-            await client.async_update_item(
+            await client.update_item(
                 table,
                 key,
                 updates=updates,
@@ -168,30 +146,27 @@ async def async_update(
                 expression_attribute_values=attr_values,
             )
         else:
-            await client.async_update_item(table, key, updates=updates)
+            await client.update_item(table, key, updates=updates)
 
-    # Record metrics from client
     if client._last_metrics is not None:
         self.__class__._record_metrics(client._last_metrics, "update")
 
-    # finalize: run AFTER_UPDATE hooks
     finalize_update(self, skip)
 
 
-async def async_update_by_key(
+async def update_by_key(
     cls: type[M],
     condition: Condition | None = None,
     **kwargs: Any,
 ) -> None:
-    """Async update item by key without fetching. No hooks."""
-    # prepare: extract key, validate attrs, build condition
+    """Async update item by key without fetching (default). No hooks."""
     result = prepare_update_by_key(cls, condition, kwargs)
     if result is None:
         return
 
     client, table, key, updates, cond_expr, attr_names, attr_values = result
     if cond_expr is not None:
-        await client.async_update_item(
+        await client.update_item(
             table,
             key,
             updates=updates,
@@ -200,26 +175,24 @@ async def async_update_by_key(
             expression_attribute_values=attr_values,
         )
     else:
-        await client.async_update_item(table, key, updates=updates)
+        await client.update_item(table, key, updates=updates)
 
-    # Record metrics from client
     if client._last_metrics is not None:
         cls._record_metrics(client._last_metrics, "update")
 
 
-async def async_delete_by_key(
+async def delete_by_key(
     cls: type[M],
     condition: Condition | None = None,
     **kwargs: Any,
 ) -> None:
-    """Async delete item by key without fetching. No hooks."""
-    # prepare: extract key, build condition
+    """Async delete item by key without fetching (default). No hooks."""
     client, table, key, cond_expr, attr_names, attr_values = prepare_delete_by_key(
         cls, condition, kwargs
     )
 
     if cond_expr is not None:
-        await client.async_delete_item(
+        await client.delete_item(
             table,
             key,
             condition_expression=cond_expr,
@@ -227,8 +200,7 @@ async def async_delete_by_key(
             expression_attribute_values=attr_values,
         )
     else:
-        await client.async_delete_item(table, key)
+        await client.delete_item(table, key)
 
-    # Record metrics from client
     if client._last_metrics is not None:
         cls._record_metrics(client._last_metrics, "delete")

--- a/python/pydynox/_internal/_model/_crud.py
+++ b/python/pydynox/_internal/_model/_crud.py
@@ -37,7 +37,7 @@ def get(
     """Get an item by key. Returns model instance, dict, or None."""
     # prepare: get client, table, resolve consistent_read
     client, table, keys_dict, use_consistent = prepare_get(cls, consistent_read, keys)
-    item = client.get_item(table, keys_dict, consistent_read=use_consistent)
+    item = client.sync_get_item(table, keys_dict, consistent_read=use_consistent)
 
     # Record metrics from client
     if client._last_metrics is not None:
@@ -85,7 +85,7 @@ def save(self: Model, condition: Condition | None = None, skip_hooks: bool | Non
     kms_duration, kms_calls = _stop_kms_metrics_collection()
 
     if cond_expr is not None:
-        client.put_item(
+        client.sync_put_item(
             table,
             item,
             condition_expression=cond_expr,
@@ -93,7 +93,7 @@ def save(self: Model, condition: Condition | None = None, skip_hooks: bool | Non
             expression_attribute_values=attr_values,
         )
     else:
-        client.put_item(table, item)
+        client.sync_put_item(table, item)
 
     # Record metrics from client
     if client._last_metrics is not None:
@@ -121,7 +121,7 @@ def delete(self: Model, condition: Condition | None = None, skip_hooks: bool | N
     )
 
     if cond_expr is not None:
-        client.delete_item(
+        client.sync_delete_item(
             table,
             key,
             condition_expression=cond_expr,
@@ -129,7 +129,7 @@ def delete(self: Model, condition: Condition | None = None, skip_hooks: bool | N
             expression_attribute_values=attr_values,
         )
     else:
-        client.delete_item(table, key)
+        client.sync_delete_item(table, key)
 
     # Record metrics from client
     if client._last_metrics is not None:
@@ -168,7 +168,7 @@ def update(
     )
 
     if update_expr is not None:
-        client.update_item(
+        client.sync_update_item(
             table,
             key,
             update_expression=update_expr,
@@ -178,7 +178,7 @@ def update(
         )
     elif updates is not None:
         if cond_expr is not None:
-            client.update_item(
+            client.sync_update_item(
                 table,
                 key,
                 updates=updates,
@@ -187,7 +187,7 @@ def update(
                 expression_attribute_values=attr_values,
             )
         else:
-            client.update_item(table, key, updates=updates)
+            client.sync_update_item(table, key, updates=updates)
 
     # Record metrics from client
     if client._last_metrics is not None:
@@ -210,7 +210,7 @@ def update_by_key(
 
     client, table, key, updates, cond_expr, attr_names, attr_values = result
     if cond_expr is not None:
-        client.update_item(
+        client.sync_update_item(
             table,
             key,
             updates=updates,
@@ -219,7 +219,7 @@ def update_by_key(
             expression_attribute_values=attr_values,
         )
     else:
-        client.update_item(table, key, updates=updates)
+        client.sync_update_item(table, key, updates=updates)
 
     # Record metrics from client
     if client._last_metrics is not None:
@@ -238,7 +238,7 @@ def delete_by_key(
     )
 
     if cond_expr is not None:
-        client.delete_item(
+        client.sync_delete_item(
             table,
             key,
             condition_expression=cond_expr,
@@ -246,7 +246,7 @@ def delete_by_key(
             expression_attribute_values=attr_values,
         )
     else:
-        client.delete_item(table, key)
+        client.sync_delete_item(table, key)
 
     # Record metrics from client
     if client._last_metrics is not None:

--- a/python/pydynox/_internal/_model/_query.py
+++ b/python/pydynox/_internal/_model/_query.py
@@ -20,7 +20,10 @@ if TYPE_CHECKING:
 M = TypeVar("M", bound="Model")
 
 
-def query(
+# ========== SYNC METHODS ==========
+
+
+def sync_query(
     cls: type[M],
     hash_key: Any,
     range_key_condition: Condition | None = None,
@@ -33,24 +36,160 @@ def query(
     as_dict: bool = False,
     fields: list[str] | None = None,
 ) -> ModelQueryResult[M]:
-    """Query items by hash key with optional conditions.
-
-    Args:
-        hash_key: The hash key value to query.
-        range_key_condition: Optional condition on the range key.
-        filter_condition: Optional filter on non-key attributes.
-        limit: Max total items to return across all pages.
-        page_size: Items per page (passed as Limit to DynamoDB).
-        scan_index_forward: Sort order. True = ascending, False = descending.
-        consistent_read: If True, use strongly consistent read.
-        last_evaluated_key: Start key for pagination.
-        as_dict: If True, return dicts instead of Model instances.
-        fields: List of fields to return. Saves RCU by fetching only what you need.
-
-    Returns:
-        ModelQueryResult that yields typed model instances or dicts.
-    """
+    """Query items by hash key with optional conditions (sync)."""
     return ModelQueryResult(
+        model_class=cls,
+        hash_key_value=hash_key,
+        range_key_condition=range_key_condition,
+        filter_condition=filter_condition,
+        limit=limit,
+        page_size=page_size,
+        scan_index_forward=scan_index_forward,
+        consistent_read=consistent_read,
+        last_evaluated_key=last_evaluated_key,
+        as_dict=as_dict,
+        fields=fields,
+    )
+
+
+def sync_scan(
+    cls: type[M],
+    filter_condition: Condition | None = None,
+    limit: int | None = None,
+    page_size: int | None = None,
+    consistent_read: bool | None = None,
+    last_evaluated_key: dict[str, Any] | None = None,
+    segment: int | None = None,
+    total_segments: int | None = None,
+    as_dict: bool = False,
+    fields: list[str] | None = None,
+) -> ModelScanResult[M]:
+    """Scan all items in the table (sync)."""
+    return ModelScanResult(
+        model_class=cls,
+        filter_condition=filter_condition,
+        limit=limit,
+        page_size=page_size,
+        consistent_read=consistent_read,
+        last_evaluated_key=last_evaluated_key,
+        segment=segment,
+        total_segments=total_segments,
+        as_dict=as_dict,
+        fields=fields,
+    )
+
+
+def sync_count(
+    cls: type[M],
+    filter_condition: Condition | None = None,
+    consistent_read: bool | None = None,
+) -> tuple[int, OperationMetrics]:
+    """Count items in the table (sync)."""
+    client = cls._get_client()
+    table = cls._get_table()
+
+    names: dict[str, str] = {}
+    values: dict[str, Any] = {}
+
+    filter_expr = None
+    if filter_condition is not None:
+        filter_expr = filter_condition.serialize(names, values)
+
+    attr_names = {v: k for k, v in names.items()}
+
+    use_consistent = consistent_read
+    if use_consistent is None:
+        use_consistent = getattr(cls.model_config, "consistent_read", False)
+
+    return client.sync_count(
+        table,
+        filter_expression=filter_expr,
+        expression_attribute_names=attr_names if attr_names else None,
+        expression_attribute_values=values if values else None,
+        consistent_read=use_consistent,
+    )
+
+
+def sync_execute_statement(
+    cls: type[M],
+    statement: str,
+    parameters: list[Any] | None = None,
+    consistent_read: bool = False,
+) -> list[M]:
+    """Execute a PartiQL statement (sync)."""
+    client = cls._get_client()
+    result = client.sync_execute_statement(
+        statement,
+        parameters=parameters,
+        consistent_read=consistent_read,
+    )
+    return [cls.from_dict(item) for item in result]
+
+
+def sync_parallel_scan(
+    cls: type[M],
+    total_segments: int,
+    filter_condition: Condition | None = None,
+    consistent_read: bool | None = None,
+    as_dict: bool = False,
+) -> tuple[list[M] | list[dict[str, Any]], OperationMetrics]:
+    """Parallel scan (sync)."""
+    client = cls._get_client()
+    table = cls._get_table()
+
+    names: dict[str, str] = {}
+    values: dict[str, Any] = {}
+
+    filter_expr = None
+    if filter_condition is not None:
+        filter_expr = filter_condition.serialize(names, values)
+
+    attr_names = {v: k for k, v in names.items()}
+
+    use_consistent = consistent_read
+    if use_consistent is None:
+        use_consistent = getattr(cls.model_config, "consistent_read", False)
+
+    items, metrics = client.sync_parallel_scan(
+        table,
+        total_segments,
+        filter_expression=filter_expr,
+        expression_attribute_names=attr_names if attr_names else None,
+        expression_attribute_values=values if values else None,
+        consistent_read=use_consistent,
+    )
+
+    if as_dict:
+        return items, metrics
+
+    instances = [cls.from_dict(item) for item in items]
+
+    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
+    if not skip:
+        for instance in instances:
+            instance._run_hooks(HookType.AFTER_LOAD)
+
+    return instances, metrics
+
+
+# ========== ASYNC METHODS (default) ==========
+
+
+def query(
+    cls: type[M],
+    hash_key: Any,
+    range_key_condition: Condition | None = None,
+    filter_condition: Condition | None = None,
+    limit: int | None = None,
+    page_size: int | None = None,
+    scan_index_forward: bool = True,
+    consistent_read: bool | None = None,
+    last_evaluated_key: dict[str, Any] | None = None,
+    as_dict: bool = False,
+    fields: list[str] | None = None,
+) -> AsyncModelQueryResult[M]:
+    """Query items by hash key with optional conditions (async, default)."""
+    return AsyncModelQueryResult(
         model_class=cls,
         hash_key_value=hash_key,
         range_key_condition=range_key_condition,
@@ -76,153 +215,8 @@ def scan(
     total_segments: int | None = None,
     as_dict: bool = False,
     fields: list[str] | None = None,
-) -> ModelScanResult[M]:
-    """Scan all items in the table.
-
-    Warning: Scan reads every item in the table. Use query() when possible.
-
-    Args:
-        filter_condition: Optional filter on attributes.
-        limit: Max total items to return across all pages.
-        page_size: Items per page (passed as Limit to DynamoDB).
-        consistent_read: If True, use strongly consistent read.
-        last_evaluated_key: Start key for pagination.
-        segment: Segment number for parallel scan (0 to total_segments-1).
-        total_segments: Total number of segments for parallel scan.
-        as_dict: If True, return dicts instead of Model instances.
-        fields: List of fields to return. Saves RCU by fetching only what you need.
-
-    Returns:
-        ModelScanResult that yields typed model instances or dicts.
-
-    Example:
-        >>> for user in User.scan():
-        ...     print(user.name)
-        >>>
-        >>> # With filter
-        >>> for user in User.scan(filter_condition=User.age >= 18):
-        ...     print(user.name)
-    """
-    return ModelScanResult(
-        model_class=cls,
-        filter_condition=filter_condition,
-        limit=limit,
-        page_size=page_size,
-        consistent_read=consistent_read,
-        last_evaluated_key=last_evaluated_key,
-        segment=segment,
-        total_segments=total_segments,
-        as_dict=as_dict,
-        fields=fields,
-    )
-
-
-def count(
-    cls: type[M],
-    filter_condition: Condition | None = None,
-    consistent_read: bool | None = None,
-) -> tuple[int, OperationMetrics]:
-    """Count items in the table.
-
-    Warning: Count scans the entire table. Use sparingly.
-
-    Args:
-        filter_condition: Optional filter on attributes.
-        consistent_read: If True, use strongly consistent read.
-
-    Returns:
-        Tuple of (count, metrics).
-
-    Example:
-        >>> count, metrics = User.count()
-        >>> print(f"Total users: {count}")
-    """
-    client = cls._get_client()
-    table = cls._get_table()
-
-    names: dict[str, str] = {}
-    values: dict[str, Any] = {}
-
-    filter_expr = None
-    if filter_condition is not None:
-        filter_expr = filter_condition.serialize(names, values)
-
-    attr_names = {v: k for k, v in names.items()}
-
-    use_consistent = consistent_read
-    if use_consistent is None:
-        use_consistent = getattr(cls.model_config, "consistent_read", False)
-
-    return client.count(
-        table,
-        filter_expression=filter_expr,
-        expression_attribute_names=attr_names if attr_names else None,
-        expression_attribute_values=values if values else None,
-        consistent_read=use_consistent,
-    )
-
-
-def execute_statement(
-    cls: type[M],
-    statement: str,
-    parameters: list[Any] | None = None,
-    consistent_read: bool = False,
-) -> list[M]:
-    """Execute a PartiQL statement and return typed model instances."""
-    client = cls._get_client()
-    result = client.execute_statement(
-        statement,
-        parameters=parameters,
-        consistent_read=consistent_read,
-    )
-    return [cls.from_dict(item) for item in result]
-
-
-# ========== ASYNC METHODS ==========
-
-
-def async_query(
-    cls: type[M],
-    hash_key: Any,
-    range_key_condition: Condition | None = None,
-    filter_condition: Condition | None = None,
-    limit: int | None = None,
-    page_size: int | None = None,
-    scan_index_forward: bool = True,
-    consistent_read: bool | None = None,
-    last_evaluated_key: dict[str, Any] | None = None,
-    as_dict: bool = False,
-    fields: list[str] | None = None,
-) -> AsyncModelQueryResult[M]:
-    """Async version of query."""
-    return AsyncModelQueryResult(
-        model_class=cls,
-        hash_key_value=hash_key,
-        range_key_condition=range_key_condition,
-        filter_condition=filter_condition,
-        limit=limit,
-        page_size=page_size,
-        scan_index_forward=scan_index_forward,
-        consistent_read=consistent_read,
-        last_evaluated_key=last_evaluated_key,
-        as_dict=as_dict,
-        fields=fields,
-    )
-
-
-def async_scan(
-    cls: type[M],
-    filter_condition: Condition | None = None,
-    limit: int | None = None,
-    page_size: int | None = None,
-    consistent_read: bool | None = None,
-    last_evaluated_key: dict[str, Any] | None = None,
-    segment: int | None = None,
-    total_segments: int | None = None,
-    as_dict: bool = False,
-    fields: list[str] | None = None,
 ) -> AsyncModelScanResult[M]:
-    """Async version of scan."""
+    """Scan all items in the table (async, default)."""
     return AsyncModelScanResult(
         model_class=cls,
         filter_condition=filter_condition,
@@ -237,12 +231,12 @@ def async_scan(
     )
 
 
-async def async_count(
+async def count(
     cls: type[M],
     filter_condition: Condition | None = None,
     consistent_read: bool | None = None,
 ) -> tuple[int, OperationMetrics]:
-    """Async version of count."""
+    """Count items in the table (async, default)."""
     client = cls._get_client()
     table = cls._get_table()
 
@@ -259,25 +253,24 @@ async def async_count(
     if use_consistent is None:
         use_consistent = getattr(cls.model_config, "consistent_read", False)
 
-    result = await client.async_count(
+    return await client.count(
         table,
         filter_expression=filter_expr,
         expression_attribute_names=attr_names if attr_names else None,
         expression_attribute_values=values if values else None,
         consistent_read=use_consistent,
     )
-    return result
 
 
-async def async_execute_statement(
+async def execute_statement(
     cls: type[M],
     statement: str,
     parameters: list[Any] | None = None,
     consistent_read: bool = False,
 ) -> list[M]:
-    """Async version of execute_statement."""
+    """Execute a PartiQL statement (async, default)."""
     client = cls._get_client()
-    result = await client.async_execute_statement(
+    result = await client.execute_statement(
         statement,
         parameters=parameters,
         consistent_read=consistent_read,
@@ -285,45 +278,14 @@ async def async_execute_statement(
     return [cls.from_dict(item) for item in result]
 
 
-# ========== PARALLEL SCAN ==========
-
-
-def parallel_scan(
+async def parallel_scan(
     cls: type[M],
     total_segments: int,
     filter_condition: Condition | None = None,
     consistent_read: bool | None = None,
     as_dict: bool = False,
 ) -> tuple[list[M] | list[dict[str, Any]], OperationMetrics]:
-    """Parallel scan - runs multiple segment scans concurrently.
-
-    Much faster than regular scan for large tables. Each segment is
-    scanned in parallel using tokio tasks in Rust.
-
-    Warning: Returns all items at once. For very large tables, consider
-    using regular scan() with segment/total_segments for streaming.
-
-    Args:
-        total_segments: Number of parallel segments (1-1000000).
-                       More segments = more parallelism, but more overhead.
-                       Good starting point: 4-8 for most tables.
-        filter_condition: Optional filter on attributes.
-        consistent_read: If True, use strongly consistent read.
-        as_dict: If True, return dicts instead of Model instances.
-
-    Returns:
-        Tuple of (list of model instances or dicts, metrics).
-
-    Example:
-        >>> users, metrics = User.parallel_scan(total_segments=4)
-        >>> print(f"Found {len(users)} users in {metrics.duration_ms:.2f}ms")
-        >>>
-        >>> # With filter
-        >>> active, metrics = User.parallel_scan(
-        ...     total_segments=4,
-        ...     filter_condition=User.status == "active"
-        ... )
-    """
+    """Parallel scan (async, default)."""
     client = cls._get_client()
     table = cls._get_table()
 
@@ -340,75 +302,7 @@ def parallel_scan(
     if use_consistent is None:
         use_consistent = getattr(cls.model_config, "consistent_read", False)
 
-    items, metrics = client.parallel_scan(
-        table,
-        total_segments,
-        filter_expression=filter_expr,
-        expression_attribute_names=attr_names if attr_names else None,
-        expression_attribute_values=values if values else None,
-        consistent_read=use_consistent,
-    )
-
-    if as_dict:
-        return items, metrics
-
-    instances = [cls.from_dict(item) for item in items]
-
-    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
-    if not skip:
-        for instance in instances:
-            instance._run_hooks(HookType.AFTER_LOAD)
-
-    return instances, metrics
-
-
-async def async_parallel_scan(
-    cls: type[M],
-    total_segments: int,
-    filter_condition: Condition | None = None,
-    consistent_read: bool | None = None,
-    as_dict: bool = False,
-) -> tuple[list[M] | list[dict[str, Any]], OperationMetrics]:
-    """Async parallel scan - runs multiple segment scans concurrently.
-
-    Much faster than regular scan for large tables. Each segment is
-    scanned in parallel using tokio tasks in Rust.
-
-    Warning: Returns all items at once. For very large tables, consider
-    using regular async_scan() with segment/total_segments for streaming.
-
-    Args:
-        total_segments: Number of parallel segments (1-1000000).
-                       More segments = more parallelism, but more overhead.
-                       Good starting point: 4-8 for most tables.
-        filter_condition: Optional filter on attributes.
-        consistent_read: If True, use strongly consistent read.
-        as_dict: If True, return dicts instead of Model instances.
-
-    Returns:
-        Tuple of (list of model instances or dicts, metrics).
-
-    Example:
-        >>> users, metrics = await User.async_parallel_scan(total_segments=4)
-        >>> print(f"Found {len(users)} users in {metrics.duration_ms:.2f}ms")
-    """
-    client = cls._get_client()
-    table = cls._get_table()
-
-    names: dict[str, str] = {}
-    values: dict[str, Any] = {}
-
-    filter_expr = None
-    if filter_condition is not None:
-        filter_expr = filter_condition.serialize(names, values)
-
-    attr_names = {v: k for k, v in names.items()}
-
-    use_consistent = consistent_read
-    if use_consistent is None:
-        use_consistent = getattr(cls.model_config, "consistent_read", False)
-
-    items, metrics = await client.async_parallel_scan(
+    items, metrics = await client.parallel_scan(
         table,
         total_segments,
         filter_expression=filter_expr,

--- a/python/pydynox/client/_batch.py
+++ b/python/pydynox/client/_batch.py
@@ -22,6 +22,9 @@ class BatchOperations:
         - Splitting requests to respect the 25-item limit per batch
         - Retrying unprocessed items with exponential backoff
         """
+        put_count = len(put_items) if put_items else 0
+        delete_count = len(delete_keys) if delete_keys else 0
+        self._acquire_wcu(float(put_count + delete_count))  # type: ignore[attr-defined]
         await self._client.batch_write(  # type: ignore[attr-defined]
             table,
             put_items or [],
@@ -42,6 +45,7 @@ class BatchOperations:
         - Retrying unprocessed keys with exponential backoff
         - Combining results from multiple requests
         """
+        self._acquire_rcu(float(len(keys)))  # type: ignore[attr-defined]
         return await self._client.batch_get(table, keys)  # type: ignore[attr-defined, no-any-return]
 
     # ========== BATCH WRITE (SYNC - with sync_ prefix) ==========

--- a/python/pydynox/client/_partiql.py
+++ b/python/pydynox/client/_partiql.py
@@ -13,16 +13,16 @@ _SLOW_QUERY_THRESHOLD_MS = 100.0
 class PartiqlOperations:
     """PartiQL statement execution."""
 
-    def execute_statement(
+    def sync_execute_statement(
         self,
         statement: str,
         parameters: list[Any] | None = None,
         consistent_read: bool = False,
         next_token: str | None = None,
     ) -> ListWithMetrics:
-        """Execute a PartiQL statement."""
+        """Execute a PartiQL statement (sync)."""
         self._acquire_rcu(1.0)  # type: ignore[attr-defined]
-        items, next_token_out, metrics = self._client.execute_statement(  # type: ignore[attr-defined]
+        items, next_token_out, metrics = self._client.sync_execute_statement(  # type: ignore[attr-defined]
             statement,
             parameters=parameters,
             consistent_read=consistent_read,
@@ -38,16 +38,16 @@ class PartiqlOperations:
             _log_warning("execute_statement", f"slow operation ({metrics.duration_ms:.1f}ms)")
         return ListWithMetrics(items, metrics, next_token_out)
 
-    async def async_execute_statement(
+    async def execute_statement(
         self,
         statement: str,
         parameters: list[Any] | None = None,
         consistent_read: bool = False,
         next_token: str | None = None,
     ) -> ListWithMetrics:
-        """Async version of execute_statement."""
+        """Execute a PartiQL statement (async)."""
         self._acquire_rcu(1.0)  # type: ignore[attr-defined]
-        result = await self._client.async_execute_statement(  # type: ignore[attr-defined]
+        result = await self._client.execute_statement(  # type: ignore[attr-defined]
             statement,
             parameters=parameters,
             consistent_read=consistent_read,

--- a/python/pydynox/client/_query.py
+++ b/python/pydynox/client/_query.py
@@ -10,7 +10,7 @@ from pydynox.query import AsyncQueryResult, QueryResult
 class QueryOperations:
     """Query operations."""
 
-    def query(
+    def sync_query(
         self,
         table: str,
         key_condition_expression: str,
@@ -25,7 +25,7 @@ class QueryOperations:
         last_evaluated_key: dict[str, Any] | None = None,
         consistent_read: bool = False,
     ) -> QueryResult:
-        """Query items from a DynamoDB table.
+        """Query items from a DynamoDB table (sync).
 
         Args:
             table: Table name.
@@ -61,7 +61,7 @@ class QueryOperations:
             consistent_read=consistent_read,
         )
 
-    def async_query(
+    def query(
         self,
         table: str,
         key_condition_expression: str,
@@ -76,7 +76,7 @@ class QueryOperations:
         last_evaluated_key: dict[str, Any] | None = None,
         consistent_read: bool = False,
     ) -> AsyncQueryResult:
-        """Async query items from a DynamoDB table.
+        """Query items from a DynamoDB table (async).
 
         Args:
             table: Table name.

--- a/python/pydynox/client/_scan.py
+++ b/python/pydynox/client/_scan.py
@@ -14,7 +14,7 @@ class ScanOperations:
 
     # ========== SCAN ==========
 
-    def scan(
+    def sync_scan(
         self,
         table: str,
         filter_expression: str | None = None,
@@ -29,7 +29,7 @@ class ScanOperations:
         segment: int | None = None,
         total_segments: int | None = None,
     ) -> ScanResult:
-        """Scan items from a DynamoDB table.
+        """Scan items from a DynamoDB table (sync).
 
         Args:
             table: Table name.
@@ -65,7 +65,7 @@ class ScanOperations:
             total_segments=total_segments,
         )
 
-    def async_scan(
+    def scan(
         self,
         table: str,
         filter_expression: str | None = None,
@@ -80,7 +80,7 @@ class ScanOperations:
         segment: int | None = None,
         total_segments: int | None = None,
     ) -> AsyncScanResult:
-        """Async scan items from a DynamoDB table.
+        """Scan items from a DynamoDB table (async).
 
         Args:
             table: Table name.
@@ -118,7 +118,7 @@ class ScanOperations:
 
     # ========== COUNT ==========
 
-    def count(
+    def sync_count(
         self,
         table: str,
         filter_expression: str | None = None,
@@ -127,8 +127,8 @@ class ScanOperations:
         index_name: str | None = None,
         consistent_read: bool = False,
     ) -> tuple[int, OperationMetrics]:
-        """Count items in a DynamoDB table."""
-        count, metrics = self._client.count(  # type: ignore[attr-defined]
+        """Count items in a DynamoDB table (sync)."""
+        count, metrics = self._client.sync_count(  # type: ignore[attr-defined]
             table,
             filter_expression=filter_expression,
             expression_attribute_names=expression_attribute_names,
@@ -139,7 +139,7 @@ class ScanOperations:
         _log_operation("count", table, metrics.duration_ms, consumed_rcu=metrics.consumed_rcu)
         return count, metrics
 
-    async def async_count(
+    async def count(
         self,
         table: str,
         filter_expression: str | None = None,
@@ -148,8 +148,8 @@ class ScanOperations:
         index_name: str | None = None,
         consistent_read: bool = False,
     ) -> tuple[int, OperationMetrics]:
-        """Async count items in a DynamoDB table."""
-        result = await self._client.async_count(  # type: ignore[attr-defined]
+        """Count items in a DynamoDB table (async)."""
+        result = await self._client.count(  # type: ignore[attr-defined]
             table,
             filter_expression=filter_expression,
             expression_attribute_names=expression_attribute_names,
@@ -164,7 +164,7 @@ class ScanOperations:
 
     # ========== PARALLEL SCAN ==========
 
-    def parallel_scan(
+    def sync_parallel_scan(
         self,
         table: str,
         total_segments: int,
@@ -174,7 +174,7 @@ class ScanOperations:
         expression_attribute_values: dict[str, Any] | None = None,
         consistent_read: bool = False,
     ) -> tuple[list[dict[str, Any]], OperationMetrics]:
-        """Parallel scan - runs multiple segment scans concurrently.
+        """Parallel scan - runs multiple segment scans concurrently (sync).
 
         Much faster than regular scan for large tables. Each segment is
         scanned in parallel using tokio tasks in Rust.
@@ -192,10 +192,10 @@ class ScanOperations:
             Tuple of (items, metrics) where items is a list of all scanned items.
 
         Example:
-            >>> items, metrics = client.parallel_scan("users", total_segments=4)
+            >>> items, metrics = client.sync_parallel_scan("users", total_segments=4)
             >>> print(f"Found {len(items)} items in {metrics.duration_ms:.2f}ms")
         """
-        items, metrics = self._client.parallel_scan(  # type: ignore[attr-defined]
+        items, metrics = self._client.sync_parallel_scan(  # type: ignore[attr-defined]
             table,
             total_segments,
             filter_expression=filter_expression,
@@ -209,7 +209,7 @@ class ScanOperations:
         )
         return items, metrics
 
-    async def async_parallel_scan(
+    async def parallel_scan(
         self,
         table: str,
         total_segments: int,
@@ -219,7 +219,7 @@ class ScanOperations:
         expression_attribute_values: dict[str, Any] | None = None,
         consistent_read: bool = False,
     ) -> tuple[list[dict[str, Any]], OperationMetrics]:
-        """Async parallel scan - runs multiple segment scans concurrently.
+        """Parallel scan - runs multiple segment scans concurrently (async).
 
         Much faster than regular scan for large tables. Each segment is
         scanned in parallel using tokio tasks in Rust.
@@ -237,10 +237,10 @@ class ScanOperations:
             Tuple of (items, metrics) where items is a list of all scanned items.
 
         Example:
-            >>> items, metrics = await client.async_parallel_scan("users", total_segments=4)
+            >>> items, metrics = await client.parallel_scan("users", total_segments=4)
             >>> print(f"Found {len(items)} items in {metrics.duration_ms:.2f}ms")
         """
-        result = await self._client.async_parallel_scan(  # type: ignore[attr-defined]
+        result = await self._client.parallel_scan(  # type: ignore[attr-defined]
             table,
             total_segments,
             filter_expression=filter_expression,

--- a/python/pydynox/model.py
+++ b/python/pydynox/model.py
@@ -6,34 +6,64 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydynox._internal._model._async import (
-    async_delete,
-    async_delete_by_key,
-    async_get,
-    async_save,
-    async_update,
-    async_update_by_key,
+    delete as async_delete,
+)
+from pydynox._internal._model._async import (
+    delete_by_key as async_delete_by_key,
+)
+from pydynox._internal._model._async import (
+    get as async_get,
+)
+from pydynox._internal._model._async import (
+    save as async_save,
+)
+from pydynox._internal._model._async import (
+    update as async_update,
+)
+from pydynox._internal._model._async import (
+    update_by_key as async_update_by_key,
 )
 from pydynox._internal._model._base import ModelBase, ModelMeta
 from pydynox._internal._model._batch import batch_get, sync_batch_get
 from pydynox._internal._model._crud import (
-    delete,
-    delete_by_key,
-    get,
-    save,
-    update,
-    update_by_key,
+    delete as sync_delete,
+)
+from pydynox._internal._model._crud import (
+    delete_by_key as sync_delete_by_key,
+)
+from pydynox._internal._model._crud import (
+    get as sync_get,
+)
+from pydynox._internal._model._crud import (
+    save as sync_save,
+)
+from pydynox._internal._model._crud import (
+    update as sync_update,
+)
+from pydynox._internal._model._crud import (
+    update_by_key as sync_update_by_key,
 )
 from pydynox._internal._model._query import (
-    async_count,
-    async_execute_statement,
-    async_parallel_scan,
-    async_query,
-    async_scan,
-    count,
-    execute_statement,
-    parallel_scan,
-    query,
-    scan,
+    count as async_count,
+)
+from pydynox._internal._model._query import (
+    execute_statement as async_execute_statement,
+)
+from pydynox._internal._model._query import (
+    parallel_scan as async_parallel_scan,
+)
+from pydynox._internal._model._query import (
+    query as async_query,
+)
+from pydynox._internal._model._query import (
+    scan as async_scan,
+)
+from pydynox._internal._model._query import (
+    sync_count,
+    sync_execute_statement,
+    sync_parallel_scan,
+    sync_query,
+    sync_scan,
 )
 from pydynox._internal._model._s3_helpers import (
     _delete_s3_files,
@@ -94,13 +124,13 @@ class Model(ModelBase, metaclass=ModelMeta):
     # ========== SYNC CRUD ==========
 
     @classmethod
-    def get(
+    def sync_get(
         cls: type[M],
         consistent_read: bool | None = None,
         as_dict: bool = False,
         **keys: Any,
     ) -> M | dict[str, Any] | None:
-        """Get an item from DynamoDB by its key.
+        """Get an item from DynamoDB by its key (sync).
 
         Args:
             consistent_read: Use strongly consistent read. Defaults to model_config value.
@@ -111,17 +141,14 @@ class Model(ModelBase, metaclass=ModelMeta):
             The model instance (or dict if as_dict=True) if found, None otherwise.
 
         Example:
-            >>> user = User.get(pk="USER#1", sk="PROFILE")
+            >>> user = User.sync_get(pk="USER#1", sk="PROFILE")
             >>> if user:
             ...     print(user.name)
-            >>>
-            >>> # Return as dict for better performance
-            >>> user_dict = User.get(pk="USER#1", sk="PROFILE", as_dict=True)
         """
-        return get(cls, consistent_read, as_dict, **keys)
+        return sync_get(cls, consistent_read, as_dict, **keys)
 
-    def save(self, condition: Condition | None = None, skip_hooks: bool | None = None) -> None:
-        """Save the model to DynamoDB.
+    def sync_save(self, condition: Condition | None = None, skip_hooks: bool | None = None) -> None:
+        """Save the model to DynamoDB (sync).
 
         Args:
             condition: Optional condition that must be true for the write.
@@ -133,15 +160,14 @@ class Model(ModelBase, metaclass=ModelMeta):
 
         Example:
             >>> user = User(pk="USER#1", sk="PROFILE", name="John")
-            >>> user.save()
-            >>>
-            >>> # With condition (prevent overwrite)
-            >>> user.save(condition=User.pk.not_exists())
+            >>> user.sync_save()
         """
-        save(self, condition, skip_hooks)
+        sync_save(self, condition, skip_hooks)
 
-    def delete(self, condition: Condition | None = None, skip_hooks: bool | None = None) -> None:
-        """Delete the model from DynamoDB.
+    def sync_delete(
+        self, condition: Condition | None = None, skip_hooks: bool | None = None
+    ) -> None:
+        """Delete the model from DynamoDB (sync).
 
         Args:
             condition: Optional condition that must be true for the delete.
@@ -151,22 +177,19 @@ class Model(ModelBase, metaclass=ModelMeta):
             ConditionalCheckFailedException: If the condition is not met.
 
         Example:
-            >>> user = User.get(pk="USER#1", sk="PROFILE")
-            >>> user.delete()
-            >>>
-            >>> # With condition
-            >>> user.delete(condition=User.status == "inactive")
+            >>> user = User.sync_get(pk="USER#1", sk="PROFILE")
+            >>> user.sync_delete()
         """
-        delete(self, condition, skip_hooks)
+        sync_delete(self, condition, skip_hooks)
 
-    def update(
+    def sync_update(
         self,
         atomic: list[AtomicOp] | None = None,
         condition: Condition | None = None,
         skip_hooks: bool | None = None,
         **kwargs: Any,
     ) -> None:
-        """Update specific attributes on the model.
+        """Update specific attributes on the model (sync).
 
         Args:
             atomic: List of atomic operations (SET, ADD, REMOVE, etc).
@@ -175,43 +198,36 @@ class Model(ModelBase, metaclass=ModelMeta):
             **kwargs: Attribute names and new values to update.
 
         Example:
-            >>> user = User.get(pk="USER#1", sk="PROFILE")
-            >>>
-            >>> # Simple update
-            >>> user.update(name="Jane")
-            >>>
-            >>> # Atomic operations
-            >>> from pydynox.atomic import AtomicOp
-            >>> user.update(atomic=[AtomicOp.add("login_count", 1)])
+            >>> user = User.sync_get(pk="USER#1", sk="PROFILE")
+            >>> user.sync_update(name="Jane")
         """
-        update(self, atomic, condition, skip_hooks, **kwargs)
+        sync_update(self, atomic, condition, skip_hooks, **kwargs)
 
     @classmethod
-    def update_by_key(cls: type[M], condition: Condition | None = None, **kwargs: Any) -> None:
-        """Update an item by key without fetching it first.
+    def sync_update_by_key(cls: type[M], condition: Condition | None = None, **kwargs: Any) -> None:
+        """Update an item by key without fetching it first (sync).
 
         Args:
             condition: Optional condition that must be true for the update.
             **kwargs: Must include key attributes plus attributes to update.
 
         Example:
-            >>> # Update without fetching
-            >>> User.update_by_key(pk="USER#1", sk="PROFILE", name="Jane")
+            >>> User.sync_update_by_key(pk="USER#1", sk="PROFILE", name="Jane")
         """
-        update_by_key(cls, condition, **kwargs)
+        sync_update_by_key(cls, condition, **kwargs)
 
     @classmethod
-    def delete_by_key(cls: type[M], condition: Condition | None = None, **kwargs: Any) -> None:
-        """Delete an item by key without fetching it first.
+    def sync_delete_by_key(cls: type[M], condition: Condition | None = None, **kwargs: Any) -> None:
+        """Delete an item by key without fetching it first (sync).
 
         Args:
             condition: Optional condition that must be true for the delete.
             **kwargs: The key attributes (hash_key and optional range_key).
 
         Example:
-            >>> User.delete_by_key(pk="USER#1", sk="PROFILE")
+            >>> User.sync_delete_by_key(pk="USER#1", sk="PROFILE")
         """
-        delete_by_key(cls, condition, **kwargs)
+        sync_delete_by_key(cls, condition, **kwargs)
 
     @classmethod
     def sync_batch_get(
@@ -272,85 +288,289 @@ class Model(ModelBase, metaclass=ModelMeta):
         """
         return await batch_get(cls, keys, consistent_read, as_dict)
 
-    # ========== ASYNC CRUD ==========
+    # ========== ASYNC CRUD (default) ==========
 
     @classmethod
-    async def async_get(
+    async def get(
         cls: type[M],
         consistent_read: bool | None = None,
         as_dict: bool = False,
         **keys: Any,
     ) -> M | dict[str, Any] | None:
-        """Async version of get.
+        """Get an item from DynamoDB by its key (async, default).
+
+        Args:
+            consistent_read: Use strongly consistent read. Defaults to model_config value.
+            as_dict: If True, return dict instead of Model instance.
+            **keys: The key attributes (hash_key and optional range_key).
+
+        Returns:
+            The model instance (or dict if as_dict=True) if found, None otherwise.
 
         Example:
-            >>> user = await User.async_get(pk="USER#1", sk="PROFILE")
-            >>>
-            >>> # Return as dict for better performance
-            >>> user_dict = await User.async_get(pk="USER#1", as_dict=True)
+            >>> user = await User.get(pk="USER#1", sk="PROFILE")
+            >>> if user:
+            ...     print(user.name)
         """
         return await async_get(cls, consistent_read, as_dict, **keys)
 
-    async def async_save(
+    async def save(
         self, condition: Condition | None = None, skip_hooks: bool | None = None
     ) -> None:
-        """Async version of save.
+        """Save the model to DynamoDB (async, default).
+
+        Args:
+            condition: Optional condition that must be true for the write.
+            skip_hooks: If True, skip before/after save hooks.
+
+        Raises:
+            ConditionalCheckFailedException: If the condition is not met.
+            ItemTooLargeException: If item exceeds max_size in model_config.
 
         Example:
             >>> user = User(pk="USER#1", sk="PROFILE", name="John")
-            >>> await user.async_save()
+            >>> await user.save()
         """
         await async_save(self, condition, skip_hooks)
 
-    async def async_delete(
+    async def delete(
         self, condition: Condition | None = None, skip_hooks: bool | None = None
     ) -> None:
-        """Async version of delete.
+        """Delete the model from DynamoDB (async, default).
+
+        Args:
+            condition: Optional condition that must be true for the delete.
+            skip_hooks: If True, skip before/after delete hooks.
+
+        Raises:
+            ConditionalCheckFailedException: If the condition is not met.
 
         Example:
-            >>> user = await User.async_get(pk="USER#1", sk="PROFILE")
-            >>> await user.async_delete()
+            >>> user = await User.get(pk="USER#1", sk="PROFILE")
+            >>> await user.delete()
         """
         await async_delete(self, condition, skip_hooks)
 
-    async def async_update(
+    async def update(
         self,
         atomic: list[AtomicOp] | None = None,
         condition: Condition | None = None,
         skip_hooks: bool | None = None,
         **kwargs: Any,
     ) -> None:
-        """Async version of update.
+        """Update specific attributes on the model (async, default).
+
+        Args:
+            atomic: List of atomic operations (SET, ADD, REMOVE, etc).
+            condition: Optional condition that must be true for the update.
+            skip_hooks: If True, skip before/after update hooks.
+            **kwargs: Attribute names and new values to update.
 
         Example:
-            >>> user = await User.async_get(pk="USER#1", sk="PROFILE")
-            >>> await user.async_update(name="Jane")
+            >>> user = await User.get(pk="USER#1", sk="PROFILE")
+            >>> await user.update(name="Jane")
         """
         await async_update(self, atomic, condition, skip_hooks, **kwargs)
 
     @classmethod
-    async def async_update_by_key(
+    async def update_by_key(
         cls: type[M], condition: Condition | None = None, **kwargs: Any
     ) -> None:
-        """Async version of update_by_key.
+        """Update an item by key without fetching it first (async, default).
+
+        Args:
+            condition: Optional condition that must be true for the update.
+            **kwargs: Must include key attributes plus attributes to update.
 
         Example:
-            >>> await User.async_update_by_key(pk="USER#1", sk="PROFILE", name="Jane")
+            >>> await User.update_by_key(pk="USER#1", sk="PROFILE", name="Jane")
         """
         await async_update_by_key(cls, condition, **kwargs)
 
     @classmethod
-    async def async_delete_by_key(
+    async def delete_by_key(
         cls: type[M], condition: Condition | None = None, **kwargs: Any
     ) -> None:
-        """Async version of delete_by_key.
+        """Delete an item by key without fetching it first (async, default).
+
+        Args:
+            condition: Optional condition that must be true for the delete.
+            **kwargs: The key attributes (hash_key and optional range_key).
 
         Example:
-            >>> await User.async_delete_by_key(pk="USER#1", sk="PROFILE")
+            >>> await User.delete_by_key(pk="USER#1", sk="PROFILE")
         """
         await async_delete_by_key(cls, condition, **kwargs)
 
-    # ========== QUERY/SCAN ==========
+    # ========== SYNC QUERY/SCAN ==========
+
+    @classmethod
+    def sync_query(
+        cls: type[M],
+        hash_key: Any,
+        range_key_condition: Condition | None = None,
+        filter_condition: Condition | None = None,
+        limit: int | None = None,
+        page_size: int | None = None,
+        scan_index_forward: bool = True,
+        consistent_read: bool | None = None,
+        last_evaluated_key: dict[str, Any] | None = None,
+        as_dict: bool = False,
+        fields: list[str] | None = None,
+    ) -> ModelQueryResult[M]:
+        """Query items by hash key with optional conditions (sync).
+
+        Args:
+            hash_key: The hash key value to query.
+            range_key_condition: Optional condition on range key.
+            filter_condition: Optional filter applied after query.
+            limit: Max total items to return across all pages.
+            page_size: Items per page (passed as Limit to DynamoDB).
+            scan_index_forward: True for ascending, False for descending.
+            consistent_read: Use strongly consistent read.
+            last_evaluated_key: Start key for pagination.
+            as_dict: If True, return dicts instead of Model instances.
+            fields: List of fields to return. Saves RCU.
+
+        Returns:
+            Iterable result that auto-paginates.
+
+        Example:
+            >>> for order in Order.sync_query(hash_key="USER#1"):
+            ...     print(order.order_id)
+        """
+        return sync_query(
+            cls,
+            hash_key=hash_key,
+            range_key_condition=range_key_condition,
+            filter_condition=filter_condition,
+            limit=limit,
+            page_size=page_size,
+            scan_index_forward=scan_index_forward,
+            consistent_read=consistent_read,
+            last_evaluated_key=last_evaluated_key,
+            as_dict=as_dict,
+            fields=fields,
+        )
+
+    @classmethod
+    def sync_scan(
+        cls: type[M],
+        filter_condition: Condition | None = None,
+        limit: int | None = None,
+        page_size: int | None = None,
+        consistent_read: bool | None = None,
+        last_evaluated_key: dict[str, Any] | None = None,
+        segment: int | None = None,
+        total_segments: int | None = None,
+        as_dict: bool = False,
+        fields: list[str] | None = None,
+    ) -> ModelScanResult[M]:
+        """Scan all items in the table (sync).
+
+        Args:
+            filter_condition: Optional filter applied after scan.
+            limit: Max total items to return across all pages.
+            page_size: Items per page (passed as Limit to DynamoDB).
+            consistent_read: Use strongly consistent read.
+            last_evaluated_key: Start key for pagination.
+            segment: Segment number for parallel scan.
+            total_segments: Total segments for parallel scan.
+            as_dict: If True, return dicts instead of Model instances.
+            fields: List of fields to return. Saves RCU.
+
+        Returns:
+            Iterable result that auto-paginates.
+
+        Example:
+            >>> for user in User.sync_scan():
+            ...     print(user.name)
+        """
+        return sync_scan(
+            cls,
+            filter_condition=filter_condition,
+            limit=limit,
+            page_size=page_size,
+            consistent_read=consistent_read,
+            last_evaluated_key=last_evaluated_key,
+            segment=segment,
+            total_segments=total_segments,
+            as_dict=as_dict,
+            fields=fields,
+        )
+
+    @classmethod
+    def sync_count(
+        cls: type[M],
+        filter_condition: Condition | None = None,
+        consistent_read: bool | None = None,
+    ) -> tuple[int, OperationMetrics]:
+        """Count items in the table (sync).
+
+        Args:
+            filter_condition: Optional filter to count matching items.
+            consistent_read: Use strongly consistent read.
+
+        Returns:
+            Tuple of (count, metrics).
+
+        Example:
+            >>> total, metrics = User.sync_count()
+            >>> print(f"Total users: {total}")
+        """
+        return sync_count(cls, filter_condition, consistent_read)
+
+    @classmethod
+    def sync_execute_statement(
+        cls: type[M],
+        statement: str,
+        parameters: list[Any] | None = None,
+        consistent_read: bool = False,
+    ) -> list[M]:
+        """Execute a PartiQL statement (sync).
+
+        Args:
+            statement: PartiQL SELECT statement.
+            parameters: Optional parameters for the statement.
+            consistent_read: Use strongly consistent read.
+
+        Returns:
+            List of model instances.
+
+        Example:
+            >>> users = User.sync_execute_statement(
+            ...     "SELECT * FROM users WHERE pk = ?",
+            ...     parameters=["USER#1"]
+            ... )
+        """
+        return sync_execute_statement(cls, statement, parameters, consistent_read)
+
+    @classmethod
+    def sync_parallel_scan(
+        cls: type[M],
+        total_segments: int,
+        filter_condition: Condition | None = None,
+        consistent_read: bool | None = None,
+        as_dict: bool = False,
+    ) -> tuple[list[M] | list[dict[str, Any]], OperationMetrics]:
+        """Parallel scan - runs multiple segment scans concurrently (sync).
+
+        Args:
+            total_segments: Number of parallel segments (workers).
+            filter_condition: Optional filter applied after scan.
+            consistent_read: Use strongly consistent read.
+            as_dict: If True, return dicts instead of Model instances.
+
+        Returns:
+            Tuple of (list of items, combined metrics).
+
+        Example:
+            >>> users, metrics = User.sync_parallel_scan(total_segments=4)
+            >>> print(f"Found {len(users)} users")
+        """
+        return sync_parallel_scan(cls, total_segments, filter_condition, consistent_read, as_dict)
+
+    # ========== ASYNC QUERY/SCAN (default) ==========
 
     @classmethod
     def query(
@@ -365,8 +585,8 @@ class Model(ModelBase, metaclass=ModelMeta):
         last_evaluated_key: dict[str, Any] | None = None,
         as_dict: bool = False,
         fields: list[str] | None = None,
-    ) -> ModelQueryResult[M]:
-        """Query items by hash key with optional conditions.
+    ) -> AsyncModelQueryResult[M]:
+        """Query items by hash key with optional conditions (async, default).
 
         Args:
             hash_key: The hash key value to query.
@@ -378,31 +598,16 @@ class Model(ModelBase, metaclass=ModelMeta):
             consistent_read: Use strongly consistent read.
             last_evaluated_key: Start key for pagination.
             as_dict: If True, return dicts instead of Model instances.
-            fields: List of fields to return. Saves RCU by fetching only what you need.
+            fields: List of fields to return. Saves RCU.
 
         Returns:
-            Iterable result that auto-paginates.
+            Async iterable result that auto-paginates.
 
         Example:
-            >>> # Get all orders for a user
-            >>> for order in Order.query(hash_key="USER#1"):
+            >>> async for order in Order.query(hash_key="USER#1"):
             ...     print(order.order_id)
-            >>>
-            >>> # With range key condition
-            >>> recent = Order.query(
-            ...     hash_key="USER#1",
-            ...     range_key_condition=Order.sk.begins_with("ORDER#2024")
-            ... )
-            >>>
-            >>> # Return as dicts for better performance
-            >>> for order in Order.query(hash_key="USER#1", as_dict=True):
-            ...     print(order["order_id"])
-            >>>
-            >>> # Fetch only specific fields (saves RCU)
-            >>> for order in Order.query(hash_key="USER#1", fields=["order_id", "total"]):
-            ...     print(order.order_id, order.total)
         """
-        return query(
+        return async_query(
             cls,
             hash_key=hash_key,
             range_key_condition=range_key_condition,
@@ -428,8 +633,8 @@ class Model(ModelBase, metaclass=ModelMeta):
         total_segments: int | None = None,
         as_dict: bool = False,
         fields: list[str] | None = None,
-    ) -> ModelScanResult[M]:
-        """Scan all items in the table.
+    ) -> AsyncModelScanResult[M]:
+        """Scan all items in the table (async, default).
 
         Args:
             filter_condition: Optional filter applied after scan.
@@ -440,157 +645,14 @@ class Model(ModelBase, metaclass=ModelMeta):
             segment: Segment number for parallel scan.
             total_segments: Total segments for parallel scan.
             as_dict: If True, return dicts instead of Model instances.
-            fields: List of fields to return. Saves RCU by fetching only what you need.
+            fields: List of fields to return. Saves RCU.
 
         Returns:
-            Iterable result that auto-paginates.
+            Async iterable result that auto-paginates.
 
         Example:
-            >>> # Scan all users
-            >>> for user in User.scan():
+            >>> async for user in User.scan():
             ...     print(user.name)
-            >>>
-            >>> # With filter
-            >>> active = User.scan(filter_condition=User.status == "active")
-            >>>
-            >>> # Return as dicts for better performance
-            >>> for user in User.scan(as_dict=True):
-            ...     print(user["name"])
-            >>>
-            >>> # Fetch only specific fields (saves RCU)
-            >>> for user in User.scan(fields=["pk", "name"]):
-            ...     print(user.pk, user.name)
-        """
-        return scan(
-            cls,
-            filter_condition=filter_condition,
-            limit=limit,
-            page_size=page_size,
-            consistent_read=consistent_read,
-            last_evaluated_key=last_evaluated_key,
-            segment=segment,
-            total_segments=total_segments,
-            as_dict=as_dict,
-            fields=fields,
-        )
-
-    @classmethod
-    def count(
-        cls: type[M],
-        filter_condition: Condition | None = None,
-        consistent_read: bool | None = None,
-    ) -> tuple[int, OperationMetrics]:
-        """Count items in the table.
-
-        Args:
-            filter_condition: Optional filter to count matching items.
-            consistent_read: Use strongly consistent read.
-
-        Returns:
-            Tuple of (count, metrics).
-
-        Example:
-            >>> total, metrics = User.count()
-            >>> print(f"Total users: {total}")
-            >>>
-            >>> # Count with filter
-            >>> active, _ = User.count(filter_condition=User.status == "active")
-        """
-        return count(cls, filter_condition, consistent_read)
-
-    @classmethod
-    def execute_statement(
-        cls: type[M],
-        statement: str,
-        parameters: list[Any] | None = None,
-        consistent_read: bool = False,
-    ) -> list[M]:
-        """Execute a PartiQL statement and return typed model instances.
-
-        Args:
-            statement: PartiQL SELECT statement.
-            parameters: Optional parameters for the statement.
-            consistent_read: Use strongly consistent read.
-
-        Returns:
-            List of model instances.
-
-        Example:
-            >>> users = User.execute_statement(
-            ...     "SELECT * FROM users WHERE pk = ?",
-            ...     parameters=["USER#1"]
-            ... )
-        """
-        return execute_statement(cls, statement, parameters, consistent_read)
-
-    @classmethod
-    def async_query(
-        cls: type[M],
-        hash_key: Any,
-        range_key_condition: Condition | None = None,
-        filter_condition: Condition | None = None,
-        limit: int | None = None,
-        page_size: int | None = None,
-        scan_index_forward: bool = True,
-        consistent_read: bool | None = None,
-        last_evaluated_key: dict[str, Any] | None = None,
-        as_dict: bool = False,
-        fields: list[str] | None = None,
-    ) -> AsyncModelQueryResult[M]:
-        """Async version of query.
-
-        Example:
-            >>> async for order in Order.async_query(hash_key="USER#1"):
-            ...     print(order.order_id)
-            >>>
-            >>> # Return as dicts for better performance
-            >>> async for order in Order.async_query(hash_key="USER#1", as_dict=True):
-            ...     print(order["order_id"])
-            >>>
-            >>> # Fetch only specific fields (saves RCU)
-            >>> async for order in Order.async_query(hash_key="USER#1", fields=["order_id"]):
-            ...     print(order.order_id)
-        """
-        return async_query(
-            cls,
-            hash_key=hash_key,
-            range_key_condition=range_key_condition,
-            filter_condition=filter_condition,
-            limit=limit,
-            page_size=page_size,
-            scan_index_forward=scan_index_forward,
-            consistent_read=consistent_read,
-            last_evaluated_key=last_evaluated_key,
-            as_dict=as_dict,
-            fields=fields,
-        )
-
-    @classmethod
-    def async_scan(
-        cls: type[M],
-        filter_condition: Condition | None = None,
-        limit: int | None = None,
-        page_size: int | None = None,
-        consistent_read: bool | None = None,
-        last_evaluated_key: dict[str, Any] | None = None,
-        segment: int | None = None,
-        total_segments: int | None = None,
-        as_dict: bool = False,
-        fields: list[str] | None = None,
-    ) -> AsyncModelScanResult[M]:
-        """Async version of scan.
-
-        Example:
-            >>> async for user in User.async_scan():
-            ...     print(user.name)
-            >>>
-            >>> # Return as dicts for better performance
-            >>> async for user in User.async_scan(as_dict=True):
-            ...     print(user["name"])
-            >>>
-            >>> # Fetch only specific fields (saves RCU)
-            >>> async for user in User.async_scan(fields=["pk", "name"]):
-            ...     print(user.pk, user.name)
         """
         return async_scan(
             cls,
@@ -606,29 +668,45 @@ class Model(ModelBase, metaclass=ModelMeta):
         )
 
     @classmethod
-    async def async_count(
+    async def count(
         cls: type[M],
         filter_condition: Condition | None = None,
         consistent_read: bool | None = None,
     ) -> tuple[int, OperationMetrics]:
-        """Async version of count.
+        """Count items in the table (async, default).
+
+        Args:
+            filter_condition: Optional filter to count matching items.
+            consistent_read: Use strongly consistent read.
+
+        Returns:
+            Tuple of (count, metrics).
 
         Example:
-            >>> total, metrics = await User.async_count()
+            >>> total, metrics = await User.count()
+            >>> print(f"Total users: {total}")
         """
         return await async_count(cls, filter_condition, consistent_read)
 
     @classmethod
-    async def async_execute_statement(
+    async def execute_statement(
         cls: type[M],
         statement: str,
         parameters: list[Any] | None = None,
         consistent_read: bool = False,
     ) -> list[M]:
-        """Async version of execute_statement.
+        """Execute a PartiQL statement (async, default).
+
+        Args:
+            statement: PartiQL SELECT statement.
+            parameters: Optional parameters for the statement.
+            consistent_read: Use strongly consistent read.
+
+        Returns:
+            List of model instances.
 
         Example:
-            >>> users = await User.async_execute_statement(
+            >>> users = await User.execute_statement(
             ...     "SELECT * FROM users WHERE pk = ?",
             ...     parameters=["USER#1"]
             ... )
@@ -636,14 +714,14 @@ class Model(ModelBase, metaclass=ModelMeta):
         return await async_execute_statement(cls, statement, parameters, consistent_read)
 
     @classmethod
-    def parallel_scan(
+    async def parallel_scan(
         cls: type[M],
         total_segments: int,
         filter_condition: Condition | None = None,
         consistent_read: bool | None = None,
         as_dict: bool = False,
     ) -> tuple[list[M] | list[dict[str, Any]], OperationMetrics]:
-        """Parallel scan - runs multiple segment scans concurrently.
+        """Parallel scan - runs multiple segment scans concurrently (async, default).
 
         Args:
             total_segments: Number of parallel segments (workers).
@@ -655,30 +733,8 @@ class Model(ModelBase, metaclass=ModelMeta):
             Tuple of (list of items, combined metrics).
 
         Example:
-            >>> # Scan with 4 parallel workers
-            >>> users, metrics = User.parallel_scan(total_segments=4)
+            >>> users, metrics = await User.parallel_scan(total_segments=4)
             >>> print(f"Found {len(users)} users")
-            >>>
-            >>> # Return as dicts for better performance
-            >>> users, metrics = User.parallel_scan(total_segments=4, as_dict=True)
-        """
-        return parallel_scan(cls, total_segments, filter_condition, consistent_read, as_dict)
-
-    @classmethod
-    async def async_parallel_scan(
-        cls: type[M],
-        total_segments: int,
-        filter_condition: Condition | None = None,
-        consistent_read: bool | None = None,
-        as_dict: bool = False,
-    ) -> tuple[list[M] | list[dict[str, Any]], OperationMetrics]:
-        """Async parallel scan - runs multiple segment scans concurrently.
-
-        Example:
-            >>> users, metrics = await User.async_parallel_scan(total_segments=4)
-            >>>
-            >>> # Return as dicts for better performance
-            >>> users, metrics = await User.async_parallel_scan(total_segments=4, as_dict=True)
         """
         return await async_parallel_scan(
             cls, total_segments, filter_condition, consistent_read, as_dict

--- a/python/pydynox/pydynox_core.pyi
+++ b/python/pydynox/pydynox_core.pyi
@@ -81,8 +81,36 @@ class DynamoDBClient:
         scan_index_forward: bool | None = None,
         index_name: str | None = None,
         consistent_read: bool = False,
+    ) -> Coroutine[Any, Any, dict[str, Any]]: ...
+    def sync_query_page(
+        self,
+        table: str,
+        key_condition_expression: str,
+        filter_expression: str | None = None,
+        projection_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        limit: int | None = None,
+        exclusive_start_key: dict[str, Any] | None = None,
+        scan_index_forward: bool | None = None,
+        index_name: str | None = None,
+        consistent_read: bool = False,
     ) -> tuple[list[dict[str, Any]], dict[str, Any] | None, OperationMetrics]: ...
     def scan_page(
+        self,
+        table: str,
+        filter_expression: str | None = None,
+        projection_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        limit: int | None = None,
+        exclusive_start_key: dict[str, Any] | None = None,
+        index_name: str | None = None,
+        consistent_read: bool = False,
+        segment: int | None = None,
+        total_segments: int | None = None,
+    ) -> Coroutine[Any, Any, dict[str, Any]]: ...
+    def sync_scan_page(
         self,
         table: str,
         filter_expression: str | None = None,

--- a/python/pydynox/query.py
+++ b/python/pydynox/query.py
@@ -133,7 +133,7 @@ class QueryResult:
         # Use page_size if set, otherwise use limit for DynamoDB Limit parameter
         dynamo_limit = self._page_size if self._page_size is not None else self._limit
 
-        items, self._last_evaluated_key, self._metrics = self._client.query_page(
+        items, self._last_evaluated_key, self._metrics = self._client.sync_query_page(
             self._table,
             self._key_condition_expression,
             filter_expression=self._filter_expression,
@@ -275,7 +275,7 @@ class AsyncQueryResult:
         # Use page_size if set, otherwise use limit for DynamoDB Limit parameter
         dynamo_limit = self._page_size if self._page_size is not None else self._limit
 
-        result = await self._client.async_query_page(
+        result = await self._client.query_page(
             self._table,
             self._key_condition_expression,
             filter_expression=self._filter_expression,
@@ -428,7 +428,7 @@ class ScanResult:
         # Use page_size if set, otherwise use limit for DynamoDB Limit parameter
         dynamo_limit = self._page_size if self._page_size is not None else self._limit
 
-        items, self._last_evaluated_key, self._metrics = self._client.scan_page(
+        items, self._last_evaluated_key, self._metrics = self._client.sync_scan_page(
             self._table,
             filter_expression=self._filter_expression,
             projection_expression=self._projection_expression,
@@ -566,7 +566,7 @@ class AsyncScanResult:
         # Use page_size if set, otherwise use limit for DynamoDB Limit parameter
         dynamo_limit = self._page_size if self._page_size is not None else self._limit
 
-        result = await self._client.async_scan_page(
+        result = await self._client.scan_page(
             self._table,
             filter_expression=self._filter_expression,
             projection_expression=self._projection_expression,

--- a/src/basic_operations/delete.rs
+++ b/src/basic_operations/delete.rs
@@ -146,7 +146,7 @@ fn extract_item_from_delete_error(
 
 /// Sync delete_item - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn delete_item(
+pub fn sync_delete_item(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -175,9 +175,9 @@ pub fn delete_item(
     }
 }
 
-/// Async delete_item - returns a Python awaitable.
+/// Async delete_item - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_delete_item<'py>(
+pub fn delete_item<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,

--- a/src/basic_operations/get.rs
+++ b/src/basic_operations/get.rs
@@ -108,7 +108,7 @@ pub async fn execute_get_item(
 
 /// Sync get_item - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn get_item(
+pub fn sync_get_item(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -145,9 +145,9 @@ pub fn get_item(
     }
 }
 
-/// Async get_item - returns a Python awaitable.
+/// Async get_item - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_get_item<'py>(
+pub fn get_item<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,

--- a/src/basic_operations/mod.rs
+++ b/src/basic_operations/mod.rs
@@ -8,6 +8,8 @@
 //! - `query` - Query items by key condition
 //! - `scan` - Scan all items in a table
 //! - `partiql` - PartiQL statement execution
+//!
+//! All operations are async by default. Sync versions have `sync_` prefix.
 
 mod delete;
 mod get;
@@ -17,7 +19,7 @@ mod query;
 mod scan;
 mod update_op;
 
-// Re-export sync operations
+// Re-export async operations (default, no prefix)
 pub use delete::delete_item;
 pub use get::get_item;
 pub use partiql::execute_statement;
@@ -26,11 +28,11 @@ pub use query::query;
 pub use scan::{count, parallel_scan, scan};
 pub use update_op::update_item;
 
-// Re-export async operations
-pub use delete::async_delete_item;
-pub use get::async_get_item;
-pub use partiql::async_execute_statement;
-pub use put::async_put_item;
-pub use query::async_query;
-pub use scan::{async_count, async_parallel_scan, async_scan};
-pub use update_op::async_update_item;
+// Re-export sync operations (with sync_ prefix)
+pub use delete::sync_delete_item;
+pub use get::sync_get_item;
+pub use partiql::sync_execute_statement;
+pub use put::sync_put_item;
+pub use query::sync_query;
+pub use scan::{sync_count, sync_parallel_scan, sync_scan};
+pub use update_op::sync_update_item;

--- a/src/basic_operations/partiql.rs
+++ b/src/basic_operations/partiql.rs
@@ -87,7 +87,7 @@ fn convert_parameters(py: Python<'_>, params: &Bound<'_, PyList>) -> PyResult<Ve
 
 /// Sync execute_statement - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn execute_statement(
+pub fn sync_execute_statement(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -122,9 +122,9 @@ pub fn execute_statement(
     }
 }
 
-/// Async execute_statement - returns a Python awaitable.
+/// Async execute_statement - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_execute_statement<'py>(
+pub fn execute_statement<'py>(
     py: Python<'py>,
     client: Client,
     statement: String,

--- a/src/basic_operations/put.rs
+++ b/src/basic_operations/put.rs
@@ -143,7 +143,7 @@ fn extract_item_from_put_error(
 
 /// Sync put_item - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn put_item(
+pub fn sync_put_item(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -172,9 +172,9 @@ pub fn put_item(
     }
 }
 
-/// Async put_item - returns a Python awaitable.
+/// Async put_item - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_put_item<'py>(
+pub fn put_item<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,

--- a/src/basic_operations/query.rs
+++ b/src/basic_operations/query.rs
@@ -202,7 +202,7 @@ fn raw_to_py_result(py: Python<'_>, raw: RawQueryResult) -> PyResult<QueryResult
 
 /// Sync query - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn query(
+pub fn sync_query(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -241,9 +241,9 @@ pub fn query(
     }
 }
 
-/// Async query - returns a Python awaitable.
+/// Async query - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_query<'py>(
+pub fn query<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,

--- a/src/basic_operations/scan.rs
+++ b/src/basic_operations/scan.rs
@@ -202,7 +202,7 @@ fn raw_to_py_result(py: Python<'_>, raw: RawScanResult) -> PyResult<ScanResult> 
 
 /// Sync scan - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn scan(
+pub fn sync_scan(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -241,9 +241,9 @@ pub fn scan(
     }
 }
 
-/// Async scan - returns a Python awaitable.
+/// Async scan - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_scan<'py>(
+pub fn scan<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,
@@ -440,7 +440,7 @@ pub async fn execute_count(
 
 /// Sync count - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn count(
+pub fn sync_count(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -469,9 +469,9 @@ pub fn count(
     }
 }
 
-/// Async count - returns a Python awaitable.
+/// Async count - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_count<'py>(
+pub fn count<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,
@@ -675,7 +675,7 @@ pub async fn execute_parallel_scan(
 
 /// Sync parallel scan - blocks until all segments complete.
 #[allow(clippy::too_many_arguments)]
-pub fn parallel_scan(
+pub fn sync_parallel_scan(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -713,9 +713,9 @@ pub fn parallel_scan(
     }
 }
 
-/// Async parallel scan - returns a Python awaitable.
+/// Async parallel scan - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_parallel_scan<'py>(
+pub fn parallel_scan<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,

--- a/src/basic_operations/update_op.rs
+++ b/src/basic_operations/update_op.rs
@@ -162,7 +162,7 @@ fn extract_item_from_update_error(
 
 /// Sync update_item - blocks until complete.
 #[allow(clippy::too_many_arguments)]
-pub fn update_item(
+pub fn sync_update_item(
     py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
@@ -195,9 +195,9 @@ pub fn update_item(
     }
 }
 
-/// Async update_item - returns a Python awaitable.
+/// Async update_item - returns a Python awaitable (default).
 #[allow(clippy::too_many_arguments)]
-pub fn async_update_item<'py>(
+pub fn update_item<'py>(
     py: Python<'py>,
     client: Client,
     table: &str,

--- a/src/client.rs
+++ b/src/client.rs
@@ -233,10 +233,35 @@ impl DynamoDBClient {
             Err(_) => Ok(false),
         }
     }
-    /// Put an item into a DynamoDB table.
+    /// Put an item into a DynamoDB table. Returns a Python awaitable.
     #[pyo3(signature = (table, item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
     #[allow(clippy::too_many_arguments)]
-    pub fn put_item(
+    pub fn put_item<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        item: &Bound<'_, PyDict>,
+        condition_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        basic_operations::put_item(
+            py,
+            self.client.clone(),
+            table,
+            item,
+            condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            return_values_on_condition_check_failure,
+        )
+    }
+
+    /// Sync put_item - blocks until complete.
+    #[pyo3(signature = (table, item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sync_put_item(
         &self,
         py: Python<'_>,
         table: &str,
@@ -246,7 +271,7 @@ impl DynamoDBClient {
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
         return_values_on_condition_check_failure: bool,
     ) -> PyResult<OperationMetrics> {
-        basic_operations::put_item(
+        basic_operations::sync_put_item(
             py,
             &self.client,
             &self.runtime,
@@ -259,7 +284,7 @@ impl DynamoDBClient {
         )
     }
 
-    /// Get an item from a DynamoDB table by its key.
+    /// Get an item from a DynamoDB table by its key. Returns a Python awaitable.
     ///
     /// # Arguments
     ///
@@ -271,9 +296,31 @@ impl DynamoDBClient {
     ///
     /// # Returns
     ///
-    /// Tuple of (item or None, metrics).
+    /// A Python awaitable that resolves to dict with item (or None) and metrics.
     #[pyo3(signature = (table, key, consistent_read=false, projection=None, expression_attribute_names=None))]
-    pub fn get_item(
+    pub fn get_item<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        key: &Bound<'_, PyDict>,
+        consistent_read: bool,
+        projection: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        basic_operations::get_item(
+            py,
+            self.client.clone(),
+            table,
+            key,
+            consistent_read,
+            projection,
+            expression_attribute_names,
+        )
+    }
+
+    /// Sync get_item - blocks until complete.
+    #[pyo3(signature = (table, key, consistent_read=false, projection=None, expression_attribute_names=None))]
+    pub fn sync_get_item(
         &self,
         py: Python<'_>,
         table: &str,
@@ -282,7 +329,7 @@ impl DynamoDBClient {
         projection: Option<String>,
         expression_attribute_names: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<(Option<Py<PyAny>>, OperationMetrics)> {
-        basic_operations::get_item(
+        basic_operations::sync_get_item(
             py,
             &self.client,
             &self.runtime,
@@ -294,10 +341,35 @@ impl DynamoDBClient {
         )
     }
 
-    /// Delete an item from a DynamoDB table.
+    /// Delete an item from a DynamoDB table. Returns a Python awaitable.
     #[pyo3(signature = (table, key, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
     #[allow(clippy::too_many_arguments)]
-    pub fn delete_item(
+    pub fn delete_item<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        key: &Bound<'_, PyDict>,
+        condition_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        basic_operations::delete_item(
+            py,
+            self.client.clone(),
+            table,
+            key,
+            condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            return_values_on_condition_check_failure,
+        )
+    }
+
+    /// Sync delete_item - blocks until complete.
+    #[pyo3(signature = (table, key, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sync_delete_item(
         &self,
         py: Python<'_>,
         table: &str,
@@ -307,7 +379,7 @@ impl DynamoDBClient {
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
         return_values_on_condition_check_failure: bool,
     ) -> PyResult<OperationMetrics> {
-        basic_operations::delete_item(
+        basic_operations::sync_delete_item(
             py,
             &self.client,
             &self.runtime,
@@ -320,10 +392,39 @@ impl DynamoDBClient {
         )
     }
 
-    /// Update an item in a DynamoDB table.
+    /// Update an item in a DynamoDB table. Returns a Python awaitable.
     #[pyo3(signature = (table, key, updates=None, update_expression=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
     #[allow(clippy::too_many_arguments)]
-    pub fn update_item(
+    pub fn update_item<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        key: &Bound<'_, PyDict>,
+        updates: Option<&Bound<'_, PyDict>>,
+        update_expression: Option<String>,
+        condition_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        return_values_on_condition_check_failure: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        basic_operations::update_item(
+            py,
+            self.client.clone(),
+            table,
+            key,
+            updates,
+            update_expression,
+            condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            return_values_on_condition_check_failure,
+        )
+    }
+
+    /// Sync update_item - blocks until complete.
+    #[pyo3(signature = (table, key, updates=None, update_expression=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sync_update_item(
         &self,
         py: Python<'_>,
         table: &str,
@@ -335,7 +436,7 @@ impl DynamoDBClient {
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
         return_values_on_condition_check_failure: bool,
     ) -> PyResult<OperationMetrics> {
-        basic_operations::update_item(
+        basic_operations::sync_update_item(
             py,
             &self.client,
             &self.runtime,
@@ -350,7 +451,7 @@ impl DynamoDBClient {
         )
     }
 
-    /// Query a single page of items from a DynamoDB table.
+    /// Query a single page of items from a DynamoDB table. Returns a Python awaitable.
     ///
     /// # Arguments
     ///
@@ -368,7 +469,43 @@ impl DynamoDBClient {
     #[pyo3(signature = (table, key_condition_expression, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, limit=None, exclusive_start_key=None, scan_index_forward=None, index_name=None, consistent_read=false))]
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::type_complexity)]
-    pub fn query_page(
+    pub fn query_page<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        key_condition_expression: &str,
+        filter_expression: Option<String>,
+        projection_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        limit: Option<i32>,
+        exclusive_start_key: Option<&Bound<'_, PyDict>>,
+        scan_index_forward: Option<bool>,
+        index_name: Option<String>,
+        consistent_read: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        basic_operations::query(
+            py,
+            self.client.clone(),
+            table,
+            key_condition_expression,
+            filter_expression,
+            projection_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            limit,
+            exclusive_start_key,
+            scan_index_forward,
+            index_name,
+            consistent_read,
+        )
+    }
+
+    /// Sync query_page - blocks until complete.
+    #[pyo3(signature = (table, key_condition_expression, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, limit=None, exclusive_start_key=None, scan_index_forward=None, index_name=None, consistent_read=false))]
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
+    pub fn sync_query_page(
         &self,
         py: Python<'_>,
         table: &str,
@@ -383,7 +520,7 @@ impl DynamoDBClient {
         index_name: Option<String>,
         consistent_read: bool,
     ) -> PyResult<(Vec<Py<PyAny>>, Option<Py<PyAny>>, OperationMetrics)> {
-        let result = basic_operations::query(
+        let result = basic_operations::sync_query(
             py,
             &self.client,
             &self.runtime,
@@ -402,7 +539,7 @@ impl DynamoDBClient {
         Ok((result.items, result.last_evaluated_key, result.metrics))
     }
 
-    /// Scan a single page of items from a DynamoDB table.
+    /// Scan a single page of items from a DynamoDB table. Returns a Python awaitable.
     ///
     /// # Arguments
     ///
@@ -420,7 +557,43 @@ impl DynamoDBClient {
     #[pyo3(signature = (table, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, limit=None, exclusive_start_key=None, index_name=None, consistent_read=false, segment=None, total_segments=None))]
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::type_complexity)]
-    pub fn scan_page(
+    pub fn scan_page<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        filter_expression: Option<String>,
+        projection_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        limit: Option<i32>,
+        exclusive_start_key: Option<&Bound<'_, PyDict>>,
+        index_name: Option<String>,
+        consistent_read: bool,
+        segment: Option<i32>,
+        total_segments: Option<i32>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        basic_operations::scan(
+            py,
+            self.client.clone(),
+            table,
+            filter_expression,
+            projection_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            limit,
+            exclusive_start_key,
+            index_name,
+            consistent_read,
+            segment,
+            total_segments,
+        )
+    }
+
+    /// Sync scan_page - blocks until complete.
+    #[pyo3(signature = (table, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, limit=None, exclusive_start_key=None, index_name=None, consistent_read=false, segment=None, total_segments=None))]
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
+    pub fn sync_scan_page(
         &self,
         py: Python<'_>,
         table: &str,
@@ -435,7 +608,7 @@ impl DynamoDBClient {
         segment: Option<i32>,
         total_segments: Option<i32>,
     ) -> PyResult<(Vec<Py<PyAny>>, Option<Py<PyAny>>, OperationMetrics)> {
-        let result = basic_operations::scan(
+        let result = basic_operations::sync_scan(
             py,
             &self.client,
             &self.runtime,
@@ -454,10 +627,35 @@ impl DynamoDBClient {
         Ok((result.items, result.last_evaluated_key, result.metrics))
     }
 
-    /// Count items in a DynamoDB table.
+    /// Count items in a DynamoDB table. Returns a Python awaitable.
     #[pyo3(signature = (table, filter_expression=None, expression_attribute_names=None, expression_attribute_values=None, index_name=None, consistent_read=false))]
     #[allow(clippy::too_many_arguments)]
-    pub fn count(
+    pub fn count<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        filter_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        index_name: Option<String>,
+        consistent_read: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        basic_operations::count(
+            py,
+            self.client.clone(),
+            table,
+            filter_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            index_name,
+            consistent_read,
+        )
+    }
+
+    /// Sync count - blocks until complete.
+    #[pyo3(signature = (table, filter_expression=None, expression_attribute_names=None, expression_attribute_values=None, index_name=None, consistent_read=false))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sync_count(
         &self,
         py: Python<'_>,
         table: &str,
@@ -467,7 +665,7 @@ impl DynamoDBClient {
         index_name: Option<String>,
         consistent_read: bool,
     ) -> PyResult<(i64, OperationMetrics)> {
-        basic_operations::count(
+        basic_operations::sync_count(
             py,
             &self.client,
             &self.runtime,
@@ -765,205 +963,9 @@ impl DynamoDBClient {
         )
     }
 
-    // ========== ASYNC METHODS ==========
+    // ========== PARALLEL SCAN ==========
 
-    /// Async version of get_item.
-    #[pyo3(signature = (table, key, consistent_read=false, projection=None, expression_attribute_names=None))]
-    pub fn async_get_item<'py>(
-        &self,
-        py: Python<'py>,
-        table: &str,
-        key: &Bound<'_, PyDict>,
-        consistent_read: bool,
-        projection: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_get_item(
-            py,
-            self.client.clone(),
-            table,
-            key,
-            consistent_read,
-            projection,
-            expression_attribute_names,
-        )
-    }
-
-    /// Async version of put_item.
-    #[pyo3(signature = (table, item, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn async_put_item<'py>(
-        &self,
-        py: Python<'py>,
-        table: &str,
-        item: &Bound<'_, PyDict>,
-        condition_expression: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-        expression_attribute_values: Option<&Bound<'_, PyDict>>,
-        return_values_on_condition_check_failure: bool,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_put_item(
-            py,
-            self.client.clone(),
-            table,
-            item,
-            condition_expression,
-            expression_attribute_names,
-            expression_attribute_values,
-            return_values_on_condition_check_failure,
-        )
-    }
-
-    /// Async version of delete_item.
-    #[pyo3(signature = (table, key, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn async_delete_item<'py>(
-        &self,
-        py: Python<'py>,
-        table: &str,
-        key: &Bound<'_, PyDict>,
-        condition_expression: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-        expression_attribute_values: Option<&Bound<'_, PyDict>>,
-        return_values_on_condition_check_failure: bool,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_delete_item(
-            py,
-            self.client.clone(),
-            table,
-            key,
-            condition_expression,
-            expression_attribute_names,
-            expression_attribute_values,
-            return_values_on_condition_check_failure,
-        )
-    }
-
-    /// Async version of update_item.
-    #[pyo3(signature = (table, key, updates=None, update_expression=None, condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, return_values_on_condition_check_failure=false))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn async_update_item<'py>(
-        &self,
-        py: Python<'py>,
-        table: &str,
-        key: &Bound<'_, PyDict>,
-        updates: Option<&Bound<'_, PyDict>>,
-        update_expression: Option<String>,
-        condition_expression: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-        expression_attribute_values: Option<&Bound<'_, PyDict>>,
-        return_values_on_condition_check_failure: bool,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_update_item(
-            py,
-            self.client.clone(),
-            table,
-            key,
-            updates,
-            update_expression,
-            condition_expression,
-            expression_attribute_names,
-            expression_attribute_values,
-            return_values_on_condition_check_failure,
-        )
-    }
-
-    /// Async version of query_page.
-    #[pyo3(signature = (table, key_condition_expression, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, limit=None, exclusive_start_key=None, scan_index_forward=None, index_name=None, consistent_read=false))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn async_query_page<'py>(
-        &self,
-        py: Python<'py>,
-        table: &str,
-        key_condition_expression: &str,
-        filter_expression: Option<String>,
-        projection_expression: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-        expression_attribute_values: Option<&Bound<'_, PyDict>>,
-        limit: Option<i32>,
-        exclusive_start_key: Option<&Bound<'_, PyDict>>,
-        scan_index_forward: Option<bool>,
-        index_name: Option<String>,
-        consistent_read: bool,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_query(
-            py,
-            self.client.clone(),
-            table,
-            key_condition_expression,
-            filter_expression,
-            projection_expression,
-            expression_attribute_names,
-            expression_attribute_values,
-            limit,
-            exclusive_start_key,
-            scan_index_forward,
-            index_name,
-            consistent_read,
-        )
-    }
-
-    /// Async version of scan_page.
-    #[pyo3(signature = (table, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, limit=None, exclusive_start_key=None, index_name=None, consistent_read=false, segment=None, total_segments=None))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn async_scan_page<'py>(
-        &self,
-        py: Python<'py>,
-        table: &str,
-        filter_expression: Option<String>,
-        projection_expression: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-        expression_attribute_values: Option<&Bound<'_, PyDict>>,
-        limit: Option<i32>,
-        exclusive_start_key: Option<&Bound<'_, PyDict>>,
-        index_name: Option<String>,
-        consistent_read: bool,
-        segment: Option<i32>,
-        total_segments: Option<i32>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_scan(
-            py,
-            self.client.clone(),
-            table,
-            filter_expression,
-            projection_expression,
-            expression_attribute_names,
-            expression_attribute_values,
-            limit,
-            exclusive_start_key,
-            index_name,
-            consistent_read,
-            segment,
-            total_segments,
-        )
-    }
-
-    /// Async version of count.
-    #[pyo3(signature = (table, filter_expression=None, expression_attribute_names=None, expression_attribute_values=None, index_name=None, consistent_read=false))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn async_count<'py>(
-        &self,
-        py: Python<'py>,
-        table: &str,
-        filter_expression: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-        expression_attribute_values: Option<&Bound<'_, PyDict>>,
-        index_name: Option<String>,
-        consistent_read: bool,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_count(
-            py,
-            self.client.clone(),
-            table,
-            filter_expression,
-            expression_attribute_names,
-            expression_attribute_values,
-            index_name,
-            consistent_read,
-        )
-    }
-
-    /// Parallel scan - runs multiple segment scans concurrently.
+    /// Parallel scan - runs multiple segment scans concurrently. Returns a Python awaitable.
     ///
     /// This is much faster than regular scan for large tables.
     /// Each segment is scanned in parallel using tokio tasks.
@@ -980,38 +982,10 @@ impl DynamoDBClient {
     ///
     /// # Returns
     ///
-    /// Tuple of (items, metrics) where items is a list of all scanned items.
+    /// A Python awaitable that resolves to dict with items and metrics.
     #[pyo3(signature = (table, total_segments, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, consistent_read=false))]
     #[allow(clippy::too_many_arguments)]
-    pub fn parallel_scan(
-        &self,
-        py: Python<'_>,
-        table: &str,
-        total_segments: i32,
-        filter_expression: Option<String>,
-        projection_expression: Option<String>,
-        expression_attribute_names: Option<&Bound<'_, PyDict>>,
-        expression_attribute_values: Option<&Bound<'_, PyDict>>,
-        consistent_read: bool,
-    ) -> PyResult<(Vec<Py<PyAny>>, OperationMetrics)> {
-        basic_operations::parallel_scan(
-            py,
-            &self.client,
-            &self.runtime,
-            table,
-            total_segments,
-            filter_expression,
-            projection_expression,
-            expression_attribute_names,
-            expression_attribute_values,
-            consistent_read,
-        )
-    }
-
-    /// Async version of parallel_scan.
-    #[pyo3(signature = (table, total_segments, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, consistent_read=false))]
-    #[allow(clippy::too_many_arguments)]
-    pub fn async_parallel_scan<'py>(
+    pub fn parallel_scan<'py>(
         &self,
         py: Python<'py>,
         table: &str,
@@ -1022,9 +996,37 @@ impl DynamoDBClient {
         expression_attribute_values: Option<&Bound<'_, PyDict>>,
         consistent_read: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_parallel_scan(
+        basic_operations::parallel_scan(
             py,
             self.client.clone(),
+            table,
+            total_segments,
+            filter_expression,
+            projection_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            consistent_read,
+        )
+    }
+
+    /// Sync parallel_scan - blocks until all segments complete.
+    #[pyo3(signature = (table, total_segments, filter_expression=None, projection_expression=None, expression_attribute_names=None, expression_attribute_values=None, consistent_read=false))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sync_parallel_scan(
+        &self,
+        py: Python<'_>,
+        table: &str,
+        total_segments: i32,
+        filter_expression: Option<String>,
+        projection_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        consistent_read: bool,
+    ) -> PyResult<(Vec<Py<PyAny>>, OperationMetrics)> {
+        basic_operations::sync_parallel_scan(
+            py,
+            &self.client,
+            &self.runtime,
             table,
             total_segments,
             filter_expression,
@@ -1037,30 +1039,9 @@ impl DynamoDBClient {
 
     // ========== PARTIQL OPERATIONS ==========
 
-    /// Execute a PartiQL statement.
+    /// Execute a PartiQL statement. Returns a Python awaitable.
     #[pyo3(signature = (statement, parameters=None, consistent_read=false, next_token=None))]
-    pub fn execute_statement(
-        &self,
-        py: Python<'_>,
-        statement: &str,
-        parameters: Option<&Bound<'_, pyo3::types::PyList>>,
-        consistent_read: bool,
-        next_token: Option<String>,
-    ) -> PyResult<(Vec<Py<PyAny>>, Option<String>, OperationMetrics)> {
-        basic_operations::execute_statement(
-            py,
-            &self.client,
-            &self.runtime,
-            statement,
-            parameters,
-            consistent_read,
-            next_token,
-        )
-    }
-
-    /// Async version of execute_statement.
-    #[pyo3(signature = (statement, parameters=None, consistent_read=false, next_token=None))]
-    pub fn async_execute_statement<'py>(
+    pub fn execute_statement<'py>(
         &self,
         py: Python<'py>,
         statement: &str,
@@ -1068,10 +1049,31 @@ impl DynamoDBClient {
         consistent_read: bool,
         next_token: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        basic_operations::async_execute_statement(
+        basic_operations::execute_statement(
             py,
             self.client.clone(),
             statement.to_string(),
+            parameters,
+            consistent_read,
+            next_token,
+        )
+    }
+
+    /// Sync execute_statement - blocks until complete.
+    #[pyo3(signature = (statement, parameters=None, consistent_read=false, next_token=None))]
+    pub fn sync_execute_statement(
+        &self,
+        py: Python<'_>,
+        statement: &str,
+        parameters: Option<&Bound<'_, pyo3::types::PyList>>,
+        consistent_read: bool,
+        next_token: Option<String>,
+    ) -> PyResult<(Vec<Py<PyAny>>, Option<String>, OperationMetrics)> {
+        basic_operations::sync_execute_statement(
+            py,
+            &self.client,
+            &self.runtime,
+            statement,
             parameters,
             consistent_read,
             next_token,

--- a/tests/integration/async_ops/test_async_crud.py
+++ b/tests/integration/async_ops/test_async_crud.py
@@ -1,4 +1,8 @@
-"""Tests for async CRUD operations."""
+"""Tests for async CRUD operations.
+
+With async-first API, async methods have no prefix (get, save, delete, etc.)
+and sync methods have sync_ prefix (sync_get, sync_save, sync_delete, etc.)
+"""
 
 import asyncio
 
@@ -40,28 +44,28 @@ async def test_async_put_and_get_item(async_table: DynamoDBClient):
     # GIVEN an item to save
     item = {"pk": "USER#async1", "sk": "PROFILE", "name": "Async User", "age": 25}
 
-    # WHEN we put the item
-    metrics = await async_table.async_put_item(TABLE_NAME, item)
+    # WHEN we put the item (async is default, no prefix)
+    metrics = await async_table.put_item(TABLE_NAME, item)
 
     # THEN metrics are returned
     assert metrics.duration_ms > 0
 
     # AND we can get the item back
-    result = await async_table.async_get_item(TABLE_NAME, {"pk": "USER#async1", "sk": "PROFILE"})
+    result = await async_table.get_item(TABLE_NAME, {"pk": "USER#async1", "sk": "PROFILE"})
     assert result is not None
     assert result["name"] == "Async User"
     assert result["age"] == 25
 
 
 @pytest.mark.asyncio
-async def test_async_update_item(async_table: DynamoDBClient):
+async def test_update_item(async_table: DynamoDBClient):
     """Test async update_item."""
     # GIVEN an existing item
     item = {"pk": "USER#async2", "sk": "PROFILE", "name": "Before Update"}
-    await async_table.async_put_item(TABLE_NAME, item)
+    await async_table.put_item(TABLE_NAME, item)
 
     # WHEN we update the item
-    metrics = await async_table.async_update_item(
+    metrics = await async_table.update_item(
         TABLE_NAME,
         {"pk": "USER#async2", "sk": "PROFILE"},
         updates={"name": "After Update"},
@@ -71,27 +75,25 @@ async def test_async_update_item(async_table: DynamoDBClient):
     assert metrics.duration_ms > 0
 
     # AND the update is applied
-    result = await async_table.async_get_item(TABLE_NAME, {"pk": "USER#async2", "sk": "PROFILE"})
+    result = await async_table.get_item(TABLE_NAME, {"pk": "USER#async2", "sk": "PROFILE"})
     assert result["name"] == "After Update"
 
 
 @pytest.mark.asyncio
-async def test_async_delete_item(async_table: DynamoDBClient):
+async def test_delete_item(async_table: DynamoDBClient):
     """Test async delete_item."""
     # GIVEN an existing item
     item = {"pk": "USER#async3", "sk": "PROFILE", "name": "To Delete"}
-    await async_table.async_put_item(TABLE_NAME, item)
+    await async_table.put_item(TABLE_NAME, item)
 
     # WHEN we delete the item
-    metrics = await async_table.async_delete_item(
-        TABLE_NAME, {"pk": "USER#async3", "sk": "PROFILE"}
-    )
+    metrics = await async_table.delete_item(TABLE_NAME, {"pk": "USER#async3", "sk": "PROFILE"})
 
     # THEN metrics are returned
     assert metrics.duration_ms > 0
 
     # AND the item is gone
-    result = await async_table.async_get_item(TABLE_NAME, {"pk": "USER#async3", "sk": "PROFILE"})
+    result = await async_table.get_item(TABLE_NAME, {"pk": "USER#async3", "sk": "PROFILE"})
     assert result is None
 
 
@@ -101,11 +103,11 @@ async def test_async_query(async_table: DynamoDBClient):
     # GIVEN items with the same partition key
     for i in range(3):
         item = {"pk": "USER#query_async", "sk": f"ITEM#{i}", "name": f"Item {i}"}
-        await async_table.async_put_item(TABLE_NAME, item)
+        await async_table.put_item(TABLE_NAME, item)
 
-    # WHEN we query by partition key
+    # WHEN we query by partition key (async is default)
     items = []
-    async for item in async_table.async_query(
+    async for item in async_table.query(
         TABLE_NAME,
         key_condition_expression="#pk = :pk",
         expression_attribute_names={"#pk": "pk"},
@@ -123,10 +125,10 @@ async def test_async_query_to_list(async_table: DynamoDBClient):
     # GIVEN items with the same partition key
     for i in range(2):
         item = {"pk": "USER#list_async", "sk": f"ITEM#{i}", "name": f"Item {i}"}
-        await async_table.async_put_item(TABLE_NAME, item)
+        await async_table.put_item(TABLE_NAME, item)
 
     # WHEN we query with to_list()
-    items = await async_table.async_query(
+    items = await async_table.query(
         TABLE_NAME,
         key_condition_expression="#pk = :pk",
         expression_attribute_names={"#pk": "pk"},
@@ -141,16 +143,16 @@ async def test_async_query_to_list(async_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_model_async_save_and_get(async_table: DynamoDBClient):
-    """Test Model.async_save() and Model.async_get()."""
+async def test_model_save_and_get(async_table: DynamoDBClient):
+    """Test Model.save() and Model.get() (async, no prefix)."""
     # GIVEN a model instance
     user = AsyncUser(pk="USER#model1", sk="PROFILE", name="Model User", age=30)
 
-    # WHEN we save it
-    await user.async_save()
+    # WHEN we save it (async is default)
+    await user.save()
 
     # THEN we can get it back
-    loaded = await AsyncUser.async_get(pk="USER#model1", sk="PROFILE")
+    loaded = await AsyncUser.get(pk="USER#model1", sk="PROFILE")
     assert loaded is not None
     assert loaded.name == "Model User"
     assert loaded.age == 30
@@ -158,32 +160,32 @@ async def test_model_async_save_and_get(async_table: DynamoDBClient):
 
 @pytest.mark.asyncio
 async def test_model_async_update(async_table: DynamoDBClient):
-    """Test Model.async_update()."""
+    """Test Model.update() (async)."""
     # GIVEN a saved model
     user = AsyncUser(pk="USER#model2", sk="PROFILE", name="Before", age=20)
-    await user.async_save()
+    await user.save()
 
     # WHEN we update it
-    await user.async_update(name="After", age=21)
+    await user.update(name="After", age=21)
 
     # THEN the changes are persisted
-    loaded = await AsyncUser.async_get(pk="USER#model2", sk="PROFILE")
+    loaded = await AsyncUser.get(pk="USER#model2", sk="PROFILE")
     assert loaded.name == "After"
     assert loaded.age == 21
 
 
 @pytest.mark.asyncio
 async def test_model_async_delete(async_table: DynamoDBClient):
-    """Test Model.async_delete()."""
+    """Test Model.delete() (async)."""
     # GIVEN a saved model
     user = AsyncUser(pk="USER#model3", sk="PROFILE", name="To Delete")
-    await user.async_save()
+    await user.save()
 
     # WHEN we delete it
-    await user.async_delete()
+    await user.delete()
 
     # THEN it's gone
-    loaded = await AsyncUser.async_get(pk="USER#model3", sk="PROFILE")
+    loaded = await AsyncUser.get(pk="USER#model3", sk="PROFILE")
     assert loaded is None
 
 
@@ -196,15 +198,15 @@ async def test_concurrent_gets(async_table: DynamoDBClient):
     # GIVEN multiple items in the table
     for i in range(5):
         item = {"pk": f"USER#concurrent{i}", "sk": "PROFILE", "name": f"User {i}"}
-        await async_table.async_put_item(TABLE_NAME, item)
+        await async_table.put_item(TABLE_NAME, item)
 
     # WHEN we get all concurrently
     results = await asyncio.gather(
-        async_table.async_get_item(TABLE_NAME, {"pk": "USER#concurrent0", "sk": "PROFILE"}),
-        async_table.async_get_item(TABLE_NAME, {"pk": "USER#concurrent1", "sk": "PROFILE"}),
-        async_table.async_get_item(TABLE_NAME, {"pk": "USER#concurrent2", "sk": "PROFILE"}),
-        async_table.async_get_item(TABLE_NAME, {"pk": "USER#concurrent3", "sk": "PROFILE"}),
-        async_table.async_get_item(TABLE_NAME, {"pk": "USER#concurrent4", "sk": "PROFILE"}),
+        async_table.get_item(TABLE_NAME, {"pk": "USER#concurrent0", "sk": "PROFILE"}),
+        async_table.get_item(TABLE_NAME, {"pk": "USER#concurrent1", "sk": "PROFILE"}),
+        async_table.get_item(TABLE_NAME, {"pk": "USER#concurrent2", "sk": "PROFILE"}),
+        async_table.get_item(TABLE_NAME, {"pk": "USER#concurrent3", "sk": "PROFILE"}),
+        async_table.get_item(TABLE_NAME, {"pk": "USER#concurrent4", "sk": "PROFILE"}),
     )
 
     # THEN all results are returned correctly
@@ -216,17 +218,17 @@ async def test_concurrent_gets(async_table: DynamoDBClient):
 
 @pytest.mark.asyncio
 async def test_concurrent_model_gets(async_table: DynamoDBClient):
-    """Test running multiple Model.async_get() concurrently."""
+    """Test running multiple Model.get() concurrently."""
     # GIVEN multiple saved models
     for i in range(3):
         user = AsyncUser(pk=f"USER#mconc{i}", sk="PROFILE", name=f"User {i}")
-        await user.async_save()
+        await user.save()
 
     # WHEN we get all concurrently
     results = await asyncio.gather(
-        AsyncUser.async_get(pk="USER#mconc0", sk="PROFILE"),
-        AsyncUser.async_get(pk="USER#mconc1", sk="PROFILE"),
-        AsyncUser.async_get(pk="USER#mconc2", sk="PROFILE"),
+        AsyncUser.get(pk="USER#mconc0", sk="PROFILE"),
+        AsyncUser.get(pk="USER#mconc1", sk="PROFILE"),
+        AsyncUser.get(pk="USER#mconc2", sk="PROFILE"),
     )
 
     # THEN all results are returned correctly
@@ -234,3 +236,39 @@ async def test_concurrent_model_gets(async_table: DynamoDBClient):
     for i, user in enumerate(results):
         assert user is not None
         assert user.name == f"User {i}"
+
+
+# ========== Sync methods (with sync_ prefix) ==========
+
+
+def test_sync_put_and_get_item(async_table: DynamoDBClient):
+    """Test sync_put_item and sync_get_item."""
+    # GIVEN an item to save
+    item = {"pk": "USER#sync1", "sk": "PROFILE", "name": "Sync User", "age": 35}
+
+    # WHEN we put the item using sync method
+    metrics = async_table.sync_put_item(TABLE_NAME, item)
+
+    # THEN metrics are returned
+    assert metrics.duration_ms > 0
+
+    # AND we can get the item back
+    result = async_table.sync_get_item(TABLE_NAME, {"pk": "USER#sync1", "sk": "PROFILE"})
+    assert result is not None
+    assert result["name"] == "Sync User"
+    assert result["age"] == 35
+
+
+def test_model_sync_save_and_get(async_table: DynamoDBClient):
+    """Test Model.sync_save() and Model.sync_get()."""
+    # GIVEN a model instance
+    user = AsyncUser(pk="USER#syncmodel1", sk="PROFILE", name="Sync Model User", age=40)
+
+    # WHEN we save it using sync method
+    user.sync_save()
+
+    # THEN we can get it back
+    loaded = AsyncUser.sync_get(pk="USER#syncmodel1", sk="PROFILE")
+    assert loaded is not None
+    assert loaded.name == "Sync Model User"
+    assert loaded.age == 40

--- a/tests/integration/async_ops/test_async_pagination.py
+++ b/tests/integration/async_ops/test_async_pagination.py
@@ -69,19 +69,19 @@ def seeded_table(pagination_table: DynamoDBClient):
             "status": "active",
             "age": 20 + i,
         }
-        pagination_table.put_item(TABLE_NAME, item)
+        pagination_table.sync_put_item(TABLE_NAME, item)
     yield pagination_table
 
 
-# ========== Model async_query pagination ==========
+# ========== Model query pagination ==========
 
 
 @pytest.mark.asyncio
-async def test_async_query_last_evaluated_key(seeded_table: DynamoDBClient):
-    """Test that async_query exposes last_evaluated_key for pagination."""
+async def test_query_last_evaluated_key(seeded_table: DynamoDBClient):
+    """Test that query exposes last_evaluated_key for pagination."""
     # GIVEN a table with 25 items
     # WHEN we query with page_size=10
-    result = PaginationUser.async_query(
+    result = PaginationUser.query(
         hash_key="USER#pagination",
         page_size=10,
     )
@@ -99,7 +99,7 @@ async def test_async_query_last_evaluated_key(seeded_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_async_query_manual_pagination(seeded_table: DynamoDBClient):
+async def test_query_manual_pagination(seeded_table: DynamoDBClient):
     """Test manual pagination using last_evaluated_key."""
     # GIVEN a table with 25 items
     all_items = []
@@ -107,7 +107,7 @@ async def test_async_query_manual_pagination(seeded_table: DynamoDBClient):
 
     # WHEN we paginate manually
     while True:
-        result = PaginationUser.async_query(
+        result = PaginationUser.query(
             hash_key="USER#pagination",
             page_size=10,
             last_evaluated_key=last_key,
@@ -125,11 +125,11 @@ async def test_async_query_manual_pagination(seeded_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_async_query_collect(seeded_table: DynamoDBClient):
-    """Test collecting all items from async_query."""
+async def test_query_collect(seeded_table: DynamoDBClient):
+    """Test collecting all items from query."""
     # GIVEN a table with 25 items
     # WHEN we collect all items
-    result = PaginationUser.async_query(hash_key="USER#pagination")
+    result = PaginationUser.query(hash_key="USER#pagination")
     all_items = []
     async for user in result:
         all_items.append(user)
@@ -138,15 +138,15 @@ async def test_async_query_collect(seeded_table: DynamoDBClient):
     assert len(all_items) == 25
 
 
-# ========== Model async_scan pagination ==========
+# ========== Model scan pagination ==========
 
 
 @pytest.mark.asyncio
-async def test_async_scan_last_evaluated_key(seeded_table: DynamoDBClient):
-    """Test that async_scan exposes last_evaluated_key for pagination."""
+async def test_scan_last_evaluated_key(seeded_table: DynamoDBClient):
+    """Test that scan exposes last_evaluated_key for pagination."""
     # GIVEN a table with items
     # WHEN we scan with page_size=10
-    result = PaginationUser.async_scan(page_size=10)
+    result = PaginationUser.scan(page_size=10)
 
     # Consume first page
     first_page = []
@@ -161,7 +161,7 @@ async def test_async_scan_last_evaluated_key(seeded_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_async_scan_manual_pagination(seeded_table: DynamoDBClient):
+async def test_scan_manual_pagination(seeded_table: DynamoDBClient):
     """Test manual scan pagination using last_evaluated_key."""
     # GIVEN a table with items
     all_items = []
@@ -169,7 +169,7 @@ async def test_async_scan_manual_pagination(seeded_table: DynamoDBClient):
 
     # WHEN we paginate manually
     while True:
-        result = PaginationUser.async_scan(
+        result = PaginationUser.scan(
             page_size=10,
             last_evaluated_key=last_key,
         )
@@ -189,11 +189,11 @@ async def test_async_scan_manual_pagination(seeded_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_async_gsi_query_last_evaluated_key(seeded_table: DynamoDBClient):
-    """Test that GSI async_query exposes last_evaluated_key."""
+async def test_gsi_query_last_evaluated_key(seeded_table: DynamoDBClient):
+    """Test that GSI query exposes last_evaluated_key."""
     # GIVEN a table with 25 active users
     # WHEN we query the GSI with page_size=10
-    result = PaginationUser.status_index.async_query(
+    result = PaginationUser.status_index.query(
         status="active",
         page_size=10,
     )
@@ -211,7 +211,7 @@ async def test_async_gsi_query_last_evaluated_key(seeded_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_async_gsi_query_manual_pagination(seeded_table: DynamoDBClient):
+async def test_gsi_query_manual_pagination(seeded_table: DynamoDBClient):
     """Test GSI manual pagination using last_evaluated_key."""
     # GIVEN a table with 25 active users
     all_items = []
@@ -219,7 +219,7 @@ async def test_async_gsi_query_manual_pagination(seeded_table: DynamoDBClient):
 
     # WHEN we paginate manually through GSI
     while True:
-        result = PaginationUser.status_index.async_query(
+        result = PaginationUser.status_index.query(
             status="active",
             page_size=10,
             last_evaluated_key=last_key,
@@ -240,11 +240,11 @@ async def test_async_gsi_query_manual_pagination(seeded_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_async_lsi_query_last_evaluated_key(seeded_table: DynamoDBClient):
-    """Test that LSI async_query exposes last_evaluated_key."""
+async def test_lsi_query_last_evaluated_key(seeded_table: DynamoDBClient):
+    """Test that LSI query exposes last_evaluated_key."""
     # GIVEN a table with 25 users
     # WHEN we query the LSI with page_size=10
-    result = PaginationUser.age_index.async_query(
+    result = PaginationUser.age_index.query(
         pk="USER#pagination",
         page_size=10,
     )
@@ -262,7 +262,7 @@ async def test_async_lsi_query_last_evaluated_key(seeded_table: DynamoDBClient):
 
 
 @pytest.mark.asyncio
-async def test_async_lsi_query_manual_pagination(seeded_table: DynamoDBClient):
+async def test_lsi_query_manual_pagination(seeded_table: DynamoDBClient):
     """Test LSI manual pagination using last_evaluated_key."""
     # GIVEN a table with 25 users
     all_items = []
@@ -270,7 +270,7 @@ async def test_async_lsi_query_manual_pagination(seeded_table: DynamoDBClient):
 
     # WHEN we paginate manually through LSI
     while True:
-        result = PaginationUser.age_index.async_query(
+        result = PaginationUser.age_index.query(
             pk="USER#pagination",
             page_size=10,
             last_evaluated_key=last_key,

--- a/tests/integration/client/test_client_config.py
+++ b/tests/integration/client/test_client_config.py
@@ -49,7 +49,8 @@ def test_client_with_all_config_options(dynamodb_endpoint):
     assert client.get_region() == "us-east-1"
 
 
-def test_client_operations_with_timeouts(dynamodb_endpoint):
+@pytest.mark.asyncio
+async def test_client_operations_with_timeouts(dynamodb_endpoint):
     """Test that operations work with timeout configuration."""
     # GIVEN a client with timeout settings
     client = DynamoDBClient(
@@ -72,15 +73,15 @@ def test_client_operations_with_timeouts(dynamodb_endpoint):
         )
 
     # WHEN we do put_item and get_item
-    client.put_item(table_name, {"pk": "CONFIG#1", "sk": "TEST", "data": "value"})
-    result = client.get_item(table_name, {"pk": "CONFIG#1", "sk": "TEST"})
+    await client.put_item(table_name, {"pk": "CONFIG#1", "sk": "TEST", "data": "value"})
+    result = await client.get_item(table_name, {"pk": "CONFIG#1", "sk": "TEST"})
 
     # THEN operations succeed
     assert result is not None
     assert result["data"] == "value"
 
     # Cleanup
-    client.delete_item(table_name, {"pk": "CONFIG#1", "sk": "TEST"})
+    await client.delete_item(table_name, {"pk": "CONFIG#1", "sk": "TEST"})
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/client/test_connection_errors.py
+++ b/tests/integration/client/test_connection_errors.py
@@ -5,7 +5,8 @@ from pydynox import DynamoDBClient
 from pydynox.exceptions import ConnectionException
 
 
-def test_connection_refused_gives_clear_error():
+@pytest.mark.asyncio
+async def test_connection_refused_gives_clear_error():
     """Test that connection refused gives a helpful error message."""
     # GIVEN a client pointing to a non-existent endpoint
     client = DynamoDBClient(
@@ -18,10 +19,11 @@ def test_connection_refused_gives_clear_error():
     # WHEN we try to put an item
     # THEN a ConnectionException is raised
     with pytest.raises(ConnectionException, match="Connection failed"):
-        client.put_item("test_table", {"pk": "TEST#1", "sk": "A"})
+        await client.put_item("test_table", {"pk": "TEST#1", "sk": "A"})
 
 
-def test_connection_refused_on_get_item():
+@pytest.mark.asyncio
+async def test_connection_refused_on_get_item():
     """Test connection error on get_item."""
     # GIVEN a client pointing to a non-existent endpoint
     client = DynamoDBClient(
@@ -34,7 +36,7 @@ def test_connection_refused_on_get_item():
     # WHEN we try to get an item
     # THEN a ConnectionException is raised
     with pytest.raises(ConnectionException, match="Connection failed"):
-        client.get_item("test_table", {"pk": "TEST#1", "sk": "A"})
+        await client.get_item("test_table", {"pk": "TEST#1", "sk": "A"})
 
 
 def test_connection_refused_on_ping():

--- a/tests/integration/encryption/test_encrypted_attribute.py
+++ b/tests/integration/encryption/test_encrypted_attribute.py
@@ -78,7 +78,8 @@ def secret_model_with_context(dynamo, localstack_endpoint, kms_key_id):
     return SecretModelWithContext
 
 
-def test_save_and_load_encrypted_field(secret_model):
+@pytest.mark.asyncio
+async def test_save_and_load_encrypted_field(secret_model):
     """Save model with encrypted field, load it back decrypted."""
     # GIVEN a model with secret data
     item_id = str(uuid.uuid4())
@@ -92,17 +93,18 @@ def test_save_and_load_encrypted_field(secret_model):
     )
 
     # WHEN we save it
-    item.save()
+    await item.save()
 
     # AND load it back
-    loaded = secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
 
     # THEN the secret is decrypted
     assert loaded.secret == secret_value
     assert loaded.name == "test-secret"
 
 
-def test_encrypted_field_stored_as_ciphertext(secret_model, dynamo):
+@pytest.mark.asyncio
+async def test_encrypted_field_stored_as_ciphertext(secret_model, dynamo):
     """Verify the field is actually encrypted in DynamoDB."""
     # GIVEN a model with secret data
     item_id = str(uuid.uuid4())
@@ -114,17 +116,18 @@ def test_encrypted_field_stored_as_ciphertext(secret_model, dynamo):
         name="test",
         secret=secret_value,
     )
-    item.save()
+    await item.save()
 
     # WHEN we read raw data from DynamoDB
-    raw = dynamo.get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
+    raw = dynamo.sync_get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
 
     # THEN the secret is stored encrypted (starts with ENC:)
     assert raw["secret"].startswith("ENC:")
     assert raw["secret"] != secret_value
 
 
-def test_encrypted_field_with_context(secret_model_with_context):
+@pytest.mark.asyncio
+async def test_encrypted_field_with_context(secret_model_with_context):
     """Encrypted field with context works."""
     # GIVEN a model with encryption context
     item_id = str(uuid.uuid4())
@@ -136,16 +139,17 @@ def test_encrypted_field_with_context(secret_model_with_context):
         name="test",
         secret=secret_value,
     )
-    item.save()
+    await item.save()
 
     # WHEN we load it back
-    loaded = secret_model_with_context.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await secret_model_with_context.get(pk=f"SECRET#{item_id}", sk="v1")
 
     # THEN it decrypts correctly
     assert loaded.secret == secret_value
 
 
-def test_encrypted_field_unicode(secret_model):
+@pytest.mark.asyncio
+async def test_encrypted_field_unicode(secret_model):
     """Encrypted field handles unicode."""
     # GIVEN unicode secret
     item_id = str(uuid.uuid4())
@@ -157,16 +161,17 @@ def test_encrypted_field_unicode(secret_model):
         name="unicode-test",
         secret=secret_value,
     )
-    item.save()
+    await item.save()
 
     # WHEN we load it back
-    loaded = secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
 
     # THEN unicode is preserved
     assert loaded.secret == secret_value
 
 
-def test_encrypted_field_large_value(secret_model):
+@pytest.mark.asyncio
+async def test_encrypted_field_large_value(secret_model):
     """Encrypted field handles large values (over KMS 4KB limit)."""
     # GIVEN a large secret (50KB)
     item_id = str(uuid.uuid4())
@@ -178,17 +183,18 @@ def test_encrypted_field_large_value(secret_model):
         name="large-secret",
         secret=secret_value,
     )
-    item.save()
+    await item.save()
 
     # WHEN we load it back
-    loaded = secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
 
     # THEN it works (envelope encryption handles large data)
     assert loaded.secret == secret_value
     assert len(loaded.secret) == 50_000
 
 
-def test_encrypted_field_null_value(secret_model):
+@pytest.mark.asyncio
+async def test_encrypted_field_null_value(secret_model):
     """Encrypted field handles null values."""
     # GIVEN a model without secret
     item_id = str(uuid.uuid4())
@@ -199,16 +205,17 @@ def test_encrypted_field_null_value(secret_model):
         name="no-secret",
         secret=None,
     )
-    item.save()
+    await item.save()
 
     # WHEN we load it back
-    loaded = secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
 
     # THEN secret is None
     assert loaded.secret is None
 
 
-def test_encrypted_field_update(secret_model):
+@pytest.mark.asyncio
+async def test_encrypted_field_update(secret_model):
     """Encrypted field can be updated."""
     # GIVEN an existing item
     item_id = str(uuid.uuid4())
@@ -219,14 +226,14 @@ def test_encrypted_field_update(secret_model):
         name="update-test",
         secret="original-secret",
     )
-    item.save()
+    await item.save()
 
     # WHEN we update the secret
     item.secret = "new-secret"
-    item.save()
+    await item.save()
 
     # AND load it back
-    loaded = secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await secret_model.get(pk=f"SECRET#{item_id}", sk="v1")
 
     # THEN the new secret is returned
     assert loaded.secret == "new-secret"

--- a/tests/integration/encryption/test_encryption_modes.py
+++ b/tests/integration/encryption/test_encryption_modes.py
@@ -110,7 +110,8 @@ def readwrite_model(dynamo, localstack_endpoint, kms_key_id):
 # --- WriteOnly mode ---
 
 
-def test_writeonly_encrypts_on_save(writeonly_model, dynamo):
+@pytest.mark.asyncio
+async def test_writeonly_encrypts_on_save(writeonly_model, dynamo):
     """WriteOnly mode encrypts data on save."""
     item_id = str(uuid.uuid4())
 
@@ -119,14 +120,15 @@ def test_writeonly_encrypts_on_save(writeonly_model, dynamo):
         sk="v1",
         secret="my-secret",
     )
-    item.save()
+    await item.save()
 
     # Raw data should be encrypted
-    raw = dynamo.get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
+    raw = dynamo.sync_get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
     assert raw["secret"].startswith("ENC:")
 
 
-def test_writeonly_returns_ciphertext_on_load(writeonly_model):
+@pytest.mark.asyncio
+async def test_writeonly_returns_ciphertext_on_load(writeonly_model):
     """WriteOnly mode returns encrypted value on load (no decrypt)."""
     item_id = str(uuid.uuid4())
 
@@ -135,10 +137,10 @@ def test_writeonly_returns_ciphertext_on_load(writeonly_model):
         sk="v1",
         secret="my-secret",
     )
-    item.save()
+    await item.save()
 
     # Load returns encrypted value
-    loaded = writeonly_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await writeonly_model.get(pk=f"SECRET#{item_id}", sk="v1")
     assert loaded.secret.startswith("ENC:")
     assert loaded.secret != "my-secret"
 
@@ -146,7 +148,8 @@ def test_writeonly_returns_ciphertext_on_load(writeonly_model):
 # --- ReadOnly mode ---
 
 
-def test_readonly_stores_plaintext(readonly_model, dynamo):
+@pytest.mark.asyncio
+async def test_readonly_stores_plaintext(readonly_model, dynamo):
     """ReadOnly mode stores value as-is (no encrypt)."""
     item_id = str(uuid.uuid4())
 
@@ -155,15 +158,16 @@ def test_readonly_stores_plaintext(readonly_model, dynamo):
         sk="v1",
         secret="plaintext-value",
     )
-    item.save()
+    await item.save()
 
     # Raw data should be plaintext
-    raw = dynamo.get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
+    raw = dynamo.sync_get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
     assert raw["secret"] == "plaintext-value"
     assert not raw["secret"].startswith("ENC:")
 
 
-def test_readonly_decrypts_existing_data(readonly_model, readwrite_model):
+@pytest.mark.asyncio
+async def test_readonly_decrypts_existing_data(readonly_model, readwrite_model):
     """ReadOnly mode can decrypt data encrypted by another service."""
     item_id = str(uuid.uuid4())
 
@@ -173,17 +177,18 @@ def test_readonly_decrypts_existing_data(readonly_model, readwrite_model):
         sk="v1",
         secret="encrypted-by-writer",
     )
-    writer.save()
+    await writer.save()
 
     # Read with ReadOnly model
-    loaded = readonly_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await readonly_model.get(pk=f"SECRET#{item_id}", sk="v1")
     assert loaded.secret == "encrypted-by-writer"
 
 
 # --- ReadWrite mode ---
 
 
-def test_readwrite_encrypts_and_decrypts(readwrite_model, dynamo):
+@pytest.mark.asyncio
+async def test_readwrite_encrypts_and_decrypts(readwrite_model, dynamo):
     """ReadWrite mode encrypts on save and decrypts on load."""
     item_id = str(uuid.uuid4())
 
@@ -192,21 +197,22 @@ def test_readwrite_encrypts_and_decrypts(readwrite_model, dynamo):
         sk="v1",
         secret="full-access-secret",
     )
-    item.save()
+    await item.save()
 
     # Raw data is encrypted
-    raw = dynamo.get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
+    raw = dynamo.sync_get_item("test_table", {"pk": f"SECRET#{item_id}", "sk": "v1"})
     assert raw["secret"].startswith("ENC:")
 
     # Load decrypts
-    loaded = readwrite_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    loaded = await readwrite_model.get(pk=f"SECRET#{item_id}", sk="v1")
     assert loaded.secret == "full-access-secret"
 
 
 # --- Cross-mode workflows ---
 
 
-def test_writeonly_and_readonly_workflow(writeonly_model, readonly_model):
+@pytest.mark.asyncio
+async def test_writeonly_and_readonly_workflow(writeonly_model, readonly_model):
     """WriteOnly writes, ReadOnly reads - typical ingest/report pattern."""
     item_id = str(uuid.uuid4())
 
@@ -216,14 +222,15 @@ def test_writeonly_and_readonly_workflow(writeonly_model, readonly_model):
         sk="v1",
         secret="sensitive-data-from-ingest",
     )
-    ingest_item.save()
+    await ingest_item.save()
 
     # Report service (ReadOnly) reads data
-    report_item = readonly_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    report_item = await readonly_model.get(pk=f"SECRET#{item_id}", sk="v1")
     assert report_item.secret == "sensitive-data-from-ingest"
 
 
-def test_readwrite_can_read_writeonly_data(readwrite_model, writeonly_model):
+@pytest.mark.asyncio
+async def test_readwrite_can_read_writeonly_data(readwrite_model, writeonly_model):
     """ReadWrite can read data written by WriteOnly."""
     item_id = str(uuid.uuid4())
 
@@ -233,8 +240,8 @@ def test_readwrite_can_read_writeonly_data(readwrite_model, writeonly_model):
         sk="v1",
         secret="written-by-writeonly",
     )
-    writer.save()
+    await writer.save()
 
     # ReadWrite reads
-    reader = readwrite_model.get(pk=f"SECRET#{item_id}", sk="v1")
+    reader = await readwrite_model.get(pk=f"SECRET#{item_id}", sk="v1")
     assert reader.secret == "written-by-writeonly"

--- a/tests/integration/indexes/test_gsi.py
+++ b/tests/integration/indexes/test_gsi.py
@@ -1,4 +1,9 @@
-"""Integration tests for GlobalSecondaryIndex queries."""
+"""Integration tests for GlobalSecondaryIndex queries.
+
+With async-first API:
+- sync_query() for sync iteration
+- query() for async iteration (default)
+"""
 
 import pytest
 from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
@@ -68,9 +73,11 @@ class User(Model):
     )
 
 
-def test_gsi_query_by_email(gsi_client):
-    """Test querying GSI by email."""
-    # GIVEN users saved with email attribute
+# ========== SYNC TESTS (sync_query) ==========
+
+
+def test_gsi_sync_query_by_email(gsi_client):
+    """Test sync querying GSI by email."""
     user1 = User(
         pk="USER#1",
         sk="PROFILE",
@@ -79,7 +86,7 @@ def test_gsi_query_by_email(gsi_client):
         name="John",
         age=30,
     )
-    user1.save()
+    user1.sync_save()
 
     user2 = User(
         pk="USER#2",
@@ -89,21 +96,17 @@ def test_gsi_query_by_email(gsi_client):
         name="Jane",
         age=25,
     )
-    user2.save()
+    user2.sync_save()
 
-    # WHEN we query by email
-    results = list(User.email_index.query(email="john@example.com"))
+    results = list(User.email_index.sync_query(email="john@example.com"))
 
-    # THEN only the matching user is returned
     assert len(results) == 1
     assert results[0].pk == "USER#1"
     assert results[0].name == "John"
-    assert results[0].email == "john@example.com"
 
 
-def test_gsi_query_by_status(gsi_client):
-    """Test querying GSI by status."""
-    # GIVEN users with different statuses
+def test_gsi_sync_query_by_status(gsi_client):
+    """Test sync querying GSI by status."""
     User(
         pk="USER#1",
         sk="PROFILE",
@@ -111,7 +114,7 @@ def test_gsi_query_by_status(gsi_client):
         status="active",
         name="John",
         age=30,
-    ).save()
+    ).sync_save()
 
     User(
         pk="USER#2",
@@ -120,7 +123,7 @@ def test_gsi_query_by_status(gsi_client):
         status="active",
         name="Jane",
         age=25,
-    ).save()
+    ).sync_save()
 
     User(
         pk="USER#3",
@@ -129,20 +132,17 @@ def test_gsi_query_by_status(gsi_client):
         status="inactive",
         name="Bob",
         age=35,
-    ).save()
+    ).sync_save()
 
-    # WHEN we query active users
-    results = list(User.status_index.query(status="active"))
+    results = list(User.status_index.sync_query(status="active"))
 
-    # THEN only active users are returned
     assert len(results) == 2
     pks = {r.pk for r in results}
     assert pks == {"USER#1", "USER#2"}
 
 
-def test_gsi_query_with_range_key_condition(gsi_client):
-    """Test GSI query with range key condition."""
-    # GIVEN users with different pk prefixes
+def test_gsi_sync_query_with_range_key_condition(gsi_client):
+    """Test GSI sync_query with range key condition."""
     User(
         pk="USER#1",
         sk="PROFILE",
@@ -150,7 +150,7 @@ def test_gsi_query_with_range_key_condition(gsi_client):
         status="active",
         name="John",
         age=30,
-    ).save()
+    ).sync_save()
 
     User(
         pk="USER#2",
@@ -159,7 +159,7 @@ def test_gsi_query_with_range_key_condition(gsi_client):
         status="active",
         name="Jane",
         age=25,
-    ).save()
+    ).sync_save()
 
     User(
         pk="ADMIN#1",
@@ -168,25 +168,22 @@ def test_gsi_query_with_range_key_condition(gsi_client):
         status="active",
         name="Admin",
         age=40,
-    ).save()
+    ).sync_save()
 
-    # WHEN we query active users with pk starting with "USER#"
     results = list(
-        User.status_index.query(
+        User.status_index.sync_query(
             status="active",
             range_key_condition=User.pk.begins_with("USER#"),
         )
     )
 
-    # THEN only USER# items are returned
     assert len(results) == 2
     pks = {r.pk for r in results}
     assert pks == {"USER#1", "USER#2"}
 
 
-def test_gsi_query_with_filter(gsi_client):
-    """Test GSI query with filter condition."""
-    # GIVEN users with different ages
+def test_gsi_sync_query_with_filter(gsi_client):
+    """Test GSI sync_query with filter condition."""
     User(
         pk="USER#1",
         sk="PROFILE",
@@ -194,7 +191,7 @@ def test_gsi_query_with_filter(gsi_client):
         status="active",
         name="John",
         age=30,
-    ).save()
+    ).sync_save()
 
     User(
         pk="USER#2",
@@ -203,25 +200,21 @@ def test_gsi_query_with_filter(gsi_client):
         status="active",
         name="Jane",
         age=25,
-    ).save()
+    ).sync_save()
 
-    # WHEN we query active users with age >= 30
     results = list(
-        User.status_index.query(
+        User.status_index.sync_query(
             status="active",
             filter_condition=User.age >= 30,
         )
     )
 
-    # THEN only users with age >= 30 are returned
     assert len(results) == 1
     assert results[0].pk == "USER#1"
-    assert results[0].name == "John"
 
 
-def test_gsi_query_with_limit(gsi_client):
-    """Test GSI query with limit returns only N items total."""
-    # GIVEN multiple users
+def test_gsi_sync_query_with_limit(gsi_client):
+    """Test GSI sync_query with limit."""
     for i in range(5):
         User(
             pk=f"USER#{i}",
@@ -230,18 +223,15 @@ def test_gsi_query_with_limit(gsi_client):
             status="active",
             name=f"User {i}",
             age=20 + i,
-        ).save()
+        ).sync_save()
 
-    # WHEN we query with limit=2
-    results = list(User.status_index.query(status="active", limit=2))
+    results = list(User.status_index.sync_query(status="active", limit=2))
 
-    # THEN only 2 items are returned (limit stops iteration)
     assert len(results) == 2
 
 
-def test_gsi_query_descending(gsi_client):
-    """Test GSI query with descending order."""
-    # GIVEN users
+def test_gsi_sync_query_descending(gsi_client):
+    """Test GSI sync_query with descending order."""
     User(
         pk="USER#1",
         sk="PROFILE",
@@ -249,7 +239,7 @@ def test_gsi_query_descending(gsi_client):
         status="active",
         name="John",
         age=30,
-    ).save()
+    ).sync_save()
 
     User(
         pk="USER#2",
@@ -258,24 +248,22 @@ def test_gsi_query_descending(gsi_client):
         status="active",
         name="Jane",
         age=25,
-    ).save()
+    ).sync_save()
 
-    # WHEN we query in descending order
     results = list(
-        User.status_index.query(
+        User.status_index.sync_query(
             status="active",
             scan_index_forward=False,
         )
     )
 
-    # THEN results are in descending order by pk (range key)
     assert len(results) == 2
     assert results[0].pk == "USER#2"
     assert results[1].pk == "USER#1"
 
 
-def test_gsi_query_returns_model_instances(gsi_client):
-    """Test that GSI query returns proper model instances."""
+def test_gsi_sync_query_returns_model_instances(gsi_client):
+    """Test that GSI sync_query returns proper model instances."""
     User(
         pk="USER#1",
         sk="PROFILE",
@@ -283,39 +271,29 @@ def test_gsi_query_returns_model_instances(gsi_client):
         status="active",
         name="John",
         age=30,
-    ).save()
+    ).sync_save()
 
-    results = list(User.email_index.query(email="john@example.com"))
+    results = list(User.email_index.sync_query(email="john@example.com"))
 
     assert len(results) == 1
     user = results[0]
-
-    # Should be a User instance
     assert isinstance(user, User)
-
-    # Should have all attributes
     assert user.pk == "USER#1"
-    assert user.sk == "PROFILE"
     assert user.email == "john@example.com"
-    assert user.status == "active"
-    assert user.name == "John"
-    assert user.age == 30
 
 
-def test_gsi_query_empty_result(gsi_client):
-    """Test GSI query with no matching items."""
-    results = list(User.email_index.query(email="nonexistent@example.com"))
-
+def test_gsi_sync_query_empty_result(gsi_client):
+    """Test GSI sync_query with no matching items."""
+    results = list(User.email_index.sync_query(email="nonexistent@example.com"))
     assert len(results) == 0
 
 
-# ========== ASYNC TESTS ==========
+# ========== ASYNC TESTS (query - default) ==========
 
 
 @pytest.mark.asyncio
 async def test_async_gsi_query_by_email(gsi_client):
     """Test async querying GSI by email."""
-    # GIVEN a user saved with email attribute
     User(
         pk="ASYNC#1",
         sk="PROFILE",
@@ -323,14 +301,12 @@ async def test_async_gsi_query_by_email(gsi_client):
         status="active",
         name="Async User",
         age=25,
-    ).save()
+    ).sync_save()
 
-    # WHEN querying by email using async_query
     results = []
-    async for user in User.email_index.async_query(email="async@example.com"):
+    async for user in User.email_index.query(email="async@example.com"):
         results.append(user)
 
-    # THEN we get the user
     assert len(results) == 1
     assert results[0].name == "Async User"
     assert results[0].pk == "ASYNC#1"
@@ -339,7 +315,6 @@ async def test_async_gsi_query_by_email(gsi_client):
 @pytest.mark.asyncio
 async def test_async_gsi_query_with_filter(gsi_client):
     """Test async GSI query with filter condition."""
-    # GIVEN users with different ages
     for i in range(3):
         User(
             pk=f"ASYNC_FILTER#{i}",
@@ -347,18 +322,16 @@ async def test_async_gsi_query_with_filter(gsi_client):
             email="filter_async@example.com",
             status="active",
             name=f"User {i}",
-            age=20 + i * 10,  # 20, 30, 40
-        ).save()
+            age=20 + i * 10,
+        ).sync_save()
 
-    # WHEN querying with age filter
     results = []
-    async for user in User.email_index.async_query(
+    async for user in User.email_index.query(
         email="filter_async@example.com",
         filter_condition=User.age >= 30,
     ):
         results.append(user)
 
-    # THEN we get only users with age >= 30
     assert len(results) == 2
     ages = {u.age for u in results}
     assert ages == {30, 40}
@@ -367,7 +340,6 @@ async def test_async_gsi_query_with_filter(gsi_client):
 @pytest.mark.asyncio
 async def test_async_gsi_query_first(gsi_client):
     """Test async GSI query first() method."""
-    # GIVEN a user
     User(
         pk="ASYNC_FIRST#1",
         sk="PROFILE",
@@ -375,12 +347,10 @@ async def test_async_gsi_query_first(gsi_client):
         status="active",
         name="First User",
         age=30,
-    ).save()
+    ).sync_save()
 
-    # WHEN using first()
-    user = await User.email_index.async_query(email="first_async@example.com").first()
+    user = await User.email_index.query(email="first_async@example.com").first()
 
-    # THEN we get the user
     assert user is not None
     assert user.name == "First User"
 
@@ -388,17 +358,13 @@ async def test_async_gsi_query_first(gsi_client):
 @pytest.mark.asyncio
 async def test_async_gsi_query_first_empty(gsi_client):
     """Test async GSI query first() with no results."""
-    # WHEN querying for non-existent email
-    user = await User.email_index.async_query(email="nonexistent_async@example.com").first()
-
-    # THEN we get None
+    user = await User.email_index.query(email="nonexistent_async@example.com").first()
     assert user is None
 
 
 @pytest.mark.asyncio
 async def test_async_gsi_query_with_range_key_condition(gsi_client):
     """Test async GSI query with range key condition."""
-    # GIVEN users with different pk prefixes
     for prefix in ["A", "B", "C"]:
         User(
             pk=f"{prefix}#ASYNC_RANGE",
@@ -407,16 +373,14 @@ async def test_async_gsi_query_with_range_key_condition(gsi_client):
             status="range_async_test",
             name=f"User {prefix}",
             age=25,
-        ).save()
+        ).sync_save()
 
-    # WHEN querying with range key condition (pk begins_with "B")
     results = []
-    async for user in User.status_index.async_query(
+    async for user in User.status_index.query(
         status="range_async_test",
         range_key_condition=User.pk.begins_with("B"),
     ):
         results.append(user)
 
-    # THEN we get only user B
     assert len(results) == 1
     assert results[0].pk == "B#ASYNC_RANGE"

--- a/tests/integration/indexes/test_lsi.py
+++ b/tests/integration/indexes/test_lsi.py
@@ -1,4 +1,9 @@
-"""Integration tests for LocalSecondaryIndex queries."""
+"""Integration tests for LocalSecondaryIndex queries.
+
+With async-first API:
+- sync_query() for sync iteration
+- query() for async iteration (default)
+"""
 
 import pytest
 from pydynox import DynamoDBClient, Model, ModelConfig, set_default_client
@@ -44,103 +49,138 @@ def user_table(client):
             projection=["email"],
         )
 
-    # Create table with LSIs
     User.sync_create_table(wait=True)
 
     yield User
 
-    # Cleanup
     client.sync_delete_table(table_name)
 
 
-def test_lsi_query_basic(user_table):
+# ========== SYNC TESTS (sync_query) ==========
+
+
+def test_lsi_sync_query_basic(user_table):
     """Query LSI returns items sorted by LSI range key."""
-    # GIVEN users with different statuses
     User = user_table
-    User(pk="USER#1", sk="PROFILE#1", status="active", age=30, email="a@test.com").save()
-    User(pk="USER#1", sk="PROFILE#2", status="inactive", age=25, email="b@test.com").save()
-    User(pk="USER#1", sk="PROFILE#3", status="active", age=35, email="c@test.com").save()
+    User(pk="USER#1", sk="PROFILE#1", status="active", age=30, email="a@test.com").sync_save()
+    User(pk="USER#1", sk="PROFILE#2", status="inactive", age=25, email="b@test.com").sync_save()
+    User(pk="USER#1", sk="PROFILE#3", status="active", age=35, email="c@test.com").sync_save()
 
-    # WHEN we query the LSI by hash key
-    results = list(User.status_index.query(pk="USER#1"))
+    results = list(User.status_index.sync_query(pk="USER#1"))
 
-    # THEN we should get all items for that hash key
     assert len(results) == 3
 
 
-def test_lsi_query_with_range_condition(user_table):
+def test_lsi_sync_query_with_range_condition(user_table):
     """Query LSI with range key condition filters by LSI range key."""
-    # GIVEN users with different statuses
     User = user_table
 
-    # WHEN we query with range key condition on status
     results = list(
-        User.status_index.query(
+        User.status_index.sync_query(
             pk="USER#1",
             range_key_condition=User.status == "active",
         )
     )
 
-    # THEN we should get only active users
     assert len(results) == 2
     for user in results:
         assert user.status == "active"
 
 
-def test_lsi_query_scan_index_forward(user_table):
+def test_lsi_sync_query_scan_index_forward(user_table):
     """Query LSI respects scan_index_forward for sort order."""
-    # GIVEN users with different ages
     User = user_table
 
-    # WHEN we query ascending
-    asc_results = list(User.age_index.query(pk="USER#1", scan_index_forward=True))
+    asc_results = list(User.age_index.sync_query(pk="USER#1", scan_index_forward=True))
+    desc_results = list(User.age_index.sync_query(pk="USER#1", scan_index_forward=False))
 
-    # AND descending
-    desc_results = list(User.age_index.query(pk="USER#1", scan_index_forward=False))
-
-    # THEN order should be reversed
     asc_ages = [u.age for u in asc_results]
     desc_ages = [u.age for u in desc_results]
     assert asc_ages == sorted(asc_ages)
     assert desc_ages == sorted(desc_ages, reverse=True)
 
 
-def test_lsi_query_with_limit(user_table):
-    """Query LSI respects limit parameter per page."""
-    # GIVEN multiple users
+def test_lsi_sync_query_with_limit(user_table):
+    """Query LSI respects limit parameter."""
     User = user_table
 
-    # WHEN we query with limit (limit is per page, iterator fetches all pages)
-    result = User.status_index.query(pk="USER#1", limit=2)
-
-    # THEN the underlying query should use limit
-    # Note: limit is per page, not total. The iterator auto-paginates.
-    # We just verify the query executes without error
+    result = User.status_index.sync_query(pk="USER#1", limit=2)
     first_item = next(iter(result))
     assert first_item is not None
 
 
-def test_lsi_query_consistent_read(user_table):
-    """Query LSI supports consistent read (LSI-specific feature)."""
-    # GIVEN users in the table
+def test_lsi_sync_query_consistent_read(user_table):
+    """Query LSI supports consistent read."""
     User = user_table
 
-    # WHEN we query with consistent_read=True
-    results = list(User.status_index.query(pk="USER#1", consistent_read=True))
+    results = list(User.status_index.sync_query(pk="USER#1", consistent_read=True))
 
-    # THEN query should succeed (LSIs support consistent reads unlike GSIs)
     assert len(results) >= 0
 
 
-def test_lsi_query_different_hash_keys(user_table):
+def test_lsi_sync_query_different_hash_keys(user_table):
     """Query LSI returns only items for the specified hash key."""
-    # GIVEN users with different hash keys
     User = user_table
-    User(pk="USER#2", sk="PROFILE#1", status="active", age=40, email="d@test.com").save()
+    User(pk="USER#2", sk="PROFILE#1", status="active", age=40, email="d@test.com").sync_save()
 
-    # WHEN we query for USER#2
-    results = list(User.status_index.query(pk="USER#2"))
+    results = list(User.status_index.sync_query(pk="USER#2"))
 
-    # THEN we should only get USER#2's items
     assert len(results) == 1
     assert results[0].pk == "USER#2"
+
+
+# ========== ASYNC TESTS (query - default) ==========
+
+
+@pytest.mark.asyncio
+async def test_lsi_async_query_basic(user_table):
+    """Async query LSI returns items."""
+    User = user_table
+    User(pk="ASYNC#1", sk="PROFILE#1", status="active", age=30, email="async@test.com").sync_save()
+
+    results = []
+    async for user in User.status_index.query(pk="ASYNC#1"):
+        results.append(user)
+
+    assert len(results) == 1
+    assert results[0].pk == "ASYNC#1"
+
+
+@pytest.mark.asyncio
+async def test_lsi_async_query_with_range_condition(user_table):
+    """Async query LSI with range key condition."""
+    User = user_table
+    User(pk="ASYNC#2", sk="PROFILE#1", status="active", age=25, email="a@test.com").sync_save()
+    User(pk="ASYNC#2", sk="PROFILE#2", status="inactive", age=30, email="b@test.com").sync_save()
+
+    results = []
+    async for user in User.status_index.query(
+        pk="ASYNC#2",
+        range_key_condition=User.status == "active",
+    ):
+        results.append(user)
+
+    assert len(results) == 1
+    assert results[0].status == "active"
+
+
+@pytest.mark.asyncio
+async def test_lsi_async_query_first(user_table):
+    """Async query LSI first() method."""
+    User = user_table
+    User(pk="ASYNC#3", sk="PROFILE#1", status="first", age=35, email="first@test.com").sync_save()
+
+    user = await User.status_index.query(pk="ASYNC#3").first()
+
+    assert user is not None
+    assert user.status == "first"
+
+
+@pytest.mark.asyncio
+async def test_lsi_async_query_first_empty(user_table):
+    """Async query LSI first() with no results."""
+    User = user_table
+
+    user = await User.status_index.query(pk="NONEXISTENT#1").first()
+
+    assert user is None

--- a/tests/integration/integrations/test_dataclass_integration.py
+++ b/tests/integration/integrations/test_dataclass_integration.py
@@ -3,10 +3,12 @@
 import uuid
 from dataclasses import dataclass
 
+import pytest
 from pydynox import dynamodb_model
 
 
-def test_dataclass_save_and_get(dynamo):
+@pytest.mark.asyncio
+async def test_dataclass_save_and_get(dynamo):
     """Save and retrieve a dataclass item."""
     pk = f"DC_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -22,8 +24,8 @@ def test_dataclass_save_and_get(dynamo):
     user = User(pk=pk, sk="PROFILE", name="John", age=30)
 
     # WHEN we save and retrieve it
-    user.save()
-    retrieved = User.get(pk=pk, sk="PROFILE")
+    await user.save()
+    retrieved = await User.get(pk=pk, sk="PROFILE")
 
     # THEN all fields are preserved
     assert retrieved is not None
@@ -32,7 +34,8 @@ def test_dataclass_save_and_get(dynamo):
     assert retrieved.age == 30
 
 
-def test_dataclass_update(dynamo):
+@pytest.mark.asyncio
+async def test_dataclass_update(dynamo):
     """Update a dataclass item."""
     pk = f"DC_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -46,18 +49,19 @@ def test_dataclass_update(dynamo):
 
     # GIVEN a saved dataclass item
     user = User(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # WHEN we update it
-    user.update(name="Jane", age=31)
+    await user.update(name="Jane", age=31)
 
     # THEN changes are persisted
-    retrieved = User.get(pk=pk, sk="PROFILE")
+    retrieved = await User.get(pk=pk, sk="PROFILE")
     assert retrieved.name == "Jane"
     assert retrieved.age == 31
 
 
-def test_dataclass_delete(dynamo):
+@pytest.mark.asyncio
+async def test_dataclass_delete(dynamo):
     """Delete a dataclass item."""
     pk = f"DC_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -70,17 +74,18 @@ def test_dataclass_delete(dynamo):
 
     # GIVEN a saved dataclass item
     user = User(pk=pk, sk="PROFILE", name="John")
-    user.save()
-    assert User.get(pk=pk, sk="PROFILE") is not None
+    await user.save()
+    assert await User.get(pk=pk, sk="PROFILE") is not None
 
     # WHEN we delete it
-    user.delete()
+    await user.delete()
 
     # THEN it's gone
-    assert User.get(pk=pk, sk="PROFILE") is None
+    assert await User.get(pk=pk, sk="PROFILE") is None
 
 
-def test_dataclass_get_not_found(dynamo):
+@pytest.mark.asyncio
+async def test_dataclass_get_not_found(dynamo):
     """Get returns None for non-existent item."""
     pk = f"DC_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -91,11 +96,12 @@ def test_dataclass_get_not_found(dynamo):
         sk: str
         name: str
 
-    result = User.get(pk=pk, sk="NONEXISTENT")
+    result = await User.get(pk=pk, sk="NONEXISTENT")
     assert result is None
 
 
-def test_dataclass_with_complex_types(dynamo):
+@pytest.mark.asyncio
+async def test_dataclass_with_complex_types(dynamo):
     """Dataclass with list and dict fields."""
     pk = f"DC_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -116,8 +122,8 @@ def test_dataclass_with_complex_types(dynamo):
     )
 
     # WHEN we save and retrieve it
-    item.save()
-    retrieved = ComplexItem.get(pk=pk, sk="COMPLEX")
+    await item.save()
+    retrieved = await ComplexItem.get(pk=pk, sk="COMPLEX")
 
     # THEN complex types are preserved
     assert retrieved.tags == ["tag1", "tag2"]

--- a/tests/integration/integrations/test_pydantic_integration.py
+++ b/tests/integration/integrations/test_pydantic_integration.py
@@ -2,11 +2,13 @@
 
 import uuid
 
+import pytest
 from pydantic import BaseModel, Field
 from pydynox import dynamodb_model
 
 
-def test_pydantic_save_and_get(dynamo):
+@pytest.mark.asyncio
+async def test_pydantic_save_and_get(dynamo):
     """Save and retrieve a Pydantic model."""
     pk = f"PYD_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -21,8 +23,8 @@ def test_pydantic_save_and_get(dynamo):
     user = User(pk=pk, sk="PROFILE", name="John", age=30)
 
     # WHEN we save and retrieve it
-    user.save()
-    retrieved = User.get(pk=pk, sk="PROFILE")
+    await user.save()
+    retrieved = await User.get(pk=pk, sk="PROFILE")
 
     # THEN all fields are preserved
     assert retrieved is not None
@@ -31,7 +33,8 @@ def test_pydantic_save_and_get(dynamo):
     assert retrieved.age == 30
 
 
-def test_pydantic_update(dynamo):
+@pytest.mark.asyncio
+async def test_pydantic_update(dynamo):
     """Update a Pydantic model."""
     pk = f"PYD_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -44,18 +47,19 @@ def test_pydantic_update(dynamo):
 
     # GIVEN a saved Pydantic model
     user = User(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # WHEN we update it
-    user.update(name="Jane", age=31)
+    await user.update(name="Jane", age=31)
 
     # THEN changes are persisted
-    retrieved = User.get(pk=pk, sk="PROFILE")
+    retrieved = await User.get(pk=pk, sk="PROFILE")
     assert retrieved.name == "Jane"
     assert retrieved.age == 31
 
 
-def test_pydantic_delete(dynamo):
+@pytest.mark.asyncio
+async def test_pydantic_delete(dynamo):
     """Delete a Pydantic model."""
     pk = f"PYD_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -67,17 +71,18 @@ def test_pydantic_delete(dynamo):
 
     # GIVEN a saved Pydantic model
     user = User(pk=pk, sk="PROFILE", name="John")
-    user.save()
-    assert User.get(pk=pk, sk="PROFILE") is not None
+    await user.save()
+    assert await User.get(pk=pk, sk="PROFILE") is not None
 
     # WHEN we delete it
-    user.delete()
+    await user.delete()
 
     # THEN it's gone
-    assert User.get(pk=pk, sk="PROFILE") is None
+    assert await User.get(pk=pk, sk="PROFILE") is None
 
 
-def test_pydantic_validation_on_save(dynamo):
+@pytest.mark.asyncio
+async def test_pydantic_validation_on_save(dynamo):
     """Pydantic validates data before save."""
     pk = f"PYD_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -88,13 +93,14 @@ def test_pydantic_validation_on_save(dynamo):
         age: int = Field(ge=0, le=150)
 
     user = User(pk=pk, sk="PROFILE", age=30)
-    user.save()
+    await user.save()
 
-    retrieved = User.get(pk=pk, sk="PROFILE")
+    retrieved = await User.get(pk=pk, sk="PROFILE")
     assert retrieved.age == 30
 
 
-def test_pydantic_with_optional_fields(dynamo):
+@pytest.mark.asyncio
+async def test_pydantic_with_optional_fields(dynamo):
     """Pydantic model with optional fields."""
     pk = f"PYD_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -106,14 +112,15 @@ def test_pydantic_with_optional_fields(dynamo):
         email: str | None = None
 
     user = User(pk=pk, sk="PROFILE", name="John")
-    user.save()
+    await user.save()
 
-    retrieved = User.get(pk=pk, sk="PROFILE")
+    retrieved = await User.get(pk=pk, sk="PROFILE")
     assert retrieved.name == "John"
     assert retrieved.email is None
 
 
-def test_pydantic_with_complex_types(dynamo):
+@pytest.mark.asyncio
+async def test_pydantic_with_complex_types(dynamo):
     """Pydantic model with list and dict fields."""
     pk = f"PYD_TEST#{uuid.uuid4().hex[:8]}"
 
@@ -133,8 +140,8 @@ def test_pydantic_with_complex_types(dynamo):
     )
 
     # WHEN we save and retrieve it
-    item.save()
-    retrieved = ComplexItem.get(pk=pk, sk="COMPLEX")
+    await item.save()
+    retrieved = await ComplexItem.get(pk=pk, sk="COMPLEX")
 
     # THEN complex types are preserved
     assert retrieved.tags == ["tag1", "tag2"]

--- a/tests/integration/operations/test_atomic.py
+++ b/tests/integration/operations/test_atomic.py
@@ -22,102 +22,111 @@ def setup_client(dynamo):
     set_default_client(dynamo)
 
 
-def test_atomic_add_increments_value(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_add_increments_value(dynamo):
     # GIVEN a user with count=0
     user = User(pk="USER#1", sk="PROFILE", name="John", count=0)
-    user.save()
+    await user.save()
 
     # WHEN we add 1 atomically
-    user.update(atomic=[User.count.add(1)])
+    await user.update(atomic=[User.count.add(1)])
 
     # THEN count is incremented
-    result = User.get(pk="USER#1", sk="PROFILE")
+    result = await User.get(pk="USER#1", sk="PROFILE")
     assert result.count == 1
 
 
-def test_atomic_add_decrements_with_negative(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_add_decrements_with_negative(dynamo):
     user = User(pk="USER#2", sk="PROFILE", name="John", balance=100)
-    user.save()
+    await user.save()
 
-    user.update(atomic=[User.balance.add(-25)])
+    await user.update(atomic=[User.balance.add(-25)])
 
-    result = User.get(pk="USER#2", sk="PROFILE")
+    result = await User.get(pk="USER#2", sk="PROFILE")
     assert result.balance == 75
 
 
-def test_atomic_set_updates_value(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_set_updates_value(dynamo):
     user = User(pk="USER#3", sk="PROFILE", name="John", count=0)
-    user.save()
+    await user.save()
 
-    user.update(atomic=[User.name.set("Jane")])
+    await user.update(atomic=[User.name.set("Jane")])
 
-    result = User.get(pk="USER#3", sk="PROFILE")
+    result = await User.get(pk="USER#3", sk="PROFILE")
     assert result.name == "Jane"
 
 
-def test_atomic_remove_deletes_attribute(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_remove_deletes_attribute(dynamo):
     user = User(pk="USER#4", sk="PROFILE", name="John", count=10)
-    user.save()
+    await user.save()
 
-    user.update(atomic=[User.count.remove()])
+    await user.update(atomic=[User.count.remove()])
 
-    result = User.get(pk="USER#4", sk="PROFILE")
+    result = await User.get(pk="USER#4", sk="PROFILE")
     assert result.count is None
 
 
-def test_atomic_append_adds_to_list(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_append_adds_to_list(dynamo):
     user = User(pk="USER#5", sk="PROFILE", name="John", tags=["a", "b"])
-    user.save()
+    await user.save()
 
-    user.update(atomic=[User.tags.append(["c", "d"])])
+    await user.update(atomic=[User.tags.append(["c", "d"])])
 
-    result = User.get(pk="USER#5", sk="PROFILE")
+    result = await User.get(pk="USER#5", sk="PROFILE")
     assert result.tags == ["a", "b", "c", "d"]
 
 
-def test_atomic_prepend_adds_to_front(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_prepend_adds_to_front(dynamo):
     user = User(pk="USER#6", sk="PROFILE", name="John", tags=["b", "c"])
-    user.save()
+    await user.save()
 
-    user.update(atomic=[User.tags.prepend(["a"])])
+    await user.update(atomic=[User.tags.prepend(["a"])])
 
-    result = User.get(pk="USER#6", sk="PROFILE")
+    result = await User.get(pk="USER#6", sk="PROFILE")
     assert result.tags == ["a", "b", "c"]
 
 
-def test_atomic_if_not_exists_sets_when_missing(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_if_not_exists_sets_when_missing(dynamo):
     # GIVEN a user without count attribute
     user = User(pk="USER#7", sk="PROFILE", name="John")
-    user.save()
+    await user.save()
 
     # WHEN we use if_not_exists
-    user.update(atomic=[User.count.if_not_exists(100)])
+    await user.update(atomic=[User.count.if_not_exists(100)])
 
     # THEN count is set to 100
-    result = User.get(pk="USER#7", sk="PROFILE")
+    result = await User.get(pk="USER#7", sk="PROFILE")
     assert result.count == 100
 
 
-def test_atomic_if_not_exists_keeps_existing(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_if_not_exists_keeps_existing(dynamo):
     # GIVEN a user with count=50
     user = User(pk="USER#8", sk="PROFILE", name="John", count=50)
-    user.save()
+    await user.save()
 
     # WHEN we use if_not_exists
-    user.update(atomic=[User.count.if_not_exists(100)])
+    await user.update(atomic=[User.count.if_not_exists(100)])
 
     # THEN count stays at 50 (existing value kept)
-    result = User.get(pk="USER#8", sk="PROFILE")
+    result = await User.get(pk="USER#8", sk="PROFILE")
     assert result.count == 50
 
 
-def test_multiple_atomic_operations(dynamo):
+@pytest.mark.asyncio
+async def test_multiple_atomic_operations(dynamo):
     # GIVEN a user with count=0 and tags=["a"]
     user = User(pk="USER#9", sk="PROFILE", name="John", count=0, tags=["a"])
-    user.save()
+    await user.save()
 
     # WHEN we apply multiple atomic operations
-    user.update(
+    await user.update(
         atomic=[
             User.count.add(5),
             User.tags.append(["b"]),
@@ -126,95 +135,101 @@ def test_multiple_atomic_operations(dynamo):
     )
 
     # THEN all operations are applied
-    result = User.get(pk="USER#9", sk="PROFILE")
+    result = await User.get(pk="USER#9", sk="PROFILE")
     assert result.count == 5
     assert result.tags == ["a", "b"]
     assert result.name == "Jane"
 
 
-def test_atomic_with_condition_succeeds(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_with_condition_succeeds(dynamo):
     # GIVEN a user with balance=100
     user = User(pk="USER#COND1", sk="PROFILE", name="John", balance=100)
-    user.save()
+    await user.save()
 
     # WHEN we subtract 50 with condition balance >= 50
-    user.update(
+    await user.update(
         atomic=[User.balance.add(-50)],
         condition=User.balance >= 50,
     )
 
     # THEN the update succeeds
-    result = User.get(pk="USER#COND1", sk="PROFILE")
+    result = await User.get(pk="USER#COND1", sk="PROFILE")
     assert result.balance == 50
 
 
-def test_atomic_with_condition_fails(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_with_condition_fails(dynamo):
     # GIVEN a user with balance=30
     user = User(pk="USER#COND2", sk="PROFILE", name="John", balance=30)
-    user.save()
+    await user.save()
 
     # WHEN we try to subtract 50 with condition balance >= 50
     # THEN ConditionalCheckFailedException is raised
     with pytest.raises(ConditionalCheckFailedException):
-        user.update(
+        await user.update(
             atomic=[User.balance.add(-50)],
             condition=User.balance >= 50,
         )
 
     # AND balance is unchanged
-    result = User.get(pk="USER#COND2", sk="PROFILE")
+    result = await User.get(pk="USER#COND2", sk="PROFILE")
     assert result.balance == 30
 
 
-def test_atomic_set_and_remove_combined(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_set_and_remove_combined(dynamo):
     user = User(pk="USER#12", sk="PROFILE", name="John", count=10, balance=100)
-    user.save()
+    await user.save()
 
-    user.update(
+    await user.update(
         atomic=[
             User.name.set("Jane"),
             User.count.remove(),
         ]
     )
 
-    result = User.get(pk="USER#12", sk="PROFILE")
+    result = await User.get(pk="USER#12", sk="PROFILE")
     assert result.name == "Jane"
     assert result.count is None
     assert result.balance == 100
 
 
-def test_atomic_add_with_string_condition(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_add_with_string_condition(dynamo):
     user = User(pk="USER#COND3", sk="PROFILE", name="John", balance=200)
-    user.save()
+    await user.save()
 
-    user.update(
+    await user.update(
         atomic=[User.balance.add(-50)],
         condition=User.name == "John",
     )
 
-    result = User.get(pk="USER#COND3", sk="PROFILE")
+    result = await User.get(pk="USER#COND3", sk="PROFILE")
     assert result.balance == 150
 
 
-def test_atomic_add_with_string_condition_fails(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_add_with_string_condition_fails(dynamo):
     user = User(pk="USER#COND4", sk="PROFILE", name="John", balance=200)
-    user.save()
+    await user.save()
 
     with pytest.raises(ConditionalCheckFailedException):
-        user.update(
+        await user.update(
             atomic=[User.balance.add(-50)],
             condition=User.name == "Jane",
         )
 
-    result = User.get(pk="USER#COND4", sk="PROFILE")
+    result = await User.get(pk="USER#COND4", sk="PROFILE")
     assert result.balance == 200
 
 
-def test_atomic_multiple_ops_with_condition(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_multiple_ops_with_condition(dynamo):
     user = User(pk="USER#COND5", sk="PROFILE", name="John", count=5, balance=100)
-    user.save()
+    await user.save()
 
-    user.update(
+    await user.update(
         atomic=[
             User.count.add(1),
             User.balance.add(-10),
@@ -222,45 +237,48 @@ def test_atomic_multiple_ops_with_condition(dynamo):
         condition=User.balance >= 10,
     )
 
-    result = User.get(pk="USER#COND5", sk="PROFILE")
+    result = await User.get(pk="USER#COND5", sk="PROFILE")
     assert result.count == 6
     assert result.balance == 90
 
 
-def test_atomic_append_with_condition(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_append_with_condition(dynamo):
     user = User(pk="USER#COND6", sk="PROFILE", name="John", tags=["a"], count=10)
-    user.save()
+    await user.save()
 
-    user.update(
+    await user.update(
         atomic=[User.tags.append(["b"])],
         condition=User.count > 5,
     )
 
-    result = User.get(pk="USER#COND6", sk="PROFILE")
+    result = await User.get(pk="USER#COND6", sk="PROFILE")
     assert result.tags == ["a", "b"]
 
 
-def test_atomic_set_with_exists_condition(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_set_with_exists_condition(dynamo):
     user = User(pk="USER#COND7", sk="PROFILE", name="John", count=10)
-    user.save()
+    await user.save()
 
-    user.update(
+    await user.update(
         atomic=[User.name.set("Jane")],
         condition=User.count.exists(),
     )
 
-    result = User.get(pk="USER#COND7", sk="PROFILE")
+    result = await User.get(pk="USER#COND7", sk="PROFILE")
     assert result.name == "Jane"
 
 
-def test_atomic_with_not_exists_condition(dynamo):
+@pytest.mark.asyncio
+async def test_atomic_with_not_exists_condition(dynamo):
     user = User(pk="USER#COND8", sk="PROFILE", name="John")
-    user.save()
+    await user.save()
 
-    user.update(
+    await user.update(
         atomic=[User.count.if_not_exists(100)],
         condition=User.count.not_exists(),
     )
 
-    result = User.get(pk="USER#COND8", sk="PROFILE")
+    result = await User.get(pk="USER#COND8", sk="PROFILE")
     assert result.count == 100

--- a/tests/integration/operations/test_attributes.py
+++ b/tests/integration/operations/test_attributes.py
@@ -28,7 +28,8 @@ def setup_client(dynamo):
     yield dynamo
 
 
-def test_json_attribute_roundtrip(setup_client, table):
+@pytest.mark.asyncio
+async def test_json_attribute_roundtrip(setup_client, table):
     """JSONAttribute saves and loads dict correctly."""
 
     class Config(Model):
@@ -45,15 +46,16 @@ def test_json_attribute_roundtrip(setup_client, table):
     )
 
     # WHEN we save and load it
-    config.save()
-    loaded = Config.get(pk="CFG#1", sk="SETTINGS")
+    await config.save()
+    loaded = await Config.get(pk="CFG#1", sk="SETTINGS")
 
     # THEN JSON data is preserved
     assert loaded is not None
     assert loaded.settings == {"theme": "dark", "notifications": True, "count": 42}
 
 
-def test_json_attribute_with_list(setup_client, table):
+@pytest.mark.asyncio
+async def test_json_attribute_with_list(setup_client, table):
     """JSONAttribute saves and loads list correctly."""
 
     class Config(Model):
@@ -63,14 +65,15 @@ def test_json_attribute_with_list(setup_client, table):
         items = JSONAttribute()
 
     config = Config(pk="CFG#2", sk="ITEMS", items=["a", "b", "c"])
-    config.save()
+    await config.save()
 
-    loaded = Config.get(pk="CFG#2", sk="ITEMS")
+    loaded = await Config.get(pk="CFG#2", sk="ITEMS")
     assert loaded is not None
     assert loaded.items == ["a", "b", "c"]
 
 
-def test_enum_attribute_roundtrip(setup_client, table):
+@pytest.mark.asyncio
+async def test_enum_attribute_roundtrip(setup_client, table):
     """EnumAttribute saves and loads enum correctly."""
 
     class User(Model):
@@ -83,15 +86,16 @@ def test_enum_attribute_roundtrip(setup_client, table):
     user = User(pk="USER#1", sk="PROFILE", status=Status.ACTIVE)
 
     # WHEN we save and load it
-    user.save()
-    loaded = User.get(pk="USER#1", sk="PROFILE")
+    await user.save()
+    loaded = await User.get(pk="USER#1", sk="PROFILE")
 
     # THEN enum value is preserved
     assert loaded is not None
     assert loaded.status == Status.ACTIVE
 
 
-def test_enum_attribute_with_default(setup_client, table):
+@pytest.mark.asyncio
+async def test_enum_attribute_with_default(setup_client, table):
     """EnumAttribute uses default value."""
 
     class User(Model):
@@ -101,14 +105,15 @@ def test_enum_attribute_with_default(setup_client, table):
         status = EnumAttribute(Status, default=Status.PENDING)
 
     user = User(pk="USER#2", sk="PROFILE")
-    user.save()
+    await user.save()
 
-    loaded = User.get(pk="USER#2", sk="PROFILE")
+    loaded = await User.get(pk="USER#2", sk="PROFILE")
     assert loaded is not None
     assert loaded.status == Status.PENDING
 
 
-def test_datetime_attribute_roundtrip(setup_client, table):
+@pytest.mark.asyncio
+async def test_datetime_attribute_roundtrip(setup_client, table):
     """DatetimeAttribute saves and loads datetime correctly."""
 
     class Event(Model):
@@ -122,15 +127,16 @@ def test_datetime_attribute_roundtrip(setup_client, table):
     event = Event(pk="EVT#1", sk="DATA", created_at=dt)
 
     # WHEN we save and load it
-    event.save()
-    loaded = Event.get(pk="EVT#1", sk="DATA")
+    await event.save()
+    loaded = await Event.get(pk="EVT#1", sk="DATA")
 
     # THEN datetime is preserved
     assert loaded is not None
     assert loaded.created_at == dt
 
 
-def test_string_set_attribute_roundtrip(setup_client, table):
+@pytest.mark.asyncio
+async def test_string_set_attribute_roundtrip(setup_client, table):
     """StringSetAttribute saves and loads set correctly."""
 
     class User(Model):
@@ -143,15 +149,16 @@ def test_string_set_attribute_roundtrip(setup_client, table):
     user = User(pk="USER#3", sk="PROFILE", tags={"admin", "verified", "premium"})
 
     # WHEN we save and load it
-    user.save()
-    loaded = User.get(pk="USER#3", sk="PROFILE")
+    await user.save()
+    loaded = await User.get(pk="USER#3", sk="PROFILE")
 
     # THEN set is preserved
     assert loaded is not None
     assert loaded.tags == {"admin", "verified", "premium"}
 
 
-def test_number_set_attribute_roundtrip(setup_client, table):
+@pytest.mark.asyncio
+async def test_number_set_attribute_roundtrip(setup_client, table):
     """NumberSetAttribute saves and loads set correctly."""
 
     class User(Model):
@@ -161,14 +168,15 @@ def test_number_set_attribute_roundtrip(setup_client, table):
         scores = NumberSetAttribute()
 
     user = User(pk="USER#4", sk="PROFILE", scores={100, 95, 88})
-    user.save()
+    await user.save()
 
-    loaded = User.get(pk="USER#4", sk="PROFILE")
+    loaded = await User.get(pk="USER#4", sk="PROFILE")
     assert loaded is not None
     assert loaded.scores == {100, 95, 88}
 
 
-def test_number_set_attribute_with_floats(setup_client, table):
+@pytest.mark.asyncio
+async def test_number_set_attribute_with_floats(setup_client, table):
     """NumberSetAttribute handles floats correctly."""
 
     class User(Model):
@@ -178,9 +186,9 @@ def test_number_set_attribute_with_floats(setup_client, table):
         ratings = NumberSetAttribute()
 
     user = User(pk="USER#5", sk="PROFILE", ratings={4.5, 3.8, 5.0})
-    user.save()
+    await user.save()
 
-    loaded = User.get(pk="USER#5", sk="PROFILE")
+    loaded = await User.get(pk="USER#5", sk="PROFILE")
     assert loaded is not None
     # 5.0 becomes 5 (int)
     assert 4.5 in loaded.ratings

--- a/tests/integration/operations/test_batch_get.py
+++ b/tests/integration/operations/test_batch_get.py
@@ -1,4 +1,4 @@
-"""Integration tests for sync_batch_get operation."""
+"""Integration tests for batch_get operation."""
 
 import uuid
 
@@ -7,8 +7,9 @@ from pydynox import Model, ModelConfig
 from pydynox.attributes import NumberAttribute, StringAttribute
 
 
-def test_sync_batch_get_returns_items(dynamo):
-    """Test sync batch get with a few items."""
+@pytest.mark.asyncio
+async def test_batch_get_returns_items(dynamo):
+    """Test batch get with a few items."""
     # GIVEN existing items
     items = [
         {"pk": "BGET#1", "sk": "ITEM#1", "name": "Alice"},
@@ -16,11 +17,11 @@ def test_sync_batch_get_returns_items(dynamo):
         {"pk": "BGET#1", "sk": "ITEM#3", "name": "Charlie"},
     ]
     for item in items:
-        dynamo.put_item("test_table", item)
+        await dynamo.put_item("test_table", item)
 
-    # WHEN sync batch getting them
+    # WHEN batch getting them
     keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    results = dynamo.sync_batch_get("test_table", keys)
+    results = await dynamo.batch_get("test_table", keys)
 
     # THEN all items are returned
     assert len(results) == 3
@@ -28,34 +29,37 @@ def test_sync_batch_get_returns_items(dynamo):
     assert names == {"Alice", "Bob", "Charlie"}
 
 
-def test_sync_batch_get_missing_items_not_returned(dynamo):
-    """Test sync batch get with some missing items."""
+@pytest.mark.asyncio
+async def test_batch_get_missing_items_not_returned(dynamo):
+    """Test batch get with some missing items."""
     # GIVEN only one existing item
-    dynamo.put_item("test_table", {"pk": "MISS#1", "sk": "EXISTS", "name": "Found"})
+    await dynamo.put_item("test_table", {"pk": "MISS#1", "sk": "EXISTS", "name": "Found"})
 
-    # WHEN sync batch getting two items (one exists, one doesn't)
+    # WHEN batch getting two items (one exists, one doesn't)
     keys = [
         {"pk": "MISS#1", "sk": "EXISTS"},
         {"pk": "MISS#1", "sk": "NOTEXISTS"},
     ]
-    results = dynamo.sync_batch_get("test_table", keys)
+    results = await dynamo.batch_get("test_table", keys)
 
     # THEN only the existing item is returned
     assert len(results) == 1
     assert results[0]["name"] == "Found"
 
 
-def test_sync_batch_get_empty_keys_returns_empty(dynamo):
-    """Test sync batch get with empty keys list."""
-    # WHEN sync batch getting with empty keys
-    results = dynamo.sync_batch_get("test_table", [])
+@pytest.mark.asyncio
+async def test_batch_get_empty_keys_returns_empty(dynamo):
+    """Test batch get with empty keys list."""
+    # WHEN batch getting with empty keys
+    results = await dynamo.batch_get("test_table", [])
 
     # THEN empty list is returned
     assert results == []
 
 
-def test_sync_batch_get_more_than_100_items(dynamo):
-    """Test sync batch get with more than 100 items.
+@pytest.mark.asyncio
+async def test_batch_get_more_than_100_items(dynamo):
+    """Test batch get with more than 100 items.
 
     DynamoDB limits batch gets to 100 items per request.
     The client should split the request into multiple batches.
@@ -66,11 +70,11 @@ def test_sync_batch_get_more_than_100_items(dynamo):
         {"pk": "LARGE#1", "sk": f"ITEM#{i:03d}", "index": i, "data": f"value_{i}"}
         for i in range(120)
     ]
-    dynamo.sync_batch_write("test_table", put_items=items)
+    await dynamo.batch_write("test_table", put_items=items)
 
-    # WHEN sync batch getting all 120 items
+    # WHEN batch getting all 120 items
     keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    results = dynamo.sync_batch_get("test_table", keys)
+    results = await dynamo.batch_get("test_table", keys)
 
     # THEN all 120 items are returned
     assert len(results) == 120
@@ -78,15 +82,16 @@ def test_sync_batch_get_more_than_100_items(dynamo):
     assert indices == set(range(120))
 
 
-def test_sync_batch_get_exactly_100_items(dynamo):
-    """Test sync batch get with exactly 100 items (the limit)."""
+@pytest.mark.asyncio
+async def test_batch_get_exactly_100_items(dynamo):
+    """Test batch get with exactly 100 items (the limit)."""
     # GIVEN exactly 100 items
     items = [{"pk": "EXACT#1", "sk": f"ITEM#{i:02d}", "value": i} for i in range(100)]
-    dynamo.sync_batch_write("test_table", put_items=items)
+    await dynamo.batch_write("test_table", put_items=items)
 
-    # WHEN sync batch getting them
+    # WHEN batch getting them
     keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    results = dynamo.sync_batch_get("test_table", keys)
+    results = await dynamo.batch_get("test_table", keys)
 
     # THEN all 100 items are returned
     assert len(results) == 100
@@ -94,15 +99,16 @@ def test_sync_batch_get_exactly_100_items(dynamo):
     assert values == set(range(100))
 
 
-def test_sync_batch_get_150_items(dynamo):
-    """Test sync batch get with 150 items (requires 2 batches)."""
+@pytest.mark.asyncio
+async def test_batch_get_150_items(dynamo):
+    """Test batch get with 150 items (requires 2 batches)."""
     # GIVEN 150 items
     items = [{"pk": "ONEFIFTY#1", "sk": f"ITEM#{i:03d}", "num": i} for i in range(150)]
-    dynamo.sync_batch_write("test_table", put_items=items)
+    await dynamo.batch_write("test_table", put_items=items)
 
-    # WHEN sync batch getting them
+    # WHEN batch getting them
     keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    results = dynamo.sync_batch_get("test_table", keys)
+    results = await dynamo.batch_get("test_table", keys)
 
     # THEN all 150 items are returned
     assert len(results) == 150
@@ -110,8 +116,9 @@ def test_sync_batch_get_150_items(dynamo):
     assert nums == set(range(150))
 
 
-def test_sync_batch_get_with_various_types(dynamo):
-    """Test sync batch get with items containing various data types."""
+@pytest.mark.asyncio
+async def test_batch_get_with_various_types(dynamo):
+    """Test batch get with items containing various data types."""
     # GIVEN items with various data types
     items = [
         {
@@ -135,11 +142,11 @@ def test_sync_batch_get_with_various_types(dynamo):
             "map": {"key": 123},
         },
     ]
-    dynamo.sync_batch_write("test_table", put_items=items)
+    await dynamo.batch_write("test_table", put_items=items)
 
-    # WHEN sync batch getting them
+    # WHEN batch getting them
     keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    results = dynamo.sync_batch_get("test_table", keys)
+    results = await dynamo.batch_get("test_table", keys)
 
     # THEN all types are preserved
     assert len(results) == 2
@@ -150,12 +157,12 @@ def test_sync_batch_get_with_various_types(dynamo):
             assert result[field] == value
 
 
-# ========== Model.sync_batch_get tests ==========
+# ========== Model.batch_get tests ==========
 
 
 @pytest.fixture
 def user_model(dynamo):
-    """Create a User model for sync_batch_get tests."""
+    """Create a User model for batch_get tests."""
 
     class User(Model):
         model_config = ModelConfig(table="test_table", client=dynamo)
@@ -168,8 +175,9 @@ def user_model(dynamo):
     return User
 
 
-def test_model_sync_batch_get_returns_model_instances(dynamo, user_model):
-    """Model.sync_batch_get returns Model instances by default."""
+@pytest.mark.asyncio
+async def test_model_batch_get_returns_model_instances(dynamo, user_model):
+    """Model.batch_get returns Model instances by default."""
     # GIVEN existing items
     uid = str(uuid.uuid4())
     items = [
@@ -178,11 +186,11 @@ def test_model_sync_batch_get_returns_model_instances(dynamo, user_model):
         {"pk": f"MBGET#{uid}", "sk": "USER#3", "name": "Charlie", "age": 35},
     ]
     for item in items:
-        dynamo.put_item("test_table", item)
+        await dynamo.put_item("test_table", item)
 
-    # WHEN sync batch getting them
+    # WHEN batch getting them
     keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    users = user_model.sync_batch_get(keys)
+    users = await user_model.batch_get(keys)
 
     # THEN Model instances are returned
     assert len(users) == 3
@@ -192,8 +200,9 @@ def test_model_sync_batch_get_returns_model_instances(dynamo, user_model):
     assert names == {"Alice", "Bob", "Charlie"}
 
 
-def test_model_sync_batch_get_as_dict_returns_dicts(dynamo, user_model):
-    """Model.sync_batch_get(as_dict=True) returns plain dicts."""
+@pytest.mark.asyncio
+async def test_model_batch_get_as_dict_returns_dicts(dynamo, user_model):
+    """Model.batch_get(as_dict=True) returns plain dicts."""
     # GIVEN existing items
     uid = str(uuid.uuid4())
     items = [
@@ -201,11 +210,11 @@ def test_model_sync_batch_get_as_dict_returns_dicts(dynamo, user_model):
         {"pk": f"MBGETD#{uid}", "sk": "USER#2", "name": "Bob", "age": 30},
     ]
     for item in items:
-        dynamo.put_item("test_table", item)
+        await dynamo.put_item("test_table", item)
 
-    # WHEN sync batch getting with as_dict=True
+    # WHEN batch getting with as_dict=True
     keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    users = user_model.sync_batch_get(keys, as_dict=True)
+    users = await user_model.batch_get(keys, as_dict=True)
 
     # THEN plain dicts are returned
     assert len(users) == 2
@@ -215,30 +224,32 @@ def test_model_sync_batch_get_as_dict_returns_dicts(dynamo, user_model):
     assert names == {"Alice", "Bob"}
 
 
-def test_model_sync_batch_get_empty_keys(user_model):
-    """Model.sync_batch_get with empty keys returns empty list."""
-    # WHEN sync batch getting with empty keys
-    users = user_model.sync_batch_get([])
+@pytest.mark.asyncio
+async def test_model_batch_get_empty_keys(user_model):
+    """Model.batch_get with empty keys returns empty list."""
+    # WHEN batch getting with empty keys
+    users = await user_model.batch_get([])
 
     # THEN empty list is returned
     assert users == []
 
 
-def test_model_sync_batch_get_missing_items(dynamo, user_model):
-    """Model.sync_batch_get only returns existing items."""
+@pytest.mark.asyncio
+async def test_model_batch_get_missing_items(dynamo, user_model):
+    """Model.batch_get only returns existing items."""
     # GIVEN only one existing item
     uid = str(uuid.uuid4())
-    dynamo.put_item(
+    await dynamo.put_item(
         "test_table",
         {"pk": f"MBGETM#{uid}", "sk": "EXISTS", "name": "Found", "age": 20},
     )
 
-    # WHEN sync batch getting two items (one exists, one doesn't)
+    # WHEN batch getting two items (one exists, one doesn't)
     keys = [
         {"pk": f"MBGETM#{uid}", "sk": "EXISTS"},
         {"pk": f"MBGETM#{uid}", "sk": "NOTEXISTS"},
     ]
-    users = user_model.sync_batch_get(keys)
+    users = await user_model.batch_get(keys)
 
     # THEN only the existing item is returned
     assert len(users) == 1

--- a/tests/integration/operations/test_batch_write.py
+++ b/tests/integration/operations/test_batch_write.py
@@ -1,8 +1,11 @@
-"""Integration tests for sync_batch_write operation."""
+"""Integration tests for batch_write operation."""
+
+import pytest
 
 
-def test_sync_batch_write_puts_items(dynamo):
-    """Test sync batch write with a few items."""
+@pytest.mark.asyncio
+async def test_batch_write_puts_items(dynamo):
+    """Test batch write with a few items."""
     # GIVEN a list of items
     items = [
         {"pk": "BATCH#1", "sk": "ITEM#1", "name": "Alice"},
@@ -10,19 +13,20 @@ def test_sync_batch_write_puts_items(dynamo):
         {"pk": "BATCH#1", "sk": "ITEM#3", "name": "Charlie"},
     ]
 
-    # WHEN sync batch writing them
-    dynamo.sync_batch_write("test_table", put_items=items)
+    # WHEN batch writing them
+    await dynamo.batch_write("test_table", put_items=items)
 
     # THEN all items are saved
     for item in items:
         key = {"pk": item["pk"], "sk": item["sk"]}
-        result = dynamo.get_item("test_table", key)
+        result = await dynamo.get_item("test_table", key)
         assert result is not None
         assert result["name"] == item["name"]
 
 
-def test_sync_batch_write_deletes_items(dynamo):
-    """Test sync batch write with delete operations."""
+@pytest.mark.asyncio
+async def test_batch_write_deletes_items(dynamo):
+    """Test batch write with delete operations."""
     # GIVEN existing items
     items = [
         {"pk": "DEL#1", "sk": "ITEM#1", "name": "ToDelete1"},
@@ -30,45 +34,47 @@ def test_sync_batch_write_deletes_items(dynamo):
         {"pk": "DEL#1", "sk": "ITEM#3", "name": "ToDelete3"},
     ]
     for item in items:
-        dynamo.put_item("test_table", item)
+        await dynamo.put_item("test_table", item)
 
-    # WHEN sync batch deleting them
+    # WHEN batch deleting them
     delete_keys = [{"pk": item["pk"], "sk": item["sk"]} for item in items]
-    dynamo.sync_batch_write("test_table", delete_keys=delete_keys)
+    await dynamo.batch_write("test_table", delete_keys=delete_keys)
 
     # THEN all items are deleted
     for key in delete_keys:
-        result = dynamo.get_item("test_table", key)
+        result = await dynamo.get_item("test_table", key)
         assert result is None
 
 
-def test_sync_batch_write_mixed_operations(dynamo):
-    """Test sync batch write with both puts and deletes."""
+@pytest.mark.asyncio
+async def test_batch_write_mixed_operations(dynamo):
+    """Test batch write with both puts and deletes."""
     # GIVEN an existing item to delete
     to_delete = {"pk": "MIX#1", "sk": "DELETE", "name": "WillBeDeleted"}
-    dynamo.put_item("test_table", to_delete)
+    await dynamo.put_item("test_table", to_delete)
 
-    # WHEN sync batch writing puts and deletes
+    # WHEN batch writing puts and deletes
     new_items = [
         {"pk": "MIX#1", "sk": "NEW#1", "name": "NewItem1"},
         {"pk": "MIX#1", "sk": "NEW#2", "name": "NewItem2"},
     ]
     delete_keys = [{"pk": "MIX#1", "sk": "DELETE"}]
-    dynamo.sync_batch_write("test_table", put_items=new_items, delete_keys=delete_keys)
+    await dynamo.batch_write("test_table", put_items=new_items, delete_keys=delete_keys)
 
     # THEN new items exist and deleted item is gone
     for item in new_items:
         key = {"pk": item["pk"], "sk": item["sk"]}
-        result = dynamo.get_item("test_table", key)
+        result = await dynamo.get_item("test_table", key)
         assert result is not None
         assert result["name"] == item["name"]
 
-    result = dynamo.get_item("test_table", {"pk": "MIX#1", "sk": "DELETE"})
+    result = await dynamo.get_item("test_table", {"pk": "MIX#1", "sk": "DELETE"})
     assert result is None
 
 
-def test_sync_batch_write_more_than_25_items(dynamo):
-    """Test sync batch write with more than 25 items.
+@pytest.mark.asyncio
+async def test_batch_write_more_than_25_items(dynamo):
+    """Test batch write with more than 25 items.
 
     DynamoDB limits batch writes to 25 items per request.
     The client should split the request into multiple batches.
@@ -80,59 +86,63 @@ def test_sync_batch_write_more_than_25_items(dynamo):
         for i in range(30)
     ]
 
-    # WHEN sync batch writing them
-    dynamo.sync_batch_write("test_table", put_items=items)
+    # WHEN batch writing them
+    await dynamo.batch_write("test_table", put_items=items)
 
     # THEN all 30 items are saved
     for item in items:
         key = {"pk": item["pk"], "sk": item["sk"]}
-        result = dynamo.get_item("test_table", key)
+        result = await dynamo.get_item("test_table", key)
         assert result is not None
         assert result["index"] == item["index"]
         assert result["data"] == item["data"]
 
 
-def test_sync_batch_write_exactly_25_items(dynamo):
-    """Test sync batch write with exactly 25 items (the limit)."""
+@pytest.mark.asyncio
+async def test_batch_write_exactly_25_items(dynamo):
+    """Test batch write with exactly 25 items (the limit)."""
     # GIVEN exactly 25 items
     items = [{"pk": "EXACT#1", "sk": f"ITEM#{i:02d}", "value": i} for i in range(25)]
 
-    # WHEN sync batch writing them
-    dynamo.sync_batch_write("test_table", put_items=items)
+    # WHEN batch writing them
+    await dynamo.batch_write("test_table", put_items=items)
 
     # THEN all items are saved
     for item in items:
         key = {"pk": item["pk"], "sk": item["sk"]}
-        result = dynamo.get_item("test_table", key)
+        result = await dynamo.get_item("test_table", key)
         assert result is not None
         assert result["value"] == item["value"]
 
 
-def test_sync_batch_write_50_items(dynamo):
-    """Test sync batch write with 50 items (requires 2 batches)."""
+@pytest.mark.asyncio
+async def test_batch_write_50_items(dynamo):
+    """Test batch write with 50 items (requires 2 batches)."""
     # GIVEN 50 items
     items = [{"pk": "FIFTY#1", "sk": f"ITEM#{i:03d}", "num": i} for i in range(50)]
 
-    # WHEN sync batch writing them
-    dynamo.sync_batch_write("test_table", put_items=items)
+    # WHEN batch writing them
+    await dynamo.batch_write("test_table", put_items=items)
 
     # THEN all 50 items are saved
     for item in items:
         key = {"pk": item["pk"], "sk": item["sk"]}
-        result = dynamo.get_item("test_table", key)
+        result = await dynamo.get_item("test_table", key)
         assert result is not None
         assert result["num"] == item["num"]
 
 
-def test_sync_batch_write_empty_lists(dynamo):
-    """Test sync batch write with empty lists does nothing."""
-    # WHEN sync batch writing empty lists
+@pytest.mark.asyncio
+async def test_batch_write_empty_lists(dynamo):
+    """Test batch write with empty lists does nothing."""
+    # WHEN batch writing empty lists
     # THEN no error is raised
-    dynamo.sync_batch_write("test_table", put_items=[], delete_keys=[])
+    await dynamo.batch_write("test_table", put_items=[], delete_keys=[])
 
 
-def test_sync_batch_write_with_various_types(dynamo):
-    """Test sync batch write with items containing various data types."""
+@pytest.mark.asyncio
+async def test_batch_write_with_various_types(dynamo):
+    """Test batch write with items containing various data types."""
     # GIVEN items with various data types
     items = [
         {
@@ -157,13 +167,13 @@ def test_sync_batch_write_with_various_types(dynamo):
         },
     ]
 
-    # WHEN sync batch writing them
-    dynamo.sync_batch_write("test_table", put_items=items)
+    # WHEN batch writing them
+    await dynamo.batch_write("test_table", put_items=items)
 
     # THEN all types are preserved
     for item in items:
         key = {"pk": item["pk"], "sk": item["sk"]}
-        result = dynamo.get_item("test_table", key)
+        result = await dynamo.get_item("test_table", key)
         assert result is not None
         for field, value in item.items():
             assert result[field] == value

--- a/tests/integration/operations/test_condition_check_failed.py
+++ b/tests/integration/operations/test_condition_check_failed.py
@@ -10,17 +10,18 @@ import pytest
 from pydynox.exceptions import ConditionalCheckFailedException
 
 
-def test_put_item_condition_failed_returns_item(dynamo):
+@pytest.mark.asyncio
+async def test_put_item_condition_failed_returns_item(dynamo):
     """put_item with condition failure returns the existing item."""
     pk = f"test-{uuid.uuid4()}"
     sk = "profile"
 
     # Create initial item
-    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "version": 1})
+    await dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "version": 1})
 
     # Try to put with condition that fails
     with pytest.raises(ConditionalCheckFailedException) as exc_info:
-        dynamo.put_item(
+        await dynamo.put_item(
             "test_table",
             {"pk": pk, "sk": sk, "name": "Bob", "version": 2},
             condition_expression="attribute_not_exists(pk)",
@@ -37,17 +38,18 @@ def test_put_item_condition_failed_returns_item(dynamo):
     assert exc.item["version"] == 1
 
 
-def test_put_item_condition_failed_no_item_by_default(dynamo):
+@pytest.mark.asyncio
+async def test_put_item_condition_failed_no_item_by_default(dynamo):
     """put_item without return flag does not return item."""
     pk = f"test-{uuid.uuid4()}"
     sk = "profile"
 
     # Create initial item
-    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice"})
+    await dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice"})
 
     # Try to put with condition that fails (no return flag)
     with pytest.raises(ConditionalCheckFailedException) as exc_info:
-        dynamo.put_item(
+        await dynamo.put_item(
             "test_table",
             {"pk": pk, "sk": sk, "name": "Bob"},
             condition_expression="attribute_not_exists(pk)",
@@ -59,17 +61,18 @@ def test_put_item_condition_failed_no_item_by_default(dynamo):
     assert item is None, "item should be None when return flag is not set"
 
 
-def test_update_item_condition_failed_returns_item(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_condition_failed_returns_item(dynamo):
     """update_item with condition failure returns the existing item."""
     pk = f"test-{uuid.uuid4()}"
     sk = "profile"
 
     # Create initial item
-    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "version": 1})
+    await dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "version": 1})
 
     # Try to update with condition that fails
     with pytest.raises(ConditionalCheckFailedException) as exc_info:
-        dynamo.update_item(
+        await dynamo.update_item(
             "test_table",
             {"pk": pk, "sk": sk},
             updates={"name": "Bob"},
@@ -86,17 +89,18 @@ def test_update_item_condition_failed_returns_item(dynamo):
     assert exc.item["version"] == 1
 
 
-def test_delete_item_condition_failed_returns_item(dynamo):
+@pytest.mark.asyncio
+async def test_delete_item_condition_failed_returns_item(dynamo):
     """delete_item with condition failure returns the existing item."""
     pk = f"test-{uuid.uuid4()}"
     sk = "profile"
 
     # Create initial item
-    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "status": "active"})
+    await dynamo.put_item("test_table", {"pk": pk, "sk": sk, "name": "Alice", "status": "active"})
 
     # Try to delete with condition that fails
     with pytest.raises(ConditionalCheckFailedException) as exc_info:
-        dynamo.delete_item(
+        await dynamo.delete_item(
             "test_table",
             {"pk": pk, "sk": sk},
             condition_expression="#s = :expected",
@@ -112,16 +116,17 @@ def test_delete_item_condition_failed_returns_item(dynamo):
     assert exc.item["status"] == "active"
 
 
-def test_optimistic_locking_pattern(dynamo):
+@pytest.mark.asyncio
+async def test_optimistic_locking_pattern(dynamo):
     """Real-world pattern: optimistic locking with version check."""
     pk = f"test-{uuid.uuid4()}"
     sk = "counter"
 
     # Create item with version
-    dynamo.put_item("test_table", {"pk": pk, "sk": sk, "count": 0, "version": 1})
+    await dynamo.put_item("test_table", {"pk": pk, "sk": sk, "count": 0, "version": 1})
 
     # Simulate concurrent update - first one succeeds
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": pk, "sk": sk},
         updates={"count": 1, "version": 2},
@@ -132,7 +137,7 @@ def test_optimistic_locking_pattern(dynamo):
 
     # Second update with stale version fails
     with pytest.raises(ConditionalCheckFailedException) as exc_info:
-        dynamo.update_item(
+        await dynamo.update_item(
             "test_table",
             {"pk": pk, "sk": sk},
             updates={"count": 100, "version": 2},

--- a/tests/integration/operations/test_conditions.py
+++ b/tests/integration/operations/test_conditions.py
@@ -28,7 +28,8 @@ def user_model(dynamo):
     return User
 
 
-def test_save_with_does_not_exist_condition_succeeds(user_model):
+@pytest.mark.asyncio
+async def test_save_with_does_not_exist_condition_succeeds(user_model):
     """First save with does_not_exist should work."""
     User = user_model
 
@@ -36,236 +37,251 @@ def test_save_with_does_not_exist_condition_succeeds(user_model):
     user = User(pk="COND#1", sk="PROFILE", name="Alice", age=25, status="active")
 
     # WHEN we save with does_not_exist condition
-    user.save(condition=User.pk.not_exists())
+    await user.save(condition=User.pk.not_exists())
 
     # THEN the save succeeds
-    loaded = User.get(pk="COND#1", sk="PROFILE")
+    loaded = await User.get(pk="COND#1", sk="PROFILE")
     assert loaded is not None
     assert loaded.name == "Alice"
 
 
-def test_save_with_does_not_exist_condition_fails_on_existing(user_model):
+@pytest.mark.asyncio
+async def test_save_with_does_not_exist_condition_fails_on_existing(user_model):
     """Second save with does_not_exist should fail."""
     User = user_model
 
     # GIVEN an existing user
     user = User(pk="COND#2", sk="PROFILE", name="Bob", age=30, status="active")
-    user.save()
+    await user.save()
 
     # WHEN we try to save another with same key and does_not_exist condition
     user2 = User(pk="COND#2", sk="PROFILE", name="Bob2", age=35, status="active")
 
     # THEN it fails
     with pytest.raises(Exception) as exc_info:
-        user2.save(condition=User.pk.not_exists())
+        await user2.save(condition=User.pk.not_exists())
 
     assert "condition" in str(exc_info.value).lower() or "Condition" in str(
         type(exc_info.value).__name__
     )
 
 
-def test_save_with_eq_condition_succeeds(user_model):
+@pytest.mark.asyncio
+async def test_save_with_eq_condition_succeeds(user_model):
     """Save with matching == condition should work."""
     User = user_model
 
     user = User(pk="COND#3", sk="PROFILE", name="Charlie", age=25, status="active")
-    user.save()
+    await user.save()
 
     # Update with matching condition
     user.name = "Charlie Updated"
-    user.save(condition=User.status == "active")
+    await user.save(condition=User.status == "active")
 
-    loaded = User.get(pk="COND#3", sk="PROFILE")
+    loaded = await User.get(pk="COND#3", sk="PROFILE")
     assert loaded.name == "Charlie Updated"
 
 
-def test_save_with_eq_condition_fails_on_mismatch(user_model):
+@pytest.mark.asyncio
+async def test_save_with_eq_condition_fails_on_mismatch(user_model):
     """Save with non-matching == condition should fail."""
     User = user_model
 
     user = User(pk="COND#4", sk="PROFILE", name="Diana", age=25, status="active")
-    user.save()
+    await user.save()
 
     user.name = "Diana Updated"
     with pytest.raises(Exception):
-        user.save(condition=User.status == "inactive")
+        await user.save(condition=User.status == "inactive")
 
     # Original should be unchanged
-    loaded = User.get(pk="COND#4", sk="PROFILE")
+    loaded = await User.get(pk="COND#4", sk="PROFILE")
     assert loaded.name == "Diana"
 
 
-def test_delete_with_condition_succeeds(user_model):
+@pytest.mark.asyncio
+async def test_delete_with_condition_succeeds(user_model):
     """Delete with matching condition should work."""
     User = user_model
 
     # GIVEN an active user
     user = User(pk="COND#5", sk="PROFILE", name="Eve", age=25, status="active")
-    user.save()
+    await user.save()
 
     # WHEN we delete with matching condition
-    user.delete(condition=User.status == "active")
+    await user.delete(condition=User.status == "active")
 
     # THEN the user is deleted
-    loaded = User.get(pk="COND#5", sk="PROFILE")
+    loaded = await User.get(pk="COND#5", sk="PROFILE")
     assert loaded is None
 
 
-def test_delete_with_condition_fails_on_mismatch(user_model):
+@pytest.mark.asyncio
+async def test_delete_with_condition_fails_on_mismatch(user_model):
     """Delete with non-matching condition should fail."""
     User = user_model
 
     # GIVEN an active user
     user = User(pk="COND#6", sk="PROFILE", name="Frank", age=25, status="active")
-    user.save()
+    await user.save()
 
     # WHEN we try to delete with wrong condition
     # THEN it fails
     with pytest.raises(Exception):
-        user.delete(condition=User.status == "inactive")
+        await user.delete(condition=User.status == "inactive")
 
     # AND user is NOT deleted
-    loaded = User.get(pk="COND#6", sk="PROFILE")
+    loaded = await User.get(pk="COND#6", sk="PROFILE")
     assert loaded is not None
     assert loaded.name == "Frank"
 
 
-def test_save_with_combined_condition(user_model):
+@pytest.mark.asyncio
+async def test_save_with_combined_condition(user_model):
     """Save with AND condition should work."""
     User = user_model
 
     user = User(pk="COND#7", sk="PROFILE", name="Grace", age=25, status="active")
-    user.save()
+    await user.save()
 
     user.name = "Grace Updated"
-    user.save(condition=(User.status == "active") & (User.age == 25))
+    await user.save(condition=(User.status == "active") & (User.age == 25))
 
-    loaded = User.get(pk="COND#7", sk="PROFILE")
+    loaded = await User.get(pk="COND#7", sk="PROFILE")
     assert loaded.name == "Grace Updated"
 
 
-def test_save_with_exists_condition(user_model):
+@pytest.mark.asyncio
+async def test_save_with_exists_condition(user_model):
     """Save with exists() condition should work."""
     User = user_model
 
     user = User(pk="COND#8", sk="PROFILE", name="Henry", age=25, status="active")
-    user.save()
+    await user.save()
 
     user.name = "Henry Updated"
-    user.save(condition=User.name.exists())
+    await user.save(condition=User.name.exists())
 
-    loaded = User.get(pk="COND#8", sk="PROFILE")
+    loaded = await User.get(pk="COND#8", sk="PROFILE")
     assert loaded.name == "Henry Updated"
 
 
-def test_delete_with_gt_condition(user_model):
+@pytest.mark.asyncio
+async def test_delete_with_gt_condition(user_model):
     """Delete with > condition should work."""
     User = user_model
 
     user = User(pk="COND#9", sk="PROFILE", name="Ivy", age=30, status="active")
-    user.save()
+    await user.save()
 
-    user.delete(condition=User.age > 25)
+    await user.delete(condition=User.age > 25)
 
-    loaded = User.get(pk="COND#9", sk="PROFILE")
+    loaded = await User.get(pk="COND#9", sk="PROFILE")
     assert loaded is None
 
 
-def test_save_with_or_condition(user_model):
+@pytest.mark.asyncio
+async def test_save_with_or_condition(user_model):
     """Save with OR condition should work."""
     User = user_model
 
     user = User(pk="COND#10", sk="PROFILE", name="Jack", age=25, status="pending")
-    user.save()
+    await user.save()
 
     # Update if status is active OR pending
     user.name = "Jack Updated"
-    user.save(condition=(User.status == "active") | (User.status == "pending"))
+    await user.save(condition=(User.status == "active") | (User.status == "pending"))
 
-    loaded = User.get(pk="COND#10", sk="PROFILE")
+    loaded = await User.get(pk="COND#10", sk="PROFILE")
     assert loaded.name == "Jack Updated"
 
 
-def test_save_with_not_condition(user_model):
+@pytest.mark.asyncio
+async def test_save_with_not_condition(user_model):
     """Save with NOT condition should work."""
     User = user_model
 
     user = User(pk="COND#11", sk="PROFILE", name="Kate", age=25, status="active")
-    user.save()
+    await user.save()
 
     # Update if status is NOT deleted
     user.name = "Kate Updated"
-    user.save(condition=~(User.status == "deleted"))
+    await user.save(condition=~(User.status == "deleted"))
 
-    loaded = User.get(pk="COND#11", sk="PROFILE")
+    loaded = await User.get(pk="COND#11", sk="PROFILE")
     assert loaded.name == "Kate Updated"
 
 
-def test_save_with_complex_condition(user_model):
+@pytest.mark.asyncio
+async def test_save_with_complex_condition(user_model):
     """Save with complex AND/OR/NOT condition should work."""
     User = user_model
 
     user = User(pk="COND#12", sk="PROFILE", name="Leo", age=30, status="active")
-    user.save()
+    await user.save()
 
     # Complex: (status == active AND age > 25) OR name exists
     complex_cond = ((User.status == "active") & (User.age > 25)) | User.name.exists()
 
     user.name = "Leo Updated"
-    user.save(condition=complex_cond)
+    await user.save(condition=complex_cond)
 
-    loaded = User.get(pk="COND#12", sk="PROFILE")
+    loaded = await User.get(pk="COND#12", sk="PROFILE")
     assert loaded.name == "Leo Updated"
 
 
-def test_delete_with_or_condition(user_model):
+@pytest.mark.asyncio
+async def test_delete_with_or_condition(user_model):
     """Delete with OR condition should work."""
     User = user_model
 
     user = User(pk="COND#13", sk="PROFILE", name="Mia", age=25, status="inactive")
-    user.save()
+    await user.save()
 
     # Delete if status is active OR inactive
-    user.delete(condition=(User.status == "active") | (User.status == "inactive"))
+    await user.delete(condition=(User.status == "active") | (User.status == "inactive"))
 
-    loaded = User.get(pk="COND#13", sk="PROFILE")
+    loaded = await User.get(pk="COND#13", sk="PROFILE")
     assert loaded is None
 
 
-def test_save_with_between_condition(user_model):
+@pytest.mark.asyncio
+async def test_save_with_between_condition(user_model):
     """Save with between condition should work."""
     User = user_model
 
     user = User(pk="COND#14", sk="PROFILE", name="Nina", age=30, status="active")
-    user.save()
+    await user.save()
 
     user.name = "Nina Updated"
-    user.save(condition=User.age.between(25, 35))
+    await user.save(condition=User.age.between(25, 35))
 
-    loaded = User.get(pk="COND#14", sk="PROFILE")
+    loaded = await User.get(pk="COND#14", sk="PROFILE")
     assert loaded.name == "Nina Updated"
 
 
-def test_save_with_begins_with_condition(user_model):
+@pytest.mark.asyncio
+async def test_save_with_begins_with_condition(user_model):
     """Save with begins_with condition should work."""
     User = user_model
 
     user = User(pk="COND#15", sk="ORDER#001", name="Oscar", age=25, status="active")
-    user.save()
+    await user.save()
 
     user.name = "Oscar Updated"
-    user.save(condition=User.sk.begins_with("ORDER#"))
+    await user.save(condition=User.sk.begins_with("ORDER#"))
 
-    loaded = User.get(pk="COND#15", sk="ORDER#001")
+    loaded = await User.get(pk="COND#15", sk="ORDER#001")
     assert loaded.name == "Oscar Updated"
 
 
-def test_save_with_condition_in_variable(user_model):
+@pytest.mark.asyncio
+async def test_save_with_condition_in_variable(user_model):
     """Save with condition stored in variable should work."""
     User = user_model
 
     user = User(pk="COND#16", sk="PROFILE", name="Paul", age=28, status="active")
-    user.save()
+    await user.save()
 
     # Build condition and store in variable
     is_active = User.status == "active"
@@ -273,48 +289,52 @@ def test_save_with_condition_in_variable(user_model):
     my_condition = is_active & is_adult
 
     user.name = "Paul Updated"
-    user.save(condition=my_condition)
+    await user.save(condition=my_condition)
 
-    loaded = User.get(pk="COND#16", sk="PROFILE")
+    loaded = await User.get(pk="COND#16", sk="PROFILE")
     assert loaded.name == "Paul Updated"
 
 
-def test_delete_with_condition_in_variable(user_model):
+@pytest.mark.asyncio
+async def test_delete_with_condition_in_variable(user_model):
     """Delete with condition stored in variable should work."""
     User = user_model
 
     user = User(pk="COND#17", sk="PROFILE", name="Quinn", age=35, status="pending")
-    user.save()
+    await user.save()
 
     # Build complex condition in steps
     status_ok = (User.status == "active") | (User.status == "pending")
     age_ok = User.age > 30
     final_condition = status_ok & age_ok
 
-    user.delete(condition=final_condition)
+    await user.delete(condition=final_condition)
 
-    loaded = User.get(pk="COND#17", sk="PROFILE")
+    loaded = await User.get(pk="COND#17", sk="PROFILE")
     assert loaded is None
 
 
-def test_reuse_condition_multiple_times(user_model):
+@pytest.mark.asyncio
+async def test_reuse_condition_multiple_times(user_model):
     """Same condition can be reused for multiple operations."""
     User = user_model
 
     # Create two users
     user1 = User(pk="COND#18", sk="PROFILE", name="Rose", age=25, status="active")
-    user1.save()
+    await user1.save()
     user2 = User(pk="COND#19", sk="PROFILE", name="Sam", age=30, status="active")
-    user2.save()
+    await user2.save()
 
     # Define condition once, use twice
     must_be_active = User.status == "active"
 
     user1.name = "Rose Updated"
-    user1.save(condition=must_be_active)
+    await user1.save(condition=must_be_active)
 
     user2.name = "Sam Updated"
-    user2.save(condition=must_be_active)
+    await user2.save(condition=must_be_active)
 
-    assert User.get(pk="COND#18", sk="PROFILE").name == "Rose Updated"
-    assert User.get(pk="COND#19", sk="PROFILE").name == "Sam Updated"
+    loaded1 = await User.get(pk="COND#18", sk="PROFILE")
+    loaded2 = await User.get(pk="COND#19", sk="PROFILE")
+    assert loaded1.name == "Rose Updated"
+    assert loaded2.name == "Sam Updated"

--- a/tests/integration/operations/test_delete_item.py
+++ b/tests/integration/operations/test_delete_item.py
@@ -4,37 +4,40 @@ import pytest
 from pydynox.exceptions import ConditionalCheckFailedException, ResourceNotFoundException
 
 
-def test_delete_item_removes_item(dynamo):
+@pytest.mark.asyncio
+async def test_delete_item_removes_item(dynamo):
     """Test that delete_item removes an existing item."""
     # GIVEN an existing item
     item = {"pk": "USER#DEL1", "sk": "PROFILE", "name": "ToDelete"}
-    dynamo.put_item("test_table", item)
-    result = dynamo.get_item("test_table", {"pk": "USER#DEL1", "sk": "PROFILE"})
+    await dynamo.put_item("test_table", item)
+    result = await dynamo.get_item("test_table", {"pk": "USER#DEL1", "sk": "PROFILE"})
     assert result is not None
 
     # WHEN deleting the item
-    dynamo.delete_item("test_table", {"pk": "USER#DEL1", "sk": "PROFILE"})
+    await dynamo.delete_item("test_table", {"pk": "USER#DEL1", "sk": "PROFILE"})
 
     # THEN the item is gone
-    result = dynamo.get_item("test_table", {"pk": "USER#DEL1", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#DEL1", "sk": "PROFILE"})
     assert result is None
 
 
-def test_delete_item_nonexistent_succeeds(dynamo):
+@pytest.mark.asyncio
+async def test_delete_item_nonexistent_succeeds(dynamo):
     """Test that deleting a non-existent item does not raise an error."""
     # WHEN deleting a non-existent item
     # THEN no error is raised (DynamoDB delete is idempotent)
-    dynamo.delete_item("test_table", {"pk": "NONEXISTENT", "sk": "NONE"})
+    await dynamo.delete_item("test_table", {"pk": "NONEXISTENT", "sk": "NONE"})
 
 
-def test_delete_item_with_condition_success(dynamo):
+@pytest.mark.asyncio
+async def test_delete_item_with_condition_success(dynamo):
     """Test delete with a condition that passes."""
     # GIVEN an item with status=inactive
     item = {"pk": "USER#DEL2", "sk": "PROFILE", "status": "inactive"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN deleting with condition status=inactive
-    dynamo.delete_item(
+    await dynamo.delete_item(
         "test_table",
         {"pk": "USER#DEL2", "sk": "PROFILE"},
         condition_expression="#s = :val",
@@ -43,20 +46,21 @@ def test_delete_item_with_condition_success(dynamo):
     )
 
     # THEN the item is deleted
-    result = dynamo.get_item("test_table", {"pk": "USER#DEL2", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#DEL2", "sk": "PROFILE"})
     assert result is None
 
 
-def test_delete_item_with_condition_fails(dynamo):
+@pytest.mark.asyncio
+async def test_delete_item_with_condition_fails(dynamo):
     """Test delete with a condition that fails raises an error."""
     # GIVEN an item with status=active
     item = {"pk": "USER#DEL3", "sk": "PROFILE", "status": "active"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN deleting with condition status=inactive
     # THEN ConditionalCheckFailedException is raised
     with pytest.raises(ConditionalCheckFailedException):
-        dynamo.delete_item(
+        await dynamo.delete_item(
             "test_table",
             {"pk": "USER#DEL3", "sk": "PROFILE"},
             condition_expression="#s = :val",
@@ -65,19 +69,20 @@ def test_delete_item_with_condition_fails(dynamo):
         )
 
     # AND item still exists
-    result = dynamo.get_item("test_table", {"pk": "USER#DEL3", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#DEL3", "sk": "PROFILE"})
     assert result is not None
     assert result["status"] == "active"
 
 
-def test_delete_item_with_attribute_exists_condition(dynamo):
+@pytest.mark.asyncio
+async def test_delete_item_with_attribute_exists_condition(dynamo):
     """Test delete with attribute_exists condition."""
     # GIVEN an existing item
     item = {"pk": "USER#DEL4", "sk": "PROFILE", "name": "Test"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN deleting with attribute_exists condition
-    dynamo.delete_item(
+    await dynamo.delete_item(
         "test_table",
         {"pk": "USER#DEL4", "sk": "PROFILE"},
         condition_expression="attribute_exists(#pk)",
@@ -85,13 +90,14 @@ def test_delete_item_with_attribute_exists_condition(dynamo):
     )
 
     # THEN the item is deleted
-    result = dynamo.get_item("test_table", {"pk": "USER#DEL4", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#DEL4", "sk": "PROFILE"})
     assert result is None
 
 
-def test_delete_item_table_not_found(dynamo):
+@pytest.mark.asyncio
+async def test_delete_item_table_not_found(dynamo):
     """Test delete from non-existent table raises error."""
     # WHEN deleting from a non-existent table
     # THEN ResourceNotFoundException is raised
     with pytest.raises(ResourceNotFoundException):
-        dynamo.delete_item("nonexistent_table", {"pk": "X", "sk": "Y"})
+        await dynamo.delete_item("nonexistent_table", {"pk": "X", "sk": "Y"})

--- a/tests/integration/operations/test_get_item.py
+++ b/tests/integration/operations/test_get_item.py
@@ -26,15 +26,16 @@ GET_ITEM_CASES = [
 ]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("item", GET_ITEM_CASES)
-def test_get_item_retrieves_correctly(dynamo, item):
+async def test_get_item_retrieves_correctly(dynamo, item):
     """Test retrieving items with different data types."""
     # GIVEN an item saved in DynamoDB
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN getting the item by key
     key = {"pk": item["pk"], "sk": item["sk"]}
-    result = dynamo.get_item("test_table", key)
+    result = await dynamo.get_item("test_table", key)
 
     # THEN all fields match
     assert result is not None
@@ -42,36 +43,39 @@ def test_get_item_retrieves_correctly(dynamo, item):
         assert result[field] == value
 
 
-def test_get_item_not_found_returns_none(dynamo):
+@pytest.mark.asyncio
+async def test_get_item_not_found_returns_none(dynamo):
     """Test that get_item returns None for non-existent items."""
     # WHEN getting a non-existent item
-    result = dynamo.get_item("test_table", {"pk": "NONEXISTENT", "sk": "NONE"})
+    result = await dynamo.get_item("test_table", {"pk": "NONEXISTENT", "sk": "NONE"})
 
     # THEN None is returned
     assert result is None
 
 
-def test_get_item_with_partial_key(dynamo):
+@pytest.mark.asyncio
+async def test_get_item_with_partial_key(dynamo):
     """Test get_item only returns exact key match."""
     # GIVEN two items with same pk but different sk
-    dynamo.put_item("test_table", {"pk": "PARTIAL#1", "sk": "A", "data": "first"})
-    dynamo.put_item("test_table", {"pk": "PARTIAL#1", "sk": "B", "data": "second"})
+    await dynamo.put_item("test_table", {"pk": "PARTIAL#1", "sk": "A", "data": "first"})
+    await dynamo.put_item("test_table", {"pk": "PARTIAL#1", "sk": "B", "data": "second"})
 
     # WHEN getting with specific sk
-    result = dynamo.get_item("test_table", {"pk": "PARTIAL#1", "sk": "A"})
+    result = await dynamo.get_item("test_table", {"pk": "PARTIAL#1", "sk": "A"})
 
     # THEN only the exact match is returned
     assert result is not None
     assert result["data"] == "first"
 
 
-def test_get_item_eventually_consistent(dynamo):
+@pytest.mark.asyncio
+async def test_get_item_eventually_consistent(dynamo):
     """Test get_item with eventually consistent read (default)."""
     # GIVEN an item in DynamoDB
-    dynamo.put_item("test_table", {"pk": "CONSISTENT#1", "sk": "TEST", "data": "value"})
+    await dynamo.put_item("test_table", {"pk": "CONSISTENT#1", "sk": "TEST", "data": "value"})
 
     # WHEN getting with default consistency
-    result = dynamo.get_item(
+    result = await dynamo.get_item(
         "test_table",
         {"pk": "CONSISTENT#1", "sk": "TEST"},
     )
@@ -81,13 +85,14 @@ def test_get_item_eventually_consistent(dynamo):
     assert result["data"] == "value"
 
 
-def test_get_item_strongly_consistent(dynamo):
+@pytest.mark.asyncio
+async def test_get_item_strongly_consistent(dynamo):
     """Test get_item with strongly consistent read."""
     # GIVEN an item in DynamoDB
-    dynamo.put_item("test_table", {"pk": "CONSISTENT#2", "sk": "TEST", "data": "value"})
+    await dynamo.put_item("test_table", {"pk": "CONSISTENT#2", "sk": "TEST", "data": "value"})
 
     # WHEN getting with consistent_read=True
-    result = dynamo.get_item(
+    result = await dynamo.get_item(
         "test_table",
         {"pk": "CONSISTENT#2", "sk": "TEST"},
         consistent_read=True,
@@ -98,10 +103,11 @@ def test_get_item_strongly_consistent(dynamo):
     assert result["data"] == "value"
 
 
-def test_get_item_consistent_read_not_found(dynamo):
+@pytest.mark.asyncio
+async def test_get_item_consistent_read_not_found(dynamo):
     """Test get_item with consistent_read returns None for non-existent items."""
     # WHEN getting a non-existent item with consistent_read
-    result = dynamo.get_item(
+    result = await dynamo.get_item(
         "test_table",
         {"pk": "NONEXISTENT", "sk": "NONE"},
         consistent_read=True,

--- a/tests/integration/operations/test_key_operations.py
+++ b/tests/integration/operations/test_key_operations.py
@@ -23,91 +23,96 @@ def user_model(dynamo):
     return User
 
 
-def test_update_by_key_updates_item(user_model):
+@pytest.mark.asyncio
+async def test_update_by_key_updates_item(user_model):
     """update_by_key updates an existing item."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     # GIVEN an existing item
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # WHEN we update by key without fetching
-    user_model.update_by_key(pk=pk, sk="PROFILE", name="Jane", age=31)
+    await user_model.update_by_key(pk=pk, sk="PROFILE", name="Jane", age=31)
 
     # THEN the update is applied
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result is not None
     assert result.name == "Jane"
     assert result.age == 31
 
 
-def test_update_by_key_partial_update(user_model):
+@pytest.mark.asyncio
+async def test_update_by_key_partial_update(user_model):
     """update_by_key only updates specified fields."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # Update only name
-    user_model.update_by_key(pk=pk, sk="PROFILE", name="Jane")
+    await user_model.update_by_key(pk=pk, sk="PROFILE", name="Jane")
 
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result.name == "Jane"
     assert result.age == 30  # Unchanged
 
 
-def test_update_by_key_creates_item_if_not_exists(user_model):
+@pytest.mark.asyncio
+async def test_update_by_key_creates_item_if_not_exists(user_model):
     """update_by_key creates item if it doesn't exist (DynamoDB behavior)."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     # Update non-existent item
-    user_model.update_by_key(pk=pk, sk="PROFILE", name="NewUser")
+    await user_model.update_by_key(pk=pk, sk="PROFILE", name="NewUser")
 
     # Item should be created
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result is not None
     assert result.name == "NewUser"
 
 
-def test_update_by_key_with_condition_success(user_model):
+@pytest.mark.asyncio
+async def test_update_by_key_with_condition_success(user_model):
     """update_by_key with condition that passes."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # Build condition separately to avoid any parsing issues
     age_condition = user_model.age == 30
 
     # Update with condition
-    user_model.update_by_key(
+    await user_model.update_by_key(
         pk=pk,
         sk="PROFILE",
         name="Jane",
         condition=age_condition,
     )
 
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result.name == "Jane"
 
 
-def test_update_by_key_with_condition_fails(user_model):
+@pytest.mark.asyncio
+async def test_update_by_key_with_condition_fails(user_model):
     """update_by_key with condition that fails raises error."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # Build condition separately
     age_condition = user_model.age == 99  # Wrong age
 
     with pytest.raises(ConditionalCheckFailedException):
-        user_model.update_by_key(
+        await user_model.update_by_key(
             pk=pk,
             sk="PROFILE",
             name="Jane",
@@ -115,124 +120,130 @@ def test_update_by_key_with_condition_fails(user_model):
         )
 
     # Item unchanged
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result.name == "John"
 
 
-def test_delete_by_key_deletes_item(user_model):
+@pytest.mark.asyncio
+async def test_delete_by_key_deletes_item(user_model):
     """delete_by_key removes an existing item."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     # GIVEN an existing item
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # WHEN we delete by key without fetching
-    user_model.delete_by_key(pk=pk, sk="PROFILE")
+    await user_model.delete_by_key(pk=pk, sk="PROFILE")
 
     # THEN the item is deleted
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result is None
 
 
-def test_delete_by_key_nonexistent_item_no_error(user_model):
+@pytest.mark.asyncio
+async def test_delete_by_key_nonexistent_item_no_error(user_model):
     """delete_by_key on non-existent item doesn't raise error."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     # Should not raise
-    user_model.delete_by_key(pk=pk, sk="PROFILE")
+    await user_model.delete_by_key(pk=pk, sk="PROFILE")
 
 
-def test_delete_by_key_with_condition_success(user_model):
+@pytest.mark.asyncio
+async def test_delete_by_key_with_condition_success(user_model):
     """delete_by_key with condition that passes."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # Build condition separately
     name_condition = user_model.name == "John"
 
-    user_model.delete_by_key(
+    await user_model.delete_by_key(
         pk=pk,
         sk="PROFILE",
         condition=name_condition,
     )
 
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result is None
 
 
-def test_delete_by_key_with_condition_fails(user_model):
+@pytest.mark.asyncio
+async def test_delete_by_key_with_condition_fails(user_model):
     """delete_by_key with condition that fails raises error."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    user.save()
+    await user.save()
 
     # Build condition separately
     name_condition = user_model.name == "Jane"  # Wrong name
 
     with pytest.raises(ConditionalCheckFailedException):
-        user_model.delete_by_key(
+        await user_model.delete_by_key(
             pk=pk,
             sk="PROFILE",
             condition=name_condition,
         )
 
     # Item still exists
-    result = user_model.get(pk=pk, sk="PROFILE")
+    result = await user_model.get(pk=pk, sk="PROFILE")
     assert result is not None
 
 
-@pytest.mark.asyncio
-async def test_async_update_by_key(user_model):
-    """async_update_by_key updates an existing item."""
+# ========== SYNC TESTS ==========
+
+
+def test_sync_update_by_key(user_model):
+    """sync_update_by_key updates an existing item."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    await user.async_save()
+    user.sync_save()
 
-    await user_model.async_update_by_key(pk=pk, sk="PROFILE", name="Jane")
+    user_model.sync_update_by_key(pk=pk, sk="PROFILE", name="Jane")
 
-    result = await user_model.async_get(pk=pk, sk="PROFILE")
+    result = user_model.sync_get(pk=pk, sk="PROFILE")
     assert result.name == "Jane"
 
 
-@pytest.mark.asyncio
-async def test_async_delete_by_key(user_model):
-    """async_delete_by_key removes an existing item."""
+def test_sync_delete_by_key(user_model):
+    """sync_delete_by_key removes an existing item."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="John", age=30)
-    await user.async_save()
+    user.sync_save()
 
-    await user_model.async_delete_by_key(pk=pk, sk="PROFILE")
+    user_model.sync_delete_by_key(pk=pk, sk="PROFILE")
 
-    result = await user_model.async_get(pk=pk, sk="PROFILE")
+    result = user_model.sync_get(pk=pk, sk="PROFILE")
     assert result is None
 
 
 # ========== as_dict tests ==========
 
 
-def test_get_as_dict_returns_dict(user_model):
+@pytest.mark.asyncio
+async def test_get_as_dict_returns_dict(user_model):
     """Model.get(as_dict=True) returns plain dict."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     # GIVEN an existing item
     user = user_model(pk=pk, sk="PROFILE", name="Alice", age=25)
-    user.save()
+    await user.save()
 
     # WHEN we get with as_dict=True
-    result = user_model.get(pk=pk, sk="PROFILE", as_dict=True)
+    result = await user_model.get(pk=pk, sk="PROFILE", as_dict=True)
 
     # THEN a plain dict is returned
     assert result is not None
@@ -241,42 +252,28 @@ def test_get_as_dict_returns_dict(user_model):
     assert result["age"] == 25
 
 
-def test_get_as_dict_false_returns_model(user_model):
+@pytest.mark.asyncio
+async def test_get_as_dict_false_returns_model(user_model):
     """Model.get(as_dict=False) returns Model instance."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
     user = user_model(pk=pk, sk="PROFILE", name="Bob", age=30)
-    user.save()
+    await user.save()
 
-    result = user_model.get(pk=pk, sk="PROFILE", as_dict=False)
+    result = await user_model.get(pk=pk, sk="PROFILE", as_dict=False)
 
     assert result is not None
     assert isinstance(result, user_model)
     assert result.name == "Bob"
 
 
-def test_get_as_dict_not_found_returns_none(user_model):
+@pytest.mark.asyncio
+async def test_get_as_dict_not_found_returns_none(user_model):
     """Model.get(as_dict=True) returns None when not found."""
     uid = str(uuid.uuid4())
     pk = f"USER#{uid}"
 
-    result = user_model.get(pk=pk, sk="PROFILE", as_dict=True)
+    result = await user_model.get(pk=pk, sk="PROFILE", as_dict=True)
 
     assert result is None
-
-
-@pytest.mark.asyncio
-async def test_async_get_as_dict_returns_dict(user_model):
-    """Model.async_get(as_dict=True) returns plain dict."""
-    uid = str(uuid.uuid4())
-    pk = f"USER#{uid}"
-
-    user = user_model(pk=pk, sk="PROFILE", name="Charlie", age=35)
-    await user.async_save()
-
-    result = await user_model.async_get(pk=pk, sk="PROFILE", as_dict=True)
-
-    assert result is not None
-    assert isinstance(result, dict)
-    assert result["name"] == "Charlie"

--- a/tests/integration/operations/test_optimistic_lock.py
+++ b/tests/integration/operations/test_optimistic_lock.py
@@ -25,59 +25,63 @@ def versioned_model(dynamo):
     return VersionedDoc
 
 
-def test_version_starts_at_one(versioned_model):
+@pytest.mark.asyncio
+async def test_version_starts_at_one(versioned_model):
     """First save sets version to 1."""
     # GIVEN a new document
     doc = versioned_model(pk="VERSION#1", sk="DOC#1", content="Hello")
     assert doc.version is None
 
     # WHEN we save it
-    doc.save()
+    await doc.save()
 
     # THEN version is set to 1
     assert doc.version == 1
 
 
-def test_version_increments_on_save(versioned_model):
+@pytest.mark.asyncio
+async def test_version_increments_on_save(versioned_model):
     """Each save increments version."""
     # GIVEN a document
     doc = versioned_model(pk="VERSION#2", sk="DOC#1", content="Hello")
-    doc.save()
+    await doc.save()
     assert doc.version == 1
 
     # WHEN we save again
     doc.content = "Updated"
-    doc.save()
+    await doc.save()
 
     # THEN version increments
     assert doc.version == 2
 
     # AND again
     doc.content = "Updated again"
-    doc.save()
+    await doc.save()
     assert doc.version == 3
 
 
-def test_version_loaded_from_db(versioned_model):
+@pytest.mark.asyncio
+async def test_version_loaded_from_db(versioned_model):
     """Version is loaded correctly from DynamoDB."""
     doc = versioned_model(pk="VERSION#3", sk="DOC#1", content="Hello")
-    doc.save()
-    doc.save()  # version = 2
+    await doc.save()
+    await doc.save()  # version = 2
 
-    loaded = versioned_model.get(pk="VERSION#3", sk="DOC#1")
+    loaded = await versioned_model.get(pk="VERSION#3", sk="DOC#1")
     assert loaded is not None
     assert loaded.version == 2
 
 
-def test_concurrent_update_fails(versioned_model):
+@pytest.mark.asyncio
+async def test_concurrent_update_fails(versioned_model):
     """Concurrent updates fail with ConditionalCheckFailedException."""
     # GIVEN a document
     doc = versioned_model(pk="VERSION#4", sk="DOC#1", content="Original")
-    doc.save()
+    await doc.save()
 
     # AND two clients load the same document
-    doc1 = versioned_model.get(pk="VERSION#4", sk="DOC#1")
-    doc2 = versioned_model.get(pk="VERSION#4", sk="DOC#1")
+    doc1 = await versioned_model.get(pk="VERSION#4", sk="DOC#1")
+    doc2 = await versioned_model.get(pk="VERSION#4", sk="DOC#1")
 
     assert doc1 is not None
     assert doc2 is not None
@@ -86,151 +90,91 @@ def test_concurrent_update_fails(versioned_model):
 
     # WHEN first client updates
     doc1.content = "Update from client 1"
-    doc1.save()
+    await doc1.save()
     assert doc1.version == 2
 
     # THEN second client's update fails (version mismatch)
     doc2.content = "Update from client 2"
     with pytest.raises(ConditionalCheckFailedException):
-        doc2.save()
+        await doc2.save()
 
 
-def test_delete_with_version_check(versioned_model):
+@pytest.mark.asyncio
+async def test_delete_with_version_check(versioned_model):
     """Delete checks version before deleting."""
     doc = versioned_model(pk="VERSION#5", sk="DOC#1", content="To delete")
-    doc.save()
-    doc.save()  # version = 2
+    await doc.save()
+    await doc.save()  # version = 2
 
     # Load stale copy
-    stale = versioned_model.get(pk="VERSION#5", sk="DOC#1")
+    stale = await versioned_model.get(pk="VERSION#5", sk="DOC#1")
     assert stale is not None
 
     # Update the document (version becomes 3)
     doc.content = "Updated"
-    doc.save()
+    await doc.save()
     assert doc.version == 3
 
     # Delete with stale version fails
     with pytest.raises(ConditionalCheckFailedException):
-        stale.delete()
+        await stale.delete()
 
     # Delete with current version succeeds
-    doc.delete()
+    await doc.delete()
 
     # Verify deleted
-    assert versioned_model.get(pk="VERSION#5", sk="DOC#1") is None
+    assert await versioned_model.get(pk="VERSION#5", sk="DOC#1") is None
 
 
-def test_new_item_fails_if_exists(versioned_model):
+@pytest.mark.asyncio
+async def test_new_item_fails_if_exists(versioned_model):
     """Creating new item fails if item already exists."""
     # Create first document
     doc1 = versioned_model(pk="VERSION#6", sk="DOC#1", content="First")
-    doc1.save()
+    await doc1.save()
 
     # Try to create another with same key (version=None means new)
     doc2 = versioned_model(pk="VERSION#6", sk="DOC#1", content="Second")
     with pytest.raises(ConditionalCheckFailedException):
-        doc2.save()
+        await doc2.save()
 
 
-def test_version_with_user_condition(versioned_model):
+@pytest.mark.asyncio
+async def test_version_with_user_condition(versioned_model):
     """User condition is combined with version condition."""
     doc = versioned_model(pk="VERSION#7", sk="DOC#1", content="Hello")
-    doc.save()
+    await doc.save()
     assert doc.version == 1
 
     # Reload to get fresh version
-    doc = versioned_model.get(pk="VERSION#7", sk="DOC#1")
+    doc = await versioned_model.get(pk="VERSION#7", sk="DOC#1")
     assert doc is not None
 
     # Add user condition that fails
     doc.content = "Updated"
     with pytest.raises(ConditionalCheckFailedException):
-        doc.save(condition=VersionedDoc.content == "Wrong")
+        await doc.save(condition=VersionedDoc.content == "Wrong")
 
     # Reload again since version was incremented locally
-    doc = versioned_model.get(pk="VERSION#7", sk="DOC#1")
+    doc = await versioned_model.get(pk="VERSION#7", sk="DOC#1")
     assert doc is not None
     assert doc.version == 1  # Still 1 because save failed
 
     # Add user condition that passes
     doc.content = "Updated"
-    doc.save(condition=VersionedDoc.content == "Hello")
+    await doc.save(condition=VersionedDoc.content == "Hello")
     assert doc.version == 2
-
-
-# ========== ASYNC TESTS ==========
-
-
-async def test_async_version_starts_at_one(versioned_model):
-    """Async: First save sets version to 1."""
-    doc = versioned_model(pk="ASYNC_VERSION#1", sk="DOC#1", content="Hello")
-    assert doc.version is None
-
-    await doc.async_save()
-
-    assert doc.version == 1
-
-
-async def test_async_version_increments_on_save(versioned_model):
-    """Async: Each save increments version."""
-    doc = versioned_model(pk="ASYNC_VERSION#2", sk="DOC#1", content="Hello")
-    await doc.async_save()
-    assert doc.version == 1
-
-    doc.content = "Updated"
-    await doc.async_save()
-    assert doc.version == 2
-
-
-async def test_async_concurrent_update_fails(versioned_model):
-    """Async: Concurrent updates fail with ConditionalCheckFailedException."""
-    doc = versioned_model(pk="ASYNC_VERSION#3", sk="DOC#1", content="Original")
-    await doc.async_save()
-
-    doc1 = await versioned_model.async_get(pk="ASYNC_VERSION#3", sk="DOC#1")
-    doc2 = await versioned_model.async_get(pk="ASYNC_VERSION#3", sk="DOC#1")
-
-    assert doc1 is not None
-    assert doc2 is not None
-
-    doc1.content = "Update from client 1"
-    await doc1.async_save()
-    assert doc1.version == 2
-
-    doc2.content = "Update from client 2"
-    with pytest.raises(ConditionalCheckFailedException):
-        await doc2.async_save()
-
-
-async def test_async_delete_with_version_check(versioned_model):
-    """Async: Delete checks version before deleting."""
-    doc = versioned_model(pk="ASYNC_VERSION#4", sk="DOC#1", content="To delete")
-    await doc.async_save()
-    await doc.async_save()  # version = 2
-
-    stale = await versioned_model.async_get(pk="ASYNC_VERSION#4", sk="DOC#1")
-    assert stale is not None
-
-    doc.content = "Updated"
-    await doc.async_save()
-    assert doc.version == 3
-
-    with pytest.raises(ConditionalCheckFailedException):
-        await stale.async_delete()
-
-    await doc.async_delete()
-    assert await versioned_model.async_get(pk="ASYNC_VERSION#4", sk="DOC#1") is None
 
 
 # ========== HIGH CONCURRENCY TESTS ==========
 
 
+@pytest.mark.asyncio
 async def test_high_concurrency_only_one_wins(versioned_model):
     """High concurrency: Only one concurrent save succeeds per version."""
     # Create initial document
     doc = versioned_model(pk="CONCURRENT#1", sk="DOC#1", content="Original")
-    await doc.async_save()
+    await doc.save()
 
     num_concurrent = 10
 
@@ -238,7 +182,7 @@ async def test_high_concurrency_only_one_wins(versioned_model):
     # This ensures all workers have the same version
     loaded_docs = []
     for i in range(num_concurrent):
-        loaded = await versioned_model.async_get(pk="CONCURRENT#1", sk="DOC#1")
+        loaded = await versioned_model.get(pk="CONCURRENT#1", sk="DOC#1")
         assert loaded is not None
         loaded.content = f"Updated by worker {i}"
         loaded_docs.append(loaded)
@@ -253,7 +197,7 @@ async def test_high_concurrency_only_one_wins(versioned_model):
     async def try_save(doc_to_save):
         nonlocal success_count, failure_count
         try:
-            await doc_to_save.async_save()
+            await doc_to_save.save()
             success_count += 1
         except ConditionalCheckFailedException:
             failure_count += 1
@@ -266,15 +210,16 @@ async def test_high_concurrency_only_one_wins(versioned_model):
     assert failure_count == num_concurrent - 1
 
     # Verify final state
-    final = await versioned_model.async_get(pk="CONCURRENT#1", sk="DOC#1")
+    final = await versioned_model.get(pk="CONCURRENT#1", sk="DOC#1")
     assert final is not None
     assert final.version == 2
 
 
+@pytest.mark.asyncio
 async def test_high_concurrency_sequential_updates(versioned_model):
     """High concurrency: Sequential updates with retry all succeed."""
     doc = versioned_model(pk="CONCURRENT#2", sk="DOC#1", content="Original")
-    await doc.async_save()
+    await doc.save()
 
     num_workers = 5
     updates_per_worker = 3
@@ -284,13 +229,13 @@ async def test_high_concurrency_sequential_updates(versioned_model):
         for i in range(updates_per_worker):
             max_retries = 10
             for attempt in range(max_retries):
-                loaded = await versioned_model.async_get(pk="CONCURRENT#2", sk="DOC#1")
+                loaded = await versioned_model.get(pk="CONCURRENT#2", sk="DOC#1")
                 if loaded is None:
                     return
 
                 loaded.content = f"Worker {worker_id}, update {i}, attempt {attempt}"
                 try:
-                    await loaded.async_save()
+                    await loaded.save()
                     break
                 except ConditionalCheckFailedException:
                     if attempt == max_retries - 1:
@@ -299,11 +244,12 @@ async def test_high_concurrency_sequential_updates(versioned_model):
 
     await asyncio.gather(*[update_with_retry(i) for i in range(num_workers)])
 
-    final = await versioned_model.async_get(pk="CONCURRENT#2", sk="DOC#1")
+    final = await versioned_model.get(pk="CONCURRENT#2", sk="DOC#1")
     assert final is not None
     assert final.version == 1 + total_updates
 
 
+@pytest.mark.asyncio
 async def test_high_concurrency_new_item_race(versioned_model):
     """High concurrency: Only one create succeeds for same key."""
     num_concurrent = 10
@@ -318,7 +264,7 @@ async def test_high_concurrency_new_item_race(versioned_model):
             content=f"Created by worker {worker_id}",
         )
         try:
-            await doc.async_save()
+            await doc.save()
             success_count += 1
         except ConditionalCheckFailedException:
             failure_count += 1
@@ -329,36 +275,37 @@ async def test_high_concurrency_new_item_race(versioned_model):
     assert success_count == 1
     assert failure_count == num_concurrent - 1
 
-    final = await versioned_model.async_get(pk="CONCURRENT#3", sk="DOC#1")
+    final = await versioned_model.get(pk="CONCURRENT#3", sk="DOC#1")
     assert final is not None
     assert final.version == 1
 
 
+@pytest.mark.asyncio
 async def test_high_concurrency_mixed_operations(versioned_model):
     """High concurrency: Mix of saves and deletes."""
     doc = versioned_model(pk="CONCURRENT#4", sk="DOC#1", content="Original")
-    await doc.async_save()
+    await doc.save()
 
     delete_success = False
     save_after_delete_failures = 0
 
     async def try_delete():
         nonlocal delete_success
-        loaded = await versioned_model.async_get(pk="CONCURRENT#4", sk="DOC#1")
+        loaded = await versioned_model.get(pk="CONCURRENT#4", sk="DOC#1")
         if loaded:
             try:
-                await loaded.async_delete()
+                await loaded.delete()
                 delete_success = True
             except ConditionalCheckFailedException:
                 pass
 
     async def try_save(worker_id: int):
         nonlocal save_after_delete_failures
-        loaded = await versioned_model.async_get(pk="CONCURRENT#4", sk="DOC#1")
+        loaded = await versioned_model.get(pk="CONCURRENT#4", sk="DOC#1")
         if loaded:
             loaded.content = f"Updated by {worker_id}"
             try:
-                await loaded.async_save()
+                await loaded.save()
             except ConditionalCheckFailedException:
                 save_after_delete_failures += 1
 
@@ -368,7 +315,7 @@ async def test_high_concurrency_mixed_operations(versioned_model):
 
     # Either delete succeeded or some saves succeeded
     # The important thing is no data corruption
-    final = await versioned_model.async_get(pk="CONCURRENT#4", sk="DOC#1")
+    final = await versioned_model.get(pk="CONCURRENT#4", sk="DOC#1")
     if delete_success:
         # If delete won, item should be gone or recreated
         pass  # Item may or may not exist

--- a/tests/integration/operations/test_put_item.py
+++ b/tests/integration/operations/test_put_item.py
@@ -38,32 +38,34 @@ PUT_ITEM_CASES = [
 ]
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("item", PUT_ITEM_CASES)
-def test_put_item_saves_correctly(dynamo, item):
+async def test_put_item_saves_correctly(dynamo, item):
     """Test saving items with different data types."""
     # WHEN saving an item
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # THEN the item can be retrieved with all fields intact
     key = {"pk": item["pk"], "sk": item["sk"]}
-    result = dynamo.get_item("test_table", key)
+    result = await dynamo.get_item("test_table", key)
 
     assert result is not None
     for field, value in item.items():
         assert result[field] == value
 
 
-def test_put_item_overwrites_existing(dynamo):
+@pytest.mark.asyncio
+async def test_put_item_overwrites_existing(dynamo):
     """Test that put_item overwrites an existing item."""
     # GIVEN an existing item
     item1 = {"pk": "USER#100", "sk": "PROFILE", "name": "Original"}
     item2 = {"pk": "USER#100", "sk": "PROFILE", "name": "Updated", "new_field": "value"}
-    dynamo.put_item("test_table", item1)
+    await dynamo.put_item("test_table", item1)
 
     # WHEN saving a new item with the same key
-    dynamo.put_item("test_table", item2)
+    await dynamo.put_item("test_table", item2)
 
     # THEN the item is overwritten
-    result = dynamo.get_item("test_table", {"pk": "USER#100", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#100", "sk": "PROFILE"})
     assert result["name"] == "Updated"
     assert result["new_field"] == "value"

--- a/tests/integration/operations/test_update_item.py
+++ b/tests/integration/operations/test_update_item.py
@@ -4,52 +4,55 @@ import pytest
 from pydynox.exceptions import ConditionalCheckFailedException, ResourceNotFoundException
 
 
-def test_update_item_simple_set(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_simple_set(dynamo):
     """Test simple update that sets field values."""
     # GIVEN an existing item
     item = {"pk": "USER#UPD1", "sk": "PROFILE", "name": "Original", "age": 25}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN updating fields
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD1", "sk": "PROFILE"},
         updates={"name": "Updated", "age": 30},
     )
 
     # THEN fields are updated
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD1", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD1", "sk": "PROFILE"})
     assert result["name"] == "Updated"
     assert result["age"] == 30
 
 
-def test_update_item_add_new_field(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_add_new_field(dynamo):
     """Test update that adds a new field."""
     # GIVEN an existing item
     item = {"pk": "USER#UPD2", "sk": "PROFILE", "name": "Test"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN adding a new field
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD2", "sk": "PROFILE"},
         updates={"email": "test@example.com"},
     )
 
     # THEN new field is added
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD2", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD2", "sk": "PROFILE"})
     assert result["name"] == "Test"
     assert result["email"] == "test@example.com"
 
 
-def test_update_item_increment_with_expression(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_increment_with_expression(dynamo):
     """Test atomic increment using update expression."""
     # GIVEN an item with a counter
     item = {"pk": "USER#UPD3", "sk": "PROFILE", "counter": 10}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN incrementing the counter
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD3", "sk": "PROFILE"},
         update_expression="SET #c = #c + :val",
@@ -58,18 +61,19 @@ def test_update_item_increment_with_expression(dynamo):
     )
 
     # THEN counter is incremented
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD3", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD3", "sk": "PROFILE"})
     assert result["counter"] == 15
 
 
-def test_update_item_decrement_with_expression(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_decrement_with_expression(dynamo):
     """Test atomic decrement using update expression."""
     # GIVEN an item with a counter
     item = {"pk": "USER#UPD3B", "sk": "PROFILE", "counter": 100}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN decrementing the counter
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD3B", "sk": "PROFILE"},
         update_expression="SET #c = #c - :val",
@@ -78,18 +82,19 @@ def test_update_item_decrement_with_expression(dynamo):
     )
 
     # THEN counter is decremented
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD3B", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD3B", "sk": "PROFILE"})
     assert result["counter"] == 75
 
 
-def test_update_item_append_to_list(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_append_to_list(dynamo):
     """Test atomic append to list using update expression."""
     # GIVEN an item with a list
     item = {"pk": "USER#UPD3C", "sk": "PROFILE", "tags": ["admin"]}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN appending to the list
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD3C", "sk": "PROFILE"},
         update_expression="SET #t = list_append(#t, :vals)",
@@ -98,18 +103,19 @@ def test_update_item_append_to_list(dynamo):
     )
 
     # THEN items are appended
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD3C", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD3C", "sk": "PROFILE"})
     assert result["tags"] == ["admin", "user", "moderator"]
 
 
-def test_update_item_remove_attribute(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_remove_attribute(dynamo):
     """Test removing an attribute using update expression."""
     # GIVEN an item with a temp field
     item = {"pk": "USER#UPD3D", "sk": "PROFILE", "name": "Test", "temp": "to_remove"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN removing the temp field
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD3D", "sk": "PROFILE"},
         update_expression="REMOVE #t",
@@ -117,19 +123,20 @@ def test_update_item_remove_attribute(dynamo):
     )
 
     # THEN temp field is removed
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD3D", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD3D", "sk": "PROFILE"})
     assert result["name"] == "Test"
     assert "temp" not in result
 
 
-def test_update_item_with_condition_success(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_with_condition_success(dynamo):
     """Test update with a condition that passes."""
     # GIVEN an item with status=pending
     item = {"pk": "USER#UPD4", "sk": "PROFILE", "status": "pending", "name": "Test"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN updating with condition status=pending
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD4", "sk": "PROFILE"},
         updates={"status": "active"},
@@ -139,20 +146,21 @@ def test_update_item_with_condition_success(dynamo):
     )
 
     # THEN update succeeds
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD4", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD4", "sk": "PROFILE"})
     assert result["status"] == "active"
 
 
-def test_update_item_with_condition_fails(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_with_condition_fails(dynamo):
     """Test update with a condition that fails raises an error."""
     # GIVEN an item with status=active
     item = {"pk": "USER#UPD5", "sk": "PROFILE", "status": "active"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN updating with condition status=pending
     # THEN ConditionalCheckFailedException is raised
     with pytest.raises(ConditionalCheckFailedException):
-        dynamo.update_item(
+        await dynamo.update_item(
             "test_table",
             {"pk": "USER#UPD5", "sk": "PROFILE"},
             updates={"status": "inactive"},
@@ -162,18 +170,19 @@ def test_update_item_with_condition_fails(dynamo):
         )
 
     # AND item is unchanged
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD5", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD5", "sk": "PROFILE"})
     assert result["status"] == "active"
 
 
-def test_update_item_multiple_types(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_multiple_types(dynamo):
     """Test update with different data types."""
     # GIVEN an existing item
     item = {"pk": "USER#UPD6", "sk": "PROFILE", "name": "Test"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN updating with various types
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#UPD6", "sk": "PROFILE"},
         updates={
@@ -186,7 +195,7 @@ def test_update_item_multiple_types(dynamo):
     )
 
     # THEN all types are preserved
-    result = dynamo.get_item("test_table", {"pk": "USER#UPD6", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#UPD6", "sk": "PROFILE"})
     assert result["age"] == 30
     assert result["score"] == 95.5
     assert result["active"] is True
@@ -194,43 +203,46 @@ def test_update_item_multiple_types(dynamo):
     assert result["meta"] == {"key": "value"}
 
 
-def test_update_item_nonexistent_creates_item(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_nonexistent_creates_item(dynamo):
     """Test that updating a non-existent item creates it."""
     # WHEN updating a non-existent item
-    dynamo.update_item(
+    await dynamo.update_item(
         "test_table",
         {"pk": "USER#NEW", "sk": "PROFILE"},
         updates={"name": "NewUser"},
     )
 
     # THEN item is created
-    result = dynamo.get_item("test_table", {"pk": "USER#NEW", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#NEW", "sk": "PROFILE"})
     assert result is not None
     assert result["name"] == "NewUser"
 
 
-def test_update_item_table_not_found(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_table_not_found(dynamo):
     """Test update on non-existent table raises error."""
     # WHEN updating on a non-existent table
     # THEN ResourceNotFoundException is raised
     with pytest.raises(ResourceNotFoundException):
-        dynamo.update_item(
+        await dynamo.update_item(
             "nonexistent_table",
             {"pk": "X", "sk": "Y"},
             updates={"name": "Test"},
         )
 
 
-def test_update_item_no_updates_or_expression_fails(dynamo):
+@pytest.mark.asyncio
+async def test_update_item_no_updates_or_expression_fails(dynamo):
     """Test that update without updates or expression raises error."""
     # GIVEN an existing item
     item = {"pk": "USER#UPD7", "sk": "PROFILE", "name": "Test"}
-    dynamo.put_item("test_table", item)
+    await dynamo.put_item("test_table", item)
 
     # WHEN updating without updates or expression
     # THEN ValueError is raised
     with pytest.raises(ValueError):
-        dynamo.update_item(
+        await dynamo.update_item(
             "test_table",
             {"pk": "USER#UPD7", "sk": "PROFILE"},
         )

--- a/tests/integration/s3/test_s3_attribute_async.py
+++ b/tests/integration/s3/test_s3_attribute_async.py
@@ -30,7 +30,7 @@ def document_model(dynamo, s3_bucket, localstack_endpoint):
 
 
 @pytest.mark.asyncio
-async def test_async_get_bytes(document_model):
+async def test_get_bytes(document_model):
     """Test async get_bytes() downloads file content."""
     doc_id = str(uuid.uuid4())
     content = b"Async download test content"
@@ -41,9 +41,9 @@ async def test_async_get_bytes(document_model):
         name="async_download.txt",
     )
     doc.content = S3File(content, name="async_download.txt")
-    doc.save()
+    await doc.save()
 
-    loaded = document_model.get(pk=f"DOC#{doc_id}", sk="v1")
+    loaded = await document_model.get(pk=f"DOC#{doc_id}", sk="v1")
 
     # Set s3_ops
     loaded._attributes["content"]._get_s3_ops(loaded._get_client())
@@ -64,9 +64,9 @@ async def test_async_presigned_url(document_model):
         name="async_presigned.txt",
     )
     doc.content = S3File(b"data", name="async_presigned.txt")
-    doc.save()
+    await doc.save()
 
-    loaded = document_model.get(pk=f"DOC#{doc_id}", sk="v1")
+    loaded = await document_model.get(pk=f"DOC#{doc_id}", sk="v1")
 
     # Set s3_ops
     loaded._attributes["content"]._get_s3_ops(loaded._get_client())
@@ -77,7 +77,7 @@ async def test_async_presigned_url(document_model):
 
 
 @pytest.mark.asyncio
-async def test_async_save_to(document_model, tmp_path):
+async def test_save_to(document_model, tmp_path):
     """Test async save_to() streams to file."""
     doc_id = str(uuid.uuid4())
     content = b"Async save to file content"
@@ -85,12 +85,12 @@ async def test_async_save_to(document_model, tmp_path):
     doc = document_model(
         pk=f"DOC#{doc_id}",
         sk="v1",
-        name="async_save.bin",
+        name="save.bin",
     )
-    doc.content = S3File(content, name="async_save.bin")
-    doc.save()
+    doc.content = S3File(content, name="save.bin")
+    await doc.save()
 
-    loaded = document_model.get(pk=f"DOC#{doc_id}", sk="v1")
+    loaded = await document_model.get(pk=f"DOC#{doc_id}", sk="v1")
 
     # Set s3_ops
     loaded._attributes["content"]._get_s3_ops(loaded._get_client())

--- a/tests/integration/size/test_size_calculator.py
+++ b/tests/integration/size/test_size_calculator.py
@@ -82,7 +82,8 @@ def test_calculate_size_detailed_breakdown(dynamo):
     assert size.fields["pk"] < size.fields["bio"]
 
 
-def test_save_succeeds_under_limit(dynamo):
+@pytest.mark.asyncio
+async def test_save_succeeds_under_limit(dynamo):
     """save() works when item is under max_size."""
 
     class LimitedUser(Model):
@@ -94,14 +95,15 @@ def test_save_succeeds_under_limit(dynamo):
     LimitedUser._client_instance = None
 
     user = LimitedUser(pk="USER#4", sk="PROFILE", bio="Short bio")
-    user.save()
+    await user.save()
 
     # Verify it was saved
-    result = dynamo.get_item("test_table", {"pk": "USER#4", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#4", "sk": "PROFILE"})
     assert result["bio"] == "Short bio"
 
 
-def test_save_raises_when_over_limit(dynamo):
+@pytest.mark.asyncio
+async def test_save_raises_when_over_limit(dynamo):
     """save() raises ItemTooLargeException when item exceeds max_size."""
 
     class LimitedUser(Model):
@@ -122,14 +124,15 @@ def test_save_raises_when_over_limit(dynamo):
     # WHEN we try to save
     # THEN ItemTooLargeException is raised
     with pytest.raises(ItemTooLargeException) as exc_info:
-        user.save()
+        await user.save()
 
     assert exc_info.value.size > 500
     assert exc_info.value.max_size == 500
     assert exc_info.value.item_key == {"pk": "USER#5", "sk": "PROFILE"}
 
 
-def test_save_without_limit_allows_large_items(dynamo):
+@pytest.mark.asyncio
+async def test_save_without_limit_allows_large_items(dynamo):
     """save() without max_size allows large items."""
 
     class User(Model):
@@ -145,7 +148,7 @@ def test_save_without_limit_allows_large_items(dynamo):
         sk="PROFILE",
         bio="Y" * 10000,  # Large but under 400KB
     )
-    user.save()
+    await user.save()
 
-    result = dynamo.get_item("test_table", {"pk": "USER#6", "sk": "PROFILE"})
+    result = await dynamo.get_item("test_table", {"pk": "USER#6", "sk": "PROFILE"})
     assert len(result["bio"]) == 10000

--- a/tests/integration/table/test_client_table.py
+++ b/tests/integration/table/test_client_table.py
@@ -35,7 +35,8 @@ def test_create_table_hash_key_only(client):
     client.sync_delete_table("hash_only_table")
 
 
-def test_create_table_hash_and_range_key(client):
+@pytest.mark.asyncio
+async def test_create_table_hash_and_range_key(client):
     """Test creating a table with hash and range key."""
     client.sync_create_table(
         "hash_range_table",
@@ -45,9 +46,9 @@ def test_create_table_hash_and_range_key(client):
 
     assert client.sync_table_exists("hash_range_table")
 
-    # Verify we can write to it
-    client.put_item("hash_range_table", {"pk": "test", "sk": "item", "data": "value"})
-    result = client.get_item("hash_range_table", {"pk": "test", "sk": "item"})
+    # Verify we can write to it (async)
+    await client.put_item("hash_range_table", {"pk": "test", "sk": "item", "data": "value"})
+    result = await client.get_item("hash_range_table", {"pk": "test", "sk": "item"})
     assert result is not None
     assert result["data"] == "value"
 
@@ -84,13 +85,14 @@ def test_create_table_provisioned_billing(client):
     client.sync_delete_table("provisioned_table")
 
 
-def test_create_table_with_wait(client):
+@pytest.mark.asyncio
+async def test_create_table_with_wait(client):
     """Test creating a table and waiting for it to be active."""
     client.sync_create_table("wait_table", hash_key=("pk", "S"), wait=True)
 
-    # Table should be immediately usable
-    client.put_item("wait_table", {"pk": "test", "data": "value"})
-    result = client.get_item("wait_table", {"pk": "test"})
+    # Table should be immediately usable (async)
+    await client.put_item("wait_table", {"pk": "test", "data": "value"})
+    result = await client.get_item("wait_table", {"pk": "test"})
     assert result is not None
     assert result["data"] == "value"
 
@@ -117,8 +119,8 @@ def test_wait_for_table_active(client):
     client.sync_create_table("wait_active_table", hash_key=("pk", "S"))
     client.sync_wait_for_table_active("wait_active_table")
 
-    # Table should be usable
-    client.put_item("wait_active_table", {"pk": "test"})
+    # Table should be usable (sync)
+    client.sync_put_item("wait_active_table", {"pk": "test"})
 
     client.sync_delete_table("wait_active_table")
 
@@ -178,8 +180,8 @@ def test_create_table_with_gsi_hash_only(client):
 
     assert client.sync_table_exists("gsi_hash_table")
 
-    # Verify we can write
-    client.put_item(
+    # Verify we can write (sync)
+    client.sync_put_item(
         "gsi_hash_table", {"pk": "USER#1", "sk": "PROFILE", "email": "test@example.com"}
     )
 
@@ -269,8 +271,8 @@ def test_create_table_with_lsi(client):
 
     assert client.sync_table_exists("lsi_table")
 
-    # Verify we can write
-    client.put_item(
+    # Verify we can write (sync)
+    client.sync_put_item(
         "lsi_table",
         {"pk": "USER#1", "sk": "PROFILE#1", "status": "active"},
     )
@@ -365,8 +367,8 @@ def test_create_table_with_gsi_and_lsi(client):
 
     assert client.sync_table_exists("gsi_lsi_table")
 
-    # Verify we can write
-    client.put_item(
+    # Verify we can write (sync)
+    client.sync_put_item(
         "gsi_lsi_table",
         {
             "pk": "USER#1",

--- a/tests/integration/table/test_client_table_async.py
+++ b/tests/integration/table/test_client_table_async.py
@@ -42,8 +42,8 @@ async def test_async_create_table_with_wait(client):
     await client.create_table("async_wait", hash_key=("pk", "S"), wait=True)
 
     # Table should be usable
-    client.put_item("async_wait", {"pk": "test", "data": "value"})
-    result = client.get_item("async_wait", {"pk": "test"})
+    await client.put_item("async_wait", {"pk": "test", "data": "value"})
+    result = await client.get_item("async_wait", {"pk": "test"})
     assert result is not None
     assert result["data"] == "value"
 
@@ -57,7 +57,7 @@ async def test_async_wait_for_table_active(client):
     await client.wait_for_table_active("async_wait_active")
 
     # Table should be usable
-    client.put_item("async_wait_active", {"pk": "test"})
+    await client.put_item("async_wait_active", {"pk": "test"})
 
     await client.delete_table("async_wait_active")
 

--- a/tests/integration/table/test_model_table_async.py
+++ b/tests/integration/table/test_model_table_async.py
@@ -81,9 +81,10 @@ async def test_async_create_table_with_gsi(model_table_client):
     assert exists is True
 
     # Verify GSI works by saving and querying
-    UserWithGSI(pk="USER#1", email="john@example.com").save()
+    user = UserWithGSI(pk="USER#1", email="john@example.com")
+    await user.save()
 
-    results = list(UserWithGSI.email_index.query(email="john@example.com"))
+    results = [x async for x in UserWithGSI.email_index.query(email="john@example.com")]
     assert len(results) == 1
 
     await UserWithGSI.delete_table()

--- a/tests/integration/testing/test_pytest_fixtures.py
+++ b/tests/integration/testing/test_pytest_fixtures.py
@@ -4,6 +4,7 @@ These tests verify that the pytest plugin fixtures work correctly.
 The fixtures are auto-registered via entry points in pyproject.toml.
 """
 
+import pytest
 from pydynox import Model, ModelConfig
 from pydynox.attributes import NumberAttribute, StringAttribute
 
@@ -29,14 +30,15 @@ class Order(Model):
 # ========== Tests using pydynox_memory_backend fixture ==========
 
 
-def test_pydynox_memory_backend_basic_crud(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_basic_crud(pydynox_memory_backend):
     """Test basic CRUD with pydynox_memory_backend fixture."""
     # GIVEN a model instance
     user = User(pk="USER#1", name="John", age=30)
 
     # WHEN we save and get it
-    user.save()
-    found = User.get(pk="USER#1")
+    await user.save()
+    found = await User.get(pk="USER#1")
 
     # THEN it's found with correct data
     assert found is not None
@@ -44,105 +46,114 @@ def test_pydynox_memory_backend_basic_crud(pydynox_memory_backend):
     assert found.age == 30
 
 
-def test_pydynox_memory_backend_update(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_update(pydynox_memory_backend):
     """Test update with pydynox_memory_backend fixture."""
     # GIVEN a saved user
     user = User(pk="USER#1", name="Jane")
-    user.save()
+    await user.save()
 
     # WHEN we update it
-    user.update(name="Janet", age=25)
+    await user.update(name="Janet", age=25)
 
     # THEN changes are persisted
-    found = User.get(pk="USER#1")
+    found = await User.get(pk="USER#1")
     assert found.name == "Janet"
     assert found.age == 25
 
 
-def test_pydynox_memory_backend_delete(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_delete(pydynox_memory_backend):
     """Test delete with pydynox_memory_backend fixture."""
     # GIVEN a saved user
     user = User(pk="USER#1", name="Bob")
-    user.save()
+    await user.save()
 
     # WHEN we delete it
-    user.delete()
+    await user.delete()
 
     # THEN it's gone
-    assert User.get(pk="USER#1") is None
+    assert await User.get(pk="USER#1") is None
 
 
-def test_pydynox_memory_backend_query(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_query(pydynox_memory_backend):
     """Test query with pydynox_memory_backend fixture."""
     # GIVEN orders for different users
-    Order(pk="USER#1", sk="ORDER#001", total=100).save()
-    Order(pk="USER#1", sk="ORDER#002", total=200).save()
-    Order(pk="USER#2", sk="ORDER#001", total=50).save()
+    await Order(pk="USER#1", sk="ORDER#001", total=100).save()
+    await Order(pk="USER#1", sk="ORDER#002", total=200).save()
+    await Order(pk="USER#2", sk="ORDER#001", total=50).save()
 
     # WHEN we query for USER#1
-    results = list(Order.query(hash_key="USER#1"))
+    results = [order async for order in Order.query(hash_key="USER#1")]
 
     # THEN only USER#1 orders are returned
     assert len(results) == 2
 
 
-def test_pydynox_memory_backend_scan(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_scan(pydynox_memory_backend):
     """Test scan with pydynox_memory_backend fixture."""
-    User(pk="USER#1", name="Alice").save()
-    User(pk="USER#2", name="Bob").save()
-    User(pk="USER#3", name="Charlie").save()
+    await User(pk="USER#1", name="Alice").save()
+    await User(pk="USER#2", name="Bob").save()
+    await User(pk="USER#3", name="Charlie").save()
 
-    results = list(User.scan())
+    results = [user async for user in User.scan()]
     assert len(results) == 3
 
 
-def test_pydynox_memory_backend_isolation(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_isolation(pydynox_memory_backend):
     """Test that each test has isolated data."""
     # GIVEN a fresh test (no data from other tests)
-    assert User.get(pk="USER#1") is None
+    assert await User.get(pk="USER#1") is None
 
     # WHEN we save a user
-    User(pk="USER#1", name="Isolated").save()
+    await User(pk="USER#1", name="Isolated").save()
 
     # THEN it exists in this test
-    assert User.get(pk="USER#1") is not None
+    assert await User.get(pk="USER#1") is not None
 
 
-def test_pydynox_memory_backend_tables_access(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_tables_access(pydynox_memory_backend):
     """Test accessing tables for inspection."""
-    User(pk="USER#1", name="Test").save()
+    await User(pk="USER#1", name="Test").save()
 
     # Can inspect the backend
     assert "users" in pydynox_memory_backend.tables
     assert len(pydynox_memory_backend.tables["users"]) == 1
 
 
-def test_pydynox_memory_backend_clear(pydynox_memory_backend):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_clear(pydynox_memory_backend):
     """Test clearing data mid-test."""
     # GIVEN a saved user
-    User(pk="USER#1", name="Test").save()
-    assert User.get(pk="USER#1") is not None
+    await User(pk="USER#1", name="Test").save()
+    assert await User.get(pk="USER#1") is not None
 
     # WHEN we clear the backend
     pydynox_memory_backend.clear()
 
     # THEN data is gone
-    assert User.get(pk="USER#1") is None
+    assert await User.get(pk="USER#1") is None
 
 
 # ========== Tests using pydynox_memory_backend_seeded fixture ==========
 
 
-def test_pydynox_memory_backend_seeded_basic(pydynox_memory_backend_seeded):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_seeded_basic(pydynox_memory_backend_seeded):
     """Test seeded fixture (no seed data by default)."""
     # Default pydynox_seed returns empty dict
-    assert User.get(pk="USER#1") is None
+    assert await User.get(pk="USER#1") is None
 
 
 # ========== Tests using pydynox_memory_backend_factory fixture ==========
 
 
-def test_pydynox_memory_backend_factory_custom_seed(pydynox_memory_backend_factory):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_factory_custom_seed(pydynox_memory_backend_factory):
     """Test factory fixture with custom seed."""
     seed = {
         "users": [
@@ -152,16 +163,17 @@ def test_pydynox_memory_backend_factory_custom_seed(pydynox_memory_backend_facto
     }
 
     with pydynox_memory_backend_factory(seed=seed):
-        user1 = User.get(pk="USER#1")
+        user1 = await User.get(pk="USER#1")
         assert user1 is not None
         assert user1.name == "Seeded User"
 
-        user2 = User.get(pk="USER#2")
+        user2 = await User.get(pk="USER#2")
         assert user2 is not None
         assert user2.name == "Another User"
 
 
-def test_pydynox_memory_backend_factory_multiple_tables(pydynox_memory_backend_factory):
+@pytest.mark.asyncio
+async def test_pydynox_memory_backend_factory_multiple_tables(pydynox_memory_backend_factory):
     """Test factory with multiple tables seeded."""
     seed = {
         "users": [{"pk": "USER#1", "name": "John", "age": 30}],
@@ -169,9 +181,9 @@ def test_pydynox_memory_backend_factory_multiple_tables(pydynox_memory_backend_f
     }
 
     with pydynox_memory_backend_factory(seed=seed):
-        user = User.get(pk="USER#1")
+        user = await User.get(pk="USER#1")
         assert user is not None
 
-        order = Order.get(pk="USER#1", sk="ORDER#1")
+        order = await Order.get(pk="USER#1", sk="ORDER#1")
         assert order is not None
         assert order.total == 100

--- a/tests/unit/test_consistent_read.py
+++ b/tests/unit/test_consistent_read.py
@@ -9,14 +9,6 @@ from pydynox import Model, ModelConfig
 from pydynox.attributes import StringAttribute
 
 
-@pytest.fixture
-def mock_client():
-    """Create a mock DynamoDB client."""
-    client = MagicMock()
-    client.get_item.return_value = None
-    return client
-
-
 def test_model_config_consistent_read_default():
     """ModelConfig.consistent_read defaults to False."""
     # WHEN we create a ModelConfig without consistent_read
@@ -35,73 +27,113 @@ def test_model_config_consistent_read_true():
     assert config.consistent_read is True
 
 
-def test_model_get_uses_config_consistent_read(mock_client):
+@pytest.mark.asyncio
+async def test_model_get_uses_config_consistent_read():
     """Model.get() uses model_config.consistent_read when not specified."""
-
     # GIVEN a model with consistent_read=True in config
+    mock_client = MagicMock()
+    get_calls = []
+
+    async def mock_get_item(table, key, consistent_read=False):
+        get_calls.append({"table": table, "key": key, "consistent_read": consistent_read})
+        return None
+
+    mock_client.get_item = mock_get_item
+
     class User(Model):
         model_config = ModelConfig(table="users", client=mock_client, consistent_read=True)
         pk = StringAttribute(hash_key=True)
         name = StringAttribute()
+
+    User._client_instance = None
 
     # WHEN we call get without specifying consistent_read
-    User.get(pk="USER#123")
+    await User.get(pk="USER#123")
 
     # THEN the client should be called with consistent_read=True
-    mock_client.get_item.assert_called_once()
-    call_kwargs = mock_client.get_item.call_args
-    assert call_kwargs[1]["consistent_read"] is True
+    assert len(get_calls) == 1
+    assert get_calls[0]["consistent_read"] is True
 
 
-def test_model_get_override_consistent_read(mock_client):
+@pytest.mark.asyncio
+async def test_model_get_override_consistent_read():
     """Model.get() can override model_config.consistent_read."""
-
     # GIVEN a model with consistent_read=True in config
+    mock_client = MagicMock()
+    get_calls = []
+
+    async def mock_get_item(table, key, consistent_read=False):
+        get_calls.append({"table": table, "key": key, "consistent_read": consistent_read})
+        return None
+
+    mock_client.get_item = mock_get_item
+
     class User(Model):
         model_config = ModelConfig(table="users", client=mock_client, consistent_read=True)
         pk = StringAttribute(hash_key=True)
         name = StringAttribute()
 
+    User._client_instance = None
+
     # WHEN we call get with consistent_read=False
-    User.get(pk="USER#123", consistent_read=False)
+    await User.get(pk="USER#123", consistent_read=False)
 
     # THEN the client should be called with consistent_read=False
-    mock_client.get_item.assert_called_once()
-    call_kwargs = mock_client.get_item.call_args
-    assert call_kwargs[1]["consistent_read"] is False
+    assert len(get_calls) == 1
+    assert get_calls[0]["consistent_read"] is False
 
 
-def test_model_get_default_eventually_consistent(mock_client):
+@pytest.mark.asyncio
+async def test_model_get_default_eventually_consistent():
     """Model.get() defaults to eventually consistent when not configured."""
-
     # GIVEN a model without consistent_read in config
+    mock_client = MagicMock()
+    get_calls = []
+
+    async def mock_get_item(table, key, consistent_read=False):
+        get_calls.append({"table": table, "key": key, "consistent_read": consistent_read})
+        return None
+
+    mock_client.get_item = mock_get_item
+
     class User(Model):
         model_config = ModelConfig(table="users", client=mock_client)
         pk = StringAttribute(hash_key=True)
         name = StringAttribute()
+
+    User._client_instance = None
 
     # WHEN we call get
-    User.get(pk="USER#123")
+    await User.get(pk="USER#123")
 
     # THEN the client should be called with consistent_read=False
-    mock_client.get_item.assert_called_once()
-    call_kwargs = mock_client.get_item.call_args
-    assert call_kwargs[1]["consistent_read"] is False
+    assert len(get_calls) == 1
+    assert get_calls[0]["consistent_read"] is False
 
 
-def test_model_get_explicit_consistent_read(mock_client):
+@pytest.mark.asyncio
+async def test_model_get_explicit_consistent_read():
     """Model.get() can request consistent read explicitly."""
-
     # GIVEN a model without consistent_read in config
+    mock_client = MagicMock()
+    get_calls = []
+
+    async def mock_get_item(table, key, consistent_read=False):
+        get_calls.append({"table": table, "key": key, "consistent_read": consistent_read})
+        return None
+
+    mock_client.get_item = mock_get_item
+
     class User(Model):
         model_config = ModelConfig(table="users", client=mock_client)
         pk = StringAttribute(hash_key=True)
         name = StringAttribute()
 
+    User._client_instance = None
+
     # WHEN we call get with consistent_read=True
-    User.get(pk="USER#123", consistent_read=True)
+    await User.get(pk="USER#123", consistent_read=True)
 
     # THEN the client should be called with consistent_read=True
-    mock_client.get_item.assert_called_once()
-    call_kwargs = mock_client.get_item.call_args
-    assert call_kwargs[1]["consistent_read"] is True
+    assert len(get_calls) == 1
+    assert get_calls[0]["consistent_read"] is True

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,6 +1,11 @@
-"""Tests for Model base class."""
+"""Tests for Model base class.
 
-from unittest.mock import MagicMock
+With async-first API:
+- get(), save(), delete(), update() are async (default)
+- sync_get(), sync_save(), sync_delete(), sync_update() are sync
+"""
+
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydynox import Model, ModelConfig, clear_default_client, set_default_client
@@ -17,8 +22,20 @@ def reset_state():
 
 @pytest.fixture
 def mock_client():
-    """Create a mock DynamoDB client."""
-    return MagicMock()
+    """Create a mock DynamoDB client with async methods."""
+    client = MagicMock()
+    # Async methods (default, no prefix)
+    client.get_item = AsyncMock(return_value=None)
+    client.put_item = AsyncMock(return_value=None)
+    client.delete_item = AsyncMock(return_value=None)
+    client.update_item = AsyncMock(return_value=None)
+    # Sync methods (with sync_ prefix)
+    client.sync_get_item = MagicMock(return_value=None)
+    client.sync_put_item = MagicMock(return_value=None)
+    client.sync_delete_item = MagicMock(return_value=None)
+    client.sync_update_item = MagicMock(return_value=None)
+    client.sync_batch_get = MagicMock(return_value=[])
+    return client
 
 
 @pytest.fixture
@@ -38,12 +55,7 @@ def user_model(mock_client):
 
 def test_model_collects_attributes(user_model):
     """Model metaclass collects all attributes."""
-    # GIVEN a User model with pk, sk, name, and age attributes
-
-    # WHEN we check the collected attributes
     attributes = user_model._attributes
-
-    # THEN all attributes should be present
     assert "pk" in attributes
     assert "sk" in attributes
     assert "name" in attributes
@@ -52,21 +64,13 @@ def test_model_collects_attributes(user_model):
 
 def test_model_identifies_keys(user_model):
     """Model metaclass identifies hash and range keys."""
-    # GIVEN a User model with pk as hash_key and sk as range_key
-
-    # THEN the model should correctly identify the keys
     assert user_model._hash_key == "pk"
     assert user_model._range_key == "sk"
 
 
 def test_model_init_sets_attributes(user_model):
     """Model init sets attribute values."""
-    # GIVEN attribute values for a user
-
-    # WHEN we create a user instance
     user = user_model(pk="USER#1", sk="PROFILE", name="John", age=30)
-
-    # THEN all attributes should be set correctly
     assert user.pk == "USER#1"
     assert user.sk == "PROFILE"
     assert user.name == "John"
@@ -75,12 +79,7 @@ def test_model_init_sets_attributes(user_model):
 
 def test_model_init_sets_defaults(user_model):
     """Model init uses default values for missing attributes."""
-    # GIVEN only required key attributes
-
-    # WHEN we create a user without optional attributes
     user = user_model(pk="USER#1", sk="PROFILE")
-
-    # THEN keys should be set and optional attributes should be None
     assert user.pk == "USER#1"
     assert user.name is None
     assert user.age is None
@@ -88,38 +87,23 @@ def test_model_init_sets_defaults(user_model):
 
 def test_model_to_dict(user_model):
     """to_dict returns all non-None attributes."""
-    # GIVEN a user with all attributes set
     user = user_model(pk="USER#1", sk="PROFILE", name="John", age=30)
-
-    # WHEN we convert to dict
     result = user.to_dict()
-
-    # THEN all attributes should be in the dict
     assert result == {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
 
 
 def test_model_to_dict_excludes_none(user_model):
     """to_dict excludes None values."""
-    # GIVEN a user with age not set
     user = user_model(pk="USER#1", sk="PROFILE", name="John")
-
-    # WHEN we convert to dict
     result = user.to_dict()
-
-    # THEN age should not be in the dict
     assert result == {"pk": "USER#1", "sk": "PROFILE", "name": "John"}
     assert "age" not in result
 
 
 def test_model_from_dict(user_model):
     """from_dict creates a model instance."""
-    # GIVEN a dict with user data
     data = {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
-
-    # WHEN we create a user from dict
     user = user_model.from_dict(data)
-
-    # THEN all attributes should be set correctly
     assert user.pk == "USER#1"
     assert user.sk == "PROFILE"
     assert user.name == "John"
@@ -128,25 +112,15 @@ def test_model_from_dict(user_model):
 
 def test_model_get_key(user_model):
     """_get_key returns the primary key dict."""
-    # GIVEN a user instance
     user = user_model(pk="USER#1", sk="PROFILE", name="John")
-
-    # WHEN we get the key
     key = user._get_key()
-
-    # THEN it should contain only pk and sk
     assert key == {"pk": "USER#1", "sk": "PROFILE"}
 
 
 def test_model_repr(user_model):
     """__repr__ returns a readable string."""
-    # GIVEN a user instance
     user = user_model(pk="USER#1", sk="PROFILE", name="John")
-
-    # WHEN we get the repr
     result = repr(user)
-
-    # THEN it should contain class name and key attributes
     assert "User" in result
     assert "pk='USER#1'" in result
     assert "name='John'" in result
@@ -154,19 +128,19 @@ def test_model_repr(user_model):
 
 def test_model_equality(user_model):
     """Models are equal if they have the same key."""
-    # GIVEN three users with different keys/names
     user1 = user_model(pk="USER#1", sk="PROFILE", name="John")
     user2 = user_model(pk="USER#1", sk="PROFILE", name="Jane")
     user3 = user_model(pk="USER#2", sk="PROFILE", name="John")
-
-    # THEN users with same key should be equal, different key should not
-    assert user1 == user2  # Same key, different name
-    assert user1 != user3  # Different key
+    assert user1 == user2
+    assert user1 != user3
 
 
-def test_model_get(user_model, mock_client):
-    """Model.get fetches item from DynamoDB."""
-    # GIVEN a mock client that returns user data
+# ========== ASYNC TESTS (default API) ==========
+
+
+@pytest.mark.asyncio
+async def test_model_get(user_model, mock_client):
+    """Model.get() fetches item from DynamoDB (async)."""
     mock_client.get_item.return_value = {
         "pk": "USER#1",
         "sk": "PROFILE",
@@ -174,10 +148,8 @@ def test_model_get(user_model, mock_client):
         "age": 30,
     }
 
-    # WHEN we call get
-    user = user_model.get(pk="USER#1", sk="PROFILE")
+    user = await user_model.get(pk="USER#1", sk="PROFILE")
 
-    # THEN the user should be returned with correct data
     assert user is not None
     assert user.pk == "USER#1"
     assert user.name == "John"
@@ -186,76 +158,64 @@ def test_model_get(user_model, mock_client):
     )
 
 
-def test_model_get_not_found(user_model, mock_client):
-    """Model.get returns None when item not found."""
-    # GIVEN a mock client that returns None
+@pytest.mark.asyncio
+async def test_model_get_not_found(user_model, mock_client):
+    """Model.get() returns None when item not found (async)."""
     mock_client.get_item.return_value = None
 
-    # WHEN we call get for a non-existent user
-    user = user_model.get(pk="USER#1", sk="PROFILE")
+    user = await user_model.get(pk="USER#1", sk="PROFILE")
 
-    # THEN None should be returned
     assert user is None
 
 
-def test_model_save(user_model, mock_client):
-    """Model.save puts item to DynamoDB."""
-    # GIVEN a user instance
+@pytest.mark.asyncio
+async def test_model_save(user_model, mock_client):
+    """Model.save() puts item to DynamoDB (async)."""
     user = user_model(pk="USER#1", sk="PROFILE", name="John", age=30)
 
-    # WHEN we save the user
-    user.save()
+    await user.save()
 
-    # THEN put_item should be called with correct data
     mock_client.put_item.assert_called_once_with(
         "users", {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
     )
 
 
-def test_model_delete(user_model, mock_client):
-    """Model.delete removes item from DynamoDB."""
-    # GIVEN a user instance
+@pytest.mark.asyncio
+async def test_model_delete(user_model, mock_client):
+    """Model.delete() removes item from DynamoDB (async)."""
     user = user_model(pk="USER#1", sk="PROFILE", name="John")
 
-    # WHEN we delete the user
-    user.delete()
+    await user.delete()
 
-    # THEN delete_item should be called with the key
     mock_client.delete_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
 
 
-def test_model_update(user_model, mock_client):
-    """Model.update updates specific attributes."""
-    # GIVEN a user instance
+@pytest.mark.asyncio
+async def test_model_update(user_model, mock_client):
+    """Model.update() updates specific attributes (async)."""
     user = user_model(pk="USER#1", sk="PROFILE", name="John", age=30)
 
-    # WHEN we update name and age
-    user.update(name="Jane", age=31)
+    await user.update(name="Jane", age=31)
 
-    # THEN local instance should be updated
     assert user.name == "Jane"
     assert user.age == 31
-
-    # AND DynamoDB should be updated
     mock_client.update_item.assert_called_once_with(
         "users", {"pk": "USER#1", "sk": "PROFILE"}, updates={"name": "Jane", "age": 31}
     )
 
 
-def test_model_update_unknown_attribute(user_model):
-    """Model.update raises error for unknown attributes."""
-    # GIVEN a user instance
+@pytest.mark.asyncio
+async def test_model_update_unknown_attribute(user_model):
+    """Model.update() raises error for unknown attributes (async)."""
     user = user_model(pk="USER#1", sk="PROFILE", name="John")
 
-    # WHEN we try to update an unknown attribute
-    # THEN ValueError should be raised
     with pytest.raises(ValueError, match="Unknown attribute"):
-        user.update(unknown_field="value")
+        await user.update(unknown_field="value")
 
 
-def test_model_with_default_client(mock_client):
-    """Model works with default client."""
-    # GIVEN a default client is set
+@pytest.mark.asyncio
+async def test_model_with_default_client(mock_client):
+    """Model works with default client (async)."""
     set_default_client(mock_client)
     mock_client.get_item.return_value = {"pk": "USER#1", "name": "John"}
 
@@ -266,26 +226,21 @@ def test_model_with_default_client(mock_client):
 
     User._client_instance = None
 
-    # WHEN we call get
-    user = User.get(pk="USER#1")
+    user = await User.get(pk="USER#1")
 
-    # THEN the default client should be used
     assert user is not None
     assert user.name == "John"
     mock_client.get_item.assert_called_once()
 
 
-# ========== update_by_key / delete_by_key tests ==========
+# ========== ASYNC update_by_key / delete_by_key tests ==========
 
 
-def test_update_by_key(user_model, mock_client):
-    """update_by_key updates item without fetching it first."""
-    # GIVEN a model class with mock client
+@pytest.mark.asyncio
+async def test_update_by_key(user_model, mock_client):
+    """update_by_key() updates item without fetching (async)."""
+    await user_model.update_by_key(pk="USER#1", sk="PROFILE", name="Jane", age=31)
 
-    # WHEN we call update_by_key
-    user_model.update_by_key(pk="USER#1", sk="PROFILE", name="Jane", age=31)
-
-    # THEN update_item should be called with correct params
     mock_client.update_item.assert_called_once_with(
         "users",
         {"pk": "USER#1", "sk": "PROFILE"},
@@ -293,122 +248,63 @@ def test_update_by_key(user_model, mock_client):
     )
 
 
-def test_update_by_key_missing_hash_key(user_model):
-    """update_by_key raises error when hash_key is missing."""
-    # GIVEN a model that requires pk as hash_key
-
-    # WHEN we call update_by_key without pk
-    # THEN ValueError should be raised
+@pytest.mark.asyncio
+async def test_update_by_key_missing_hash_key(user_model):
+    """update_by_key() raises error when hash_key is missing."""
     with pytest.raises(ValueError, match="Missing required hash_key"):
-        user_model.update_by_key(sk="PROFILE", name="Jane")
+        await user_model.update_by_key(sk="PROFILE", name="Jane")
 
 
-def test_update_by_key_missing_range_key(user_model):
-    """update_by_key raises error when range_key is missing."""
-    # GIVEN a model that requires sk as range_key
-
-    # WHEN we call update_by_key without sk
-    # THEN ValueError should be raised
+@pytest.mark.asyncio
+async def test_update_by_key_missing_range_key(user_model):
+    """update_by_key() raises error when range_key is missing."""
     with pytest.raises(ValueError, match="Missing required range_key"):
-        user_model.update_by_key(pk="USER#1", name="Jane")
+        await user_model.update_by_key(pk="USER#1", name="Jane")
 
 
-def test_update_by_key_unknown_attribute(user_model):
-    """update_by_key raises error for unknown attributes."""
-    # GIVEN a model with known attributes
-
-    # WHEN we try to update an unknown attribute
-    # THEN ValueError should be raised
+@pytest.mark.asyncio
+async def test_update_by_key_unknown_attribute(user_model):
+    """update_by_key() raises error for unknown attributes."""
     with pytest.raises(ValueError, match="Unknown attribute"):
-        user_model.update_by_key(pk="USER#1", sk="PROFILE", unknown_field="value")
+        await user_model.update_by_key(pk="USER#1", sk="PROFILE", unknown_field="value")
 
 
-def test_update_by_key_no_updates(user_model, mock_client):
-    """update_by_key does nothing when no updates provided."""
-    # GIVEN a model class
+@pytest.mark.asyncio
+async def test_update_by_key_no_updates(user_model, mock_client):
+    """update_by_key() does nothing when no updates provided."""
+    await user_model.update_by_key(pk="USER#1", sk="PROFILE")
 
-    # WHEN we call update_by_key with only keys
-    user_model.update_by_key(pk="USER#1", sk="PROFILE")
-
-    # THEN update_item should not be called
     mock_client.update_item.assert_not_called()
 
 
-def test_delete_by_key(user_model, mock_client):
-    """delete_by_key deletes item without fetching it first."""
-    # GIVEN a model class with mock client
+@pytest.mark.asyncio
+async def test_delete_by_key(user_model, mock_client):
+    """delete_by_key() deletes item without fetching (async)."""
+    await user_model.delete_by_key(pk="USER#1", sk="PROFILE")
 
-    # WHEN we call delete_by_key
-    user_model.delete_by_key(pk="USER#1", sk="PROFILE")
-
-    # THEN delete_item should be called with the key
     mock_client.delete_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
 
 
-def test_delete_by_key_missing_hash_key(user_model):
-    """delete_by_key raises error when hash_key is missing."""
-    # GIVEN a model that requires pk as hash_key
-
-    # WHEN we call delete_by_key without pk
-    # THEN ValueError should be raised
+@pytest.mark.asyncio
+async def test_delete_by_key_missing_hash_key(user_model):
+    """delete_by_key() raises error when hash_key is missing."""
     with pytest.raises(ValueError, match="Missing required hash_key"):
-        user_model.delete_by_key(sk="PROFILE")
+        await user_model.delete_by_key(sk="PROFILE")
 
 
-def test_delete_by_key_missing_range_key(user_model):
-    """delete_by_key raises error when range_key is missing."""
-    # GIVEN a model that requires sk as range_key
-
-    # WHEN we call delete_by_key without sk
-    # THEN ValueError should be raised
+@pytest.mark.asyncio
+async def test_delete_by_key_missing_range_key(user_model):
+    """delete_by_key() raises error when range_key is missing."""
     with pytest.raises(ValueError, match="Missing required range_key"):
-        user_model.delete_by_key(pk="USER#1")
+        await user_model.delete_by_key(pk="USER#1")
+
+
+# ========== ASYNC as_dict tests ==========
 
 
 @pytest.mark.asyncio
-async def test_async_update_by_key(user_model, mock_client):
-    """async_update_by_key updates item without fetching it first."""
-    import asyncio
-
-    # GIVEN a mock async client
-    mock_client.async_update_item.return_value = asyncio.Future()
-    mock_client.async_update_item.return_value.set_result(None)
-
-    # WHEN we call async_update_by_key
-    await user_model.async_update_by_key(pk="USER#1", sk="PROFILE", name="Jane")
-
-    # THEN async_update_item should be called with correct params
-    mock_client.async_update_item.assert_called_once_with(
-        "users",
-        {"pk": "USER#1", "sk": "PROFILE"},
-        updates={"name": "Jane"},
-    )
-
-
-@pytest.mark.asyncio
-async def test_async_delete_by_key(user_model, mock_client):
-    """async_delete_by_key deletes item without fetching it first."""
-    import asyncio
-
-    # GIVEN a mock async client
-    mock_client.async_delete_item.return_value = asyncio.Future()
-    mock_client.async_delete_item.return_value.set_result(None)
-
-    # WHEN we call async_delete_by_key
-    await user_model.async_delete_by_key(pk="USER#1", sk="PROFILE")
-
-    # THEN async_delete_item should be called with the key
-    mock_client.async_delete_item.assert_called_once_with(
-        "users", {"pk": "USER#1", "sk": "PROFILE"}
-    )
-
-
-# ========== as_dict tests ==========
-
-
-def test_get_as_dict_true_returns_dict(user_model, mock_client):
-    """get(as_dict=True) returns plain dict."""
-    # GIVEN a mock client that returns user data
+async def test_get_as_dict_true_returns_dict(user_model, mock_client):
+    """get(as_dict=True) returns plain dict (async)."""
     mock_client.get_item.return_value = {
         "pk": "USER#1",
         "sk": "PROFILE",
@@ -416,17 +312,15 @@ def test_get_as_dict_true_returns_dict(user_model, mock_client):
         "age": 30,
     }
 
-    # WHEN we call get with as_dict=True
-    user = user_model.get(pk="USER#1", sk="PROFILE", as_dict=True)
+    user = await user_model.get(pk="USER#1", sk="PROFILE", as_dict=True)
 
-    # THEN a plain dict should be returned
     assert isinstance(user, dict)
     assert user["name"] == "Alice"
 
 
-def test_get_as_dict_false_returns_model_instance(user_model, mock_client):
-    """get(as_dict=False) returns Model instance."""
-    # GIVEN a mock client that returns user data
+@pytest.mark.asyncio
+async def test_get_as_dict_false_returns_model_instance(user_model, mock_client):
+    """get(as_dict=False) returns Model instance (async)."""
     mock_client.get_item.return_value = {
         "pk": "USER#1",
         "sk": "PROFILE",
@@ -434,24 +328,150 @@ def test_get_as_dict_false_returns_model_instance(user_model, mock_client):
         "age": 30,
     }
 
-    # WHEN we call get with as_dict=False
-    user = user_model.get(pk="USER#1", sk="PROFILE", as_dict=False)
+    user = await user_model.get(pk="USER#1", sk="PROFILE", as_dict=False)
 
-    # THEN a Model instance should be returned
     assert isinstance(user, user_model)
     assert user.name == "Alice"
 
 
-def test_get_as_dict_returns_none_when_not_found(user_model, mock_client):
-    """get(as_dict=True) returns None when item not found."""
-    # GIVEN a mock client that returns None
+@pytest.mark.asyncio
+async def test_get_as_dict_returns_none_when_not_found(user_model, mock_client):
+    """get(as_dict=True) returns None when item not found (async)."""
     mock_client.get_item.return_value = None
 
-    # WHEN we call get with as_dict=True for non-existent item
-    user = user_model.get(pk="USER#1", sk="PROFILE", as_dict=True)
+    user = await user_model.get(pk="USER#1", sk="PROFILE", as_dict=True)
 
-    # THEN None should be returned
     assert user is None
+
+
+# ========== SYNC TESTS (sync_ prefix) ==========
+
+
+def test_sync_model_get(user_model, mock_client):
+    """Model.sync_get() fetches item from DynamoDB (sync)."""
+    mock_client.sync_get_item.return_value = {
+        "pk": "USER#1",
+        "sk": "PROFILE",
+        "name": "John",
+        "age": 30,
+    }
+
+    user = user_model.sync_get(pk="USER#1", sk="PROFILE")
+
+    assert user is not None
+    assert user.pk == "USER#1"
+    assert user.name == "John"
+    mock_client.sync_get_item.assert_called_once_with(
+        "users", {"pk": "USER#1", "sk": "PROFILE"}, consistent_read=False
+    )
+
+
+def test_sync_model_get_not_found(user_model, mock_client):
+    """Model.sync_get() returns None when item not found (sync)."""
+    mock_client.sync_get_item.return_value = None
+
+    user = user_model.sync_get(pk="USER#1", sk="PROFILE")
+
+    assert user is None
+
+
+def test_sync_model_save(user_model, mock_client):
+    """Model.sync_save() puts item to DynamoDB (sync)."""
+    user = user_model(pk="USER#1", sk="PROFILE", name="John", age=30)
+
+    user.sync_save()
+
+    mock_client.sync_put_item.assert_called_once_with(
+        "users", {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
+    )
+
+
+def test_sync_model_delete(user_model, mock_client):
+    """Model.sync_delete() removes item from DynamoDB (sync)."""
+    user = user_model(pk="USER#1", sk="PROFILE", name="John")
+
+    user.sync_delete()
+
+    mock_client.sync_delete_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
+
+
+def test_sync_model_update(user_model, mock_client):
+    """Model.sync_update() updates specific attributes (sync)."""
+    user = user_model(pk="USER#1", sk="PROFILE", name="John", age=30)
+
+    user.sync_update(name="Jane", age=31)
+
+    assert user.name == "Jane"
+    assert user.age == 31
+    mock_client.sync_update_item.assert_called_once_with(
+        "users", {"pk": "USER#1", "sk": "PROFILE"}, updates={"name": "Jane", "age": 31}
+    )
+
+
+def test_sync_model_update_unknown_attribute(user_model):
+    """Model.sync_update() raises error for unknown attributes (sync)."""
+    user = user_model(pk="USER#1", sk="PROFILE", name="John")
+
+    with pytest.raises(ValueError, match="Unknown attribute"):
+        user.sync_update(unknown_field="value")
+
+
+# ========== SYNC update_by_key / delete_by_key tests ==========
+
+
+def test_sync_update_by_key(user_model, mock_client):
+    """sync_update_by_key() updates item without fetching (sync)."""
+    user_model.sync_update_by_key(pk="USER#1", sk="PROFILE", name="Jane", age=31)
+
+    mock_client.sync_update_item.assert_called_once_with(
+        "users",
+        {"pk": "USER#1", "sk": "PROFILE"},
+        updates={"name": "Jane", "age": 31},
+    )
+
+
+def test_sync_update_by_key_missing_hash_key(user_model):
+    """sync_update_by_key() raises error when hash_key is missing."""
+    with pytest.raises(ValueError, match="Missing required hash_key"):
+        user_model.sync_update_by_key(sk="PROFILE", name="Jane")
+
+
+def test_sync_update_by_key_missing_range_key(user_model):
+    """sync_update_by_key() raises error when range_key is missing."""
+    with pytest.raises(ValueError, match="Missing required range_key"):
+        user_model.sync_update_by_key(pk="USER#1", name="Jane")
+
+
+def test_sync_update_by_key_unknown_attribute(user_model):
+    """sync_update_by_key() raises error for unknown attributes."""
+    with pytest.raises(ValueError, match="Unknown attribute"):
+        user_model.sync_update_by_key(pk="USER#1", sk="PROFILE", unknown_field="value")
+
+
+def test_sync_update_by_key_no_updates(user_model, mock_client):
+    """sync_update_by_key() does nothing when no updates provided."""
+    user_model.sync_update_by_key(pk="USER#1", sk="PROFILE")
+
+    mock_client.sync_update_item.assert_not_called()
+
+
+def test_sync_delete_by_key(user_model, mock_client):
+    """sync_delete_by_key() deletes item without fetching (sync)."""
+    user_model.sync_delete_by_key(pk="USER#1", sk="PROFILE")
+
+    mock_client.sync_delete_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
+
+
+def test_sync_delete_by_key_missing_hash_key(user_model):
+    """sync_delete_by_key() raises error when hash_key is missing."""
+    with pytest.raises(ValueError, match="Missing required hash_key"):
+        user_model.sync_delete_by_key(sk="PROFILE")
+
+
+def test_sync_delete_by_key_missing_range_key(user_model):
+    """sync_delete_by_key() raises error when range_key is missing."""
+    with pytest.raises(ValueError, match="Missing required range_key"):
+        user_model.sync_delete_by_key(pk="USER#1")
 
 
 # ========== sync_batch_get tests ==========
@@ -459,7 +479,6 @@ def test_get_as_dict_returns_none_when_not_found(user_model, mock_client):
 
 def test_sync_batch_get_returns_model_instances(user_model, mock_client):
     """sync_batch_get returns Model instances by default."""
-    # GIVEN a mock client that returns multiple users
     mock_client.sync_batch_get.return_value = [
         {"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30},
         {"pk": "USER#2", "sk": "PROFILE", "name": "Bob", "age": 25},
@@ -470,10 +489,8 @@ def test_sync_batch_get_returns_model_instances(user_model, mock_client):
         {"pk": "USER#2", "sk": "PROFILE"},
     ]
 
-    # WHEN we call sync_batch_get
     users = user_model.sync_batch_get(keys)
 
-    # THEN Model instances should be returned
     assert len(users) == 2
     assert isinstance(users[0], user_model)
     assert isinstance(users[1], user_model)
@@ -483,7 +500,6 @@ def test_sync_batch_get_returns_model_instances(user_model, mock_client):
 
 def test_sync_batch_get_as_dict_true_returns_dicts(user_model, mock_client):
     """sync_batch_get(as_dict=True) returns plain dicts."""
-    # GIVEN a mock client that returns multiple users
     mock_client.sync_batch_get.return_value = [
         {"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30},
         {"pk": "USER#2", "sk": "PROFILE", "name": "Bob", "age": 25},
@@ -494,10 +510,8 @@ def test_sync_batch_get_as_dict_true_returns_dicts(user_model, mock_client):
         {"pk": "USER#2", "sk": "PROFILE"},
     ]
 
-    # WHEN we call sync_batch_get with as_dict=True
     users = user_model.sync_batch_get(keys, as_dict=True)
 
-    # THEN plain dicts should be returned
     assert len(users) == 2
     assert isinstance(users[0], dict)
     assert isinstance(users[1], dict)
@@ -507,11 +521,7 @@ def test_sync_batch_get_as_dict_true_returns_dicts(user_model, mock_client):
 
 def test_sync_batch_get_empty_keys_returns_empty_list(user_model, mock_client):
     """sync_batch_get with empty keys returns empty list."""
-    # GIVEN an empty list of keys
-
-    # WHEN we call sync_batch_get with empty keys
     users = user_model.sync_batch_get([])
 
-    # THEN empty list should be returned without calling the client
     assert users == []
     mock_client.sync_batch_get.assert_not_called()

--- a/tests/unit/test_pydantic.py
+++ b/tests/unit/test_pydantic.py
@@ -102,10 +102,10 @@ def test_get_key_returns_hash_and_range():
 
 
 def test_get_fetches_from_dynamodb():
-    """get() fetches item from DynamoDB and returns Pydantic model."""
+    """sync_get() fetches item from DynamoDB and returns Pydantic model."""
     # GIVEN a mock client that returns user data
     mock_client = MagicMock()
-    mock_client.get_item.return_value = {
+    mock_client.sync_get_item.return_value = {
         "pk": "USER#1",
         "sk": "PROFILE",
         "name": "John",
@@ -119,22 +119,22 @@ def test_get_fetches_from_dynamodb():
         name: str
         age: int = 0
 
-    # WHEN we call get
-    user = User.get(pk="USER#1", sk="PROFILE")
+    # WHEN we call sync_get
+    user = User.sync_get(pk="USER#1", sk="PROFILE")
 
     # THEN a Pydantic model instance should be returned
     assert user is not None
     assert isinstance(user, User)
     assert user.pk == "USER#1"
     assert user.name == "John"
-    mock_client.get_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
+    mock_client.sync_get_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
 
 
 def test_get_returns_none_when_not_found():
-    """get() returns None when item not found."""
+    """sync_get() returns None when item not found."""
     # GIVEN a mock client that returns None
     mock_client = MagicMock()
-    mock_client.get_item.return_value = None
+    mock_client.sync_get_item.return_value = None
 
     @dynamodb_model(table="users", hash_key="pk", range_key="sk", client=mock_client)
     class User(BaseModel):
@@ -142,15 +142,15 @@ def test_get_returns_none_when_not_found():
         sk: str
         name: str
 
-    # WHEN we call get for non-existent item
-    user = User.get(pk="USER#1", sk="PROFILE")
+    # WHEN we call sync_get for non-existent item
+    user = User.sync_get(pk="USER#1", sk="PROFILE")
 
     # THEN None should be returned
     assert user is None
 
 
 def test_save_puts_to_dynamodb():
-    """save() puts item to DynamoDB."""
+    """sync_save() puts item to DynamoDB."""
     # GIVEN a mock client
     mock_client = MagicMock()
 
@@ -163,17 +163,17 @@ def test_save_puts_to_dynamodb():
 
     user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
 
-    # WHEN we save
-    user.save()
+    # WHEN we sync_save
+    user.sync_save()
 
-    # THEN put_item should be called with correct data
-    mock_client.put_item.assert_called_once_with(
+    # THEN sync_put_item should be called with correct data
+    mock_client.sync_put_item.assert_called_once_with(
         "users", {"pk": "USER#1", "sk": "PROFILE", "name": "John", "age": 30}
     )
 
 
 def test_delete_removes_from_dynamodb():
-    """delete() removes item from DynamoDB."""
+    """sync_delete() removes item from DynamoDB."""
     # GIVEN a mock client
     mock_client = MagicMock()
 
@@ -185,15 +185,15 @@ def test_delete_removes_from_dynamodb():
 
     user = User(pk="USER#1", sk="PROFILE", name="John")
 
-    # WHEN we delete
-    user.delete()
+    # WHEN we sync_delete
+    user.sync_delete()
 
-    # THEN delete_item should be called with the key
-    mock_client.delete_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
+    # THEN sync_delete_item should be called with the key
+    mock_client.sync_delete_item.assert_called_once_with("users", {"pk": "USER#1", "sk": "PROFILE"})
 
 
 def test_update_updates_dynamodb():
-    """update() updates item in DynamoDB."""
+    """sync_update() updates item in DynamoDB."""
     # GIVEN a mock client
     mock_client = MagicMock()
 
@@ -206,15 +206,15 @@ def test_update_updates_dynamodb():
 
     user = User(pk="USER#1", sk="PROFILE", name="John", age=30)
 
-    # WHEN we update
-    user.update(name="Jane", age=31)
+    # WHEN we sync_update
+    user.sync_update(name="Jane", age=31)
 
     # THEN local instance should be updated
     assert user.name == "Jane"
     assert user.age == 31
 
     # AND DynamoDB should be updated
-    mock_client.update_item.assert_called_once_with(
+    mock_client.sync_update_item.assert_called_once_with(
         "users", {"pk": "USER#1", "sk": "PROFILE"}, updates={"name": "Jane", "age": 31}
     )
 
@@ -294,11 +294,11 @@ def test_set_client_after_creation():
         name: str
 
     mock_client = MagicMock()
-    mock_client.get_item.return_value = {"pk": "USER#1", "name": "John"}
+    mock_client.sync_get_item.return_value = {"pk": "USER#1", "name": "John"}
 
     # WHEN we set the client
     User._set_client(mock_client)
-    user = User.get(pk="USER#1")
+    user = User.sync_get(pk="USER#1")
 
     # THEN operations should work
     assert user is not None
@@ -316,7 +316,7 @@ def test_no_client_raises_error():
 
     user = User(pk="USER#1", name="John")
 
-    # WHEN we try to save without client
+    # WHEN we try to sync_save without client
     # THEN RuntimeError should be raised
     with pytest.raises(RuntimeError, match="No client set"):
-        user.save()
+        user.sync_save()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,11 +1,16 @@
-"""Tests for Model.query() method."""
+"""Tests for Model.query() method.
 
-from unittest.mock import MagicMock, patch
+With async-first API:
+- query() returns AsyncModelQueryResult (async, default)
+- sync_query() returns ModelQueryResult (sync)
+"""
+
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydynox import Model, ModelConfig, clear_default_client
+from pydynox._internal._results import AsyncModelQueryResult, ModelQueryResult
 from pydynox.attributes import NumberAttribute, StringAttribute
-from pydynox.model import AsyncModelQueryResult, ModelQueryResult
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +27,18 @@ def mock_client():
     client = MagicMock()
     client._client = MagicMock()
     client._acquire_rcu = MagicMock()
+    # Async methods on _client (Rust client)
+    client._client.query_page = AsyncMock(
+        return_value={
+            "items": [],
+            "last_evaluated_key": None,
+            "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0),
+        }
+    )
+    # Sync methods on _client (Rust client)
+    client._client.sync_query_page = MagicMock(
+        return_value=([], None, MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0))
+    )
     return client
 
 
@@ -40,26 +57,23 @@ def user_model(mock_client):
     return User
 
 
-def test_query_returns_model_query_result(user_model):
-    """Model.query returns a ModelQueryResult."""
-    # WHEN we call query
-    result = user_model.query(hash_key="USER#123")
+# ========== ASYNC TESTS (query - default) ==========
 
-    # THEN a ModelQueryResult should be returned
-    assert isinstance(result, ModelQueryResult)
+
+def test_query_returns_async_model_query_result(user_model):
+    """Model.query() returns an AsyncModelQueryResult (async, default)."""
+    result = user_model.query(hash_key="USER#123")
+    assert isinstance(result, AsyncModelQueryResult)
 
 
 def test_query_stores_parameters(user_model):
-    """ModelQueryResult stores all query parameters."""
-    # WHEN we call query with various parameters
+    """AsyncModelQueryResult stores all query parameters."""
     result = user_model.query(
         hash_key="USER#123",
         limit=10,
         scan_index_forward=False,
         consistent_read=True,
     )
-
-    # THEN all parameters should be stored
     assert result._hash_key_value == "USER#123"
     assert result._limit == 10
     assert result._scan_index_forward is False
@@ -67,150 +81,100 @@ def test_query_stores_parameters(user_model):
 
 
 def test_query_with_range_key_condition(user_model):
-    """Model.query accepts range_key_condition."""
-    # GIVEN a range key condition
+    """Model.query() accepts range_key_condition."""
     condition = user_model.sk.begins_with("ORDER#")
-
-    # WHEN we call query with the condition
     result = user_model.query(
         hash_key="USER#123",
         range_key_condition=condition,
     )
-
-    # THEN the condition should be stored
     assert result._range_key_condition is condition
 
 
 def test_query_with_filter_condition(user_model):
-    """Model.query accepts filter_condition."""
-    # GIVEN a filter condition
+    """Model.query() accepts filter_condition."""
     condition = user_model.age > 18
-
-    # WHEN we call query with the condition
     result = user_model.query(
         hash_key="USER#123",
         filter_condition=condition,
     )
-
-    # THEN the condition should be stored
     assert result._filter_condition is condition
 
 
 def test_query_with_pagination(user_model):
-    """Model.query accepts last_evaluated_key for pagination."""
-    # GIVEN a last evaluated key
+    """Model.query() accepts last_evaluated_key for pagination."""
     last_key = {"pk": "USER#123", "sk": "ORDER#999"}
-
-    # WHEN we call query with the key
     result = user_model.query(
         hash_key="USER#123",
         last_evaluated_key=last_key,
     )
-
-    # THEN the key should be stored
     assert result._start_key == last_key
 
 
-def test_model_query_result_first_returns_none_when_empty(user_model):
-    """ModelQueryResult.first() returns None when no results."""
-    # GIVEN a query that returns no results
-    with patch.object(ModelQueryResult, "_build_result") as mock_build:
-        mock_query_result = MagicMock()
-        mock_query_result.__iter__ = MagicMock(return_value=iter([]))
-        mock_build.return_value = mock_query_result
+@pytest.mark.asyncio
+async def test_async_query_first_returns_none_when_empty(user_model, mock_client):
+    """AsyncModelQueryResult.first() returns None when no results."""
+    mock_client._client.query_page.return_value = {
+        "items": [],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0),
+    }
 
-        result = user_model.query(hash_key="USER#123")
-
-        # WHEN we call first
-        first = result.first()
-
-        # THEN None should be returned
-        assert first is None
-
-
-def test_model_query_result_list(user_model):
-    """list(ModelQueryResult) collects all results."""
-    # GIVEN a query that returns multiple items
-    with patch.object(ModelQueryResult, "_build_result") as mock_build:
-        mock_query_result = MagicMock()
-        items = [
-            {"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1"},
-            {"pk": "USER#123", "sk": "ORDER#2", "name": "Order 2"},
-        ]
-        mock_query_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_query_result
-
-        result = user_model.query(hash_key="USER#123")
-
-        # WHEN we convert to list
-        users = list(result)
-
-        # THEN all items should be returned
-        assert len(users) == 2
-        assert users[0].sk == "ORDER#1"
-        assert users[1].sk == "ORDER#2"
-
-
-def test_model_query_result_iteration(user_model):
-    """ModelQueryResult can be iterated."""
-    # GIVEN a query that returns items
-    with patch.object(ModelQueryResult, "_build_result") as mock_build:
-        mock_query_result = MagicMock()
-        items = [
-            {"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1"},
-        ]
-        mock_query_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_query_result
-
-        result = user_model.query(hash_key="USER#123")
-
-        # WHEN we iterate
-        users = list(result)
-
-        # THEN items should be Model instances
-        assert len(users) == 1
-        assert isinstance(users[0], user_model)
-
-
-def test_model_query_result_last_evaluated_key_before_iteration(user_model):
-    """ModelQueryResult.last_evaluated_key is None before iteration."""
-    # GIVEN a query result
     result = user_model.query(hash_key="USER#123")
+    first = await result.first()
 
-    # THEN last_evaluated_key should be None before iteration
+    assert first is None
+
+
+@pytest.mark.asyncio
+async def test_async_query_to_list(user_model, mock_client):
+    """AsyncModelQueryResult collects all results via async iteration."""
+    mock_client._client.query_page.return_value = {
+        "items": [
+            {"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10},
+            {"pk": "USER#123", "sk": "ORDER#2", "name": "Order 2", "age": 20},
+        ],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=2),
+    }
+
+    result = user_model.query(hash_key="USER#123")
+    users = [user async for user in result]
+
+    assert len(users) == 2
+    assert users[0].sk == "ORDER#1"
+    assert users[1].sk == "ORDER#2"
+
+
+@pytest.mark.asyncio
+async def test_async_query_iteration(user_model, mock_client):
+    """AsyncModelQueryResult can be iterated with async for."""
+    mock_client._client.query_page.return_value = {
+        "items": [
+            {"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10},
+        ],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    }
+
+    result = user_model.query(hash_key="USER#123")
+    users = []
+    async for user in result:
+        users.append(user)
+
+    assert len(users) == 1
+    assert isinstance(users[0], user_model)
+
+
+def test_query_last_evaluated_key_before_iteration(user_model):
+    """AsyncModelQueryResult.last_evaluated_key is None before iteration."""
+    result = user_model.query(hash_key="USER#123")
     assert result.last_evaluated_key is None
 
 
-def test_async_query_returns_async_model_query_result(user_model):
-    """Model.async_query returns an AsyncModelQueryResult."""
-    # WHEN we call async_query
-    result = user_model.async_query(hash_key="USER#123")
+@pytest.mark.asyncio
+async def test_query_raises_error_without_hash_key(mock_client):
+    """Model.query() raises error if model has no hash key."""
 
-    # THEN an AsyncModelQueryResult should be returned
-    assert isinstance(result, AsyncModelQueryResult)
-
-
-def test_async_query_stores_parameters(user_model):
-    """AsyncModelQueryResult stores all query parameters."""
-    # WHEN we call async_query with various parameters
-    result = user_model.async_query(
-        hash_key="USER#123",
-        limit=10,
-        scan_index_forward=False,
-        consistent_read=True,
-    )
-
-    # THEN all parameters should be stored
-    assert result._hash_key_value == "USER#123"
-    assert result._limit == 10
-    assert result._scan_index_forward is False
-    assert result._consistent_read is True
-
-
-def test_query_raises_error_without_hash_key(mock_client):
-    """Model.query raises error if model has no hash key."""
-
-    # GIVEN a model without hash key
     class BadModel(Model):
         model_config = ModelConfig(table="bad", client=mock_client)
         name = StringAttribute()
@@ -219,76 +183,155 @@ def test_query_raises_error_without_hash_key(mock_client):
 
     result = BadModel.query(hash_key="test")
 
-    # WHEN we try to get results
-    # THEN ValueError should be raised
     with pytest.raises(ValueError, match="has no hash key defined"):
-        result.first()
+        await result.first()
 
 
-# ========== as_dict tests ==========
+# ========== ASYNC as_dict tests ==========
 
 
 def test_query_as_dict_default_is_false(user_model):
     """query() defaults as_dict to False."""
-    # WHEN we call query without as_dict
     result = user_model.query(hash_key="USER#123")
-
-    # THEN as_dict should default to False
     assert result._as_dict is False
 
 
 def test_query_as_dict_stores_parameter(user_model):
-    """ModelQueryResult stores as_dict parameter."""
-    # WHEN we call query with as_dict=True
-    result = user_model.query(hash_key="USER#123", as_dict=True)
-
-    # THEN as_dict should be stored
-    assert result._as_dict is True
-
-
-def test_query_as_dict_true_returns_dicts(user_model):
-    """query(as_dict=True) returns plain dicts."""
-    # GIVEN a query with as_dict=True
-    with patch.object(ModelQueryResult, "_build_result") as mock_build:
-        mock_query_result = MagicMock()
-        items = [{"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10}]
-        mock_query_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_query_result
-
-        result = user_model.query(hash_key="USER#123", as_dict=True)
-
-        # WHEN we iterate
-        orders = list(result)
-
-        # THEN plain dicts should be returned
-        assert len(orders) == 1
-        assert isinstance(orders[0], dict)
-        assert orders[0]["name"] == "Order 1"
-
-
-def test_query_as_dict_false_returns_model_instances(user_model):
-    """query(as_dict=False) returns Model instances."""
-    # GIVEN a query with as_dict=False
-    with patch.object(ModelQueryResult, "_build_result") as mock_build:
-        mock_query_result = MagicMock()
-        items = [{"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10}]
-        mock_query_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_query_result
-
-        result = user_model.query(hash_key="USER#123", as_dict=False)
-
-        # WHEN we iterate
-        orders = list(result)
-
-        # THEN Model instances should be returned
-        assert len(orders) == 1
-        assert isinstance(orders[0], user_model)
-
-
-def test_async_query_as_dict_stores_parameter(user_model):
     """AsyncModelQueryResult stores as_dict parameter."""
-    # WHEN we call async_query with as_dict=True
-    result = user_model.async_query(hash_key="USER#123", as_dict=True)
-
-    # THEN as_dict should be stored
+    result = user_model.query(hash_key="USER#123", as_dict=True)
     assert result._as_dict is True
+
+
+@pytest.mark.asyncio
+async def test_query_as_dict_true_returns_dicts(user_model, mock_client):
+    """query(as_dict=True) returns plain dicts."""
+    mock_client._client.query_page.return_value = {
+        "items": [{"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10}],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    }
+
+    result = user_model.query(hash_key="USER#123", as_dict=True)
+    orders = [order async for order in result]
+
+    assert len(orders) == 1
+    assert isinstance(orders[0], dict)
+    assert orders[0]["name"] == "Order 1"
+
+
+@pytest.mark.asyncio
+async def test_query_as_dict_false_returns_model_instances(user_model, mock_client):
+    """query(as_dict=False) returns Model instances."""
+    mock_client._client.query_page.return_value = {
+        "items": [{"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10}],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    }
+
+    result = user_model.query(hash_key="USER#123", as_dict=False)
+    orders = [order async for order in result]
+
+    assert len(orders) == 1
+    assert isinstance(orders[0], user_model)
+
+
+# ========== SYNC TESTS (sync_query) ==========
+
+
+def test_sync_query_returns_model_query_result(user_model):
+    """Model.sync_query() returns a ModelQueryResult (sync)."""
+    result = user_model.sync_query(hash_key="USER#123")
+    assert isinstance(result, ModelQueryResult)
+
+
+def test_sync_query_stores_parameters(user_model):
+    """ModelQueryResult stores all query parameters."""
+    result = user_model.sync_query(
+        hash_key="USER#123",
+        limit=10,
+        scan_index_forward=False,
+        consistent_read=True,
+    )
+    assert result._hash_key_value == "USER#123"
+    assert result._limit == 10
+    assert result._scan_index_forward is False
+    assert result._consistent_read is True
+
+
+def test_sync_query_first_returns_none_when_empty(user_model, mock_client):
+    """ModelQueryResult.first() returns None when no results."""
+    mock_client._client.sync_query_page.return_value = (
+        [],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0),
+    )
+
+    result = user_model.sync_query(hash_key="USER#123")
+    first = result.first()
+
+    assert first is None
+
+
+def test_sync_query_list(user_model, mock_client):
+    """list(ModelQueryResult) collects all results."""
+    mock_client._client.sync_query_page.return_value = (
+        [
+            {"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10},
+            {"pk": "USER#123", "sk": "ORDER#2", "name": "Order 2", "age": 20},
+        ],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=2),
+    )
+
+    result = user_model.sync_query(hash_key="USER#123")
+    users = list(result)
+
+    assert len(users) == 2
+    assert users[0].sk == "ORDER#1"
+    assert users[1].sk == "ORDER#2"
+
+
+def test_sync_query_iteration(user_model, mock_client):
+    """ModelQueryResult can be iterated."""
+    mock_client._client.sync_query_page.return_value = (
+        [{"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10}],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    )
+
+    result = user_model.sync_query(hash_key="USER#123")
+    users = list(result)
+
+    assert len(users) == 1
+    assert isinstance(users[0], user_model)
+
+
+def test_sync_query_as_dict_true_returns_dicts(user_model, mock_client):
+    """sync_query(as_dict=True) returns plain dicts."""
+    mock_client._client.sync_query_page.return_value = (
+        [{"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10}],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    )
+
+    result = user_model.sync_query(hash_key="USER#123", as_dict=True)
+    orders = list(result)
+
+    assert len(orders) == 1
+    assert isinstance(orders[0], dict)
+    assert orders[0]["name"] == "Order 1"
+
+
+def test_sync_query_as_dict_false_returns_model_instances(user_model, mock_client):
+    """sync_query(as_dict=False) returns Model instances."""
+    mock_client._client.sync_query_page.return_value = (
+        [{"pk": "USER#123", "sk": "ORDER#1", "name": "Order 1", "age": 10}],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    )
+
+    result = user_model.sync_query(hash_key="USER#123", as_dict=False)
+    orders = list(result)
+
+    assert len(orders) == 1
+    assert isinstance(orders[0], user_model)

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -1,11 +1,18 @@
-"""Tests for Model.scan() and Model.count() methods."""
+"""Tests for Model.scan() and Model.count() methods.
 
-from unittest.mock import MagicMock, patch
+With async-first API:
+- scan() returns AsyncModelScanResult (async, default)
+- sync_scan() returns ModelScanResult (sync)
+- count() is async (default)
+- sync_count() is sync
+"""
+
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydynox import Model, ModelConfig, clear_default_client
+from pydynox._internal._results import AsyncModelScanResult, ModelScanResult
 from pydynox.attributes import NumberAttribute, StringAttribute
-from pydynox.model import AsyncModelScanResult, ModelScanResult
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +29,23 @@ def mock_client():
     client = MagicMock()
     client._client = MagicMock()
     client._acquire_rcu = MagicMock()
+    # Async methods on _client (Rust client)
+    client._client.scan_page = AsyncMock(
+        return_value={
+            "items": [],
+            "last_evaluated_key": None,
+            "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0),
+        }
+    )
+    # Sync methods on _client (Rust client)
+    client._client.sync_scan_page = MagicMock(
+        return_value=([], None, MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0))
+    )
+    # Client-level methods (count, parallel_scan)
+    client.count = AsyncMock(return_value=(0, MagicMock(duration_ms=1.0, consumed_rcu=1.0)))
+    client.parallel_scan = AsyncMock(return_value=([], MagicMock(duration_ms=1.0)))
+    client.sync_count = MagicMock(return_value=(0, MagicMock(duration_ms=1.0, consumed_rcu=1.0)))
+    client.sync_parallel_scan = MagicMock(return_value=([], MagicMock(duration_ms=1.0)))
     return client
 
 
@@ -40,273 +64,199 @@ def user_model(mock_client):
     return User
 
 
-def test_scan_returns_model_scan_result(user_model):
-    """Model.scan returns a ModelScanResult."""
-    # WHEN calling scan on a model
+# ========== ASYNC TESTS (scan - default) ==========
+
+
+def test_scan_returns_async_model_scan_result(user_model):
+    """Model.scan() returns an AsyncModelScanResult (async, default)."""
     result = user_model.scan()
-
-    # THEN it returns a ModelScanResult instance
-    assert isinstance(result, ModelScanResult)
-
-
-def test_scan_stores_parameters(user_model):
-    """ModelScanResult stores all scan parameters."""
-    # WHEN calling scan with limit and consistent_read
-    result = user_model.scan(
-        limit=10,
-        consistent_read=True,
-    )
-
-    # THEN the parameters are stored in the result
-    assert result._limit == 10
-    assert result._consistent_read is True
-
-
-def test_scan_with_filter_condition(user_model):
-    """Model.scan accepts filter_condition."""
-    # GIVEN a filter condition
-    condition = user_model.age > 18
-
-    # WHEN calling scan with the filter
-    result = user_model.scan(filter_condition=condition)
-
-    # THEN the condition is stored
-    assert result._filter_condition is condition
-
-
-def test_scan_with_pagination(user_model):
-    """Model.scan accepts last_evaluated_key for pagination."""
-    # GIVEN a last evaluated key from a previous scan
-    last_key = {"pk": "USER#123", "sk": "ORDER#999"}
-
-    # WHEN calling scan with the key
-    result = user_model.scan(last_evaluated_key=last_key)
-
-    # THEN the key is stored as start_key
-    assert result._start_key == last_key
-
-
-def test_scan_with_parallel_scan_params(user_model):
-    """Model.scan accepts segment and total_segments for parallel scan."""
-    # WHEN calling scan with parallel scan parameters
-    result = user_model.scan(segment=0, total_segments=4)
-
-    # THEN the segment parameters are stored
-    assert result._segment == 0
-    assert result._total_segments == 4
-
-
-def test_model_scan_result_first_returns_none_when_empty(user_model):
-    """ModelScanResult.first() returns None when no results."""
-    # GIVEN a scan that returns no items
-    with patch.object(ModelScanResult, "_build_result") as mock_build:
-        mock_scan_result = MagicMock()
-        mock_scan_result.__iter__ = MagicMock(return_value=iter([]))
-        mock_build.return_value = mock_scan_result
-
-        # WHEN calling first()
-        result = user_model.scan()
-        first = result.first()
-
-        # THEN it returns None
-        assert first is None
-
-
-def test_model_scan_result_list(user_model):
-    """list(ModelScanResult) collects all results."""
-    # GIVEN a scan that returns multiple items
-    with patch.object(ModelScanResult, "_build_result") as mock_build:
-        mock_scan_result = MagicMock()
-        items = [
-            {"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 25},
-            {"pk": "USER#2", "sk": "PROFILE", "name": "Bob", "age": 30},
-        ]
-        mock_scan_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_scan_result
-
-        # WHEN converting to list
-        result = user_model.scan()
-        users = list(result)
-
-        # THEN all items are returned as model instances
-        assert len(users) == 2
-        assert users[0].name == "Alice"
-        assert users[1].name == "Bob"
-
-
-def test_model_scan_result_iteration(user_model):
-    """ModelScanResult can be iterated."""
-    # GIVEN a scan that returns one item
-    with patch.object(ModelScanResult, "_build_result") as mock_build:
-        mock_scan_result = MagicMock()
-        items = [
-            {"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 25},
-        ]
-        mock_scan_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_scan_result
-
-        # WHEN iterating over the result
-        result = user_model.scan()
-        users = list(result)
-
-        # THEN items are returned as model instances
-        assert len(users) == 1
-        assert isinstance(users[0], user_model)
-
-
-def test_model_scan_result_last_evaluated_key_before_iteration(user_model):
-    """ModelScanResult.last_evaluated_key is None before iteration."""
-    # WHEN creating a scan result without iterating
-    result = user_model.scan()
-
-    # THEN last_evaluated_key is None
-    assert result.last_evaluated_key is None
-
-
-def test_async_scan_returns_async_model_scan_result(user_model):
-    """Model.async_scan returns an AsyncModelScanResult."""
-    # WHEN calling async_scan on a model
-    result = user_model.async_scan()
-
-    # THEN it returns an AsyncModelScanResult instance
     assert isinstance(result, AsyncModelScanResult)
 
 
-def test_async_scan_stores_parameters(user_model):
+def test_scan_stores_parameters(user_model):
     """AsyncModelScanResult stores all scan parameters."""
-    # WHEN calling async_scan with various parameters
-    result = user_model.async_scan(
+    result = user_model.scan(
         limit=10,
         consistent_read=True,
         segment=1,
         total_segments=4,
     )
-
-    # THEN all parameters are stored
     assert result._limit == 10
     assert result._consistent_read is True
     assert result._segment == 1
     assert result._total_segments == 4
 
 
-def test_count_calls_client(user_model, mock_client):
-    """Model.count calls client.count with correct parameters."""
-    # GIVEN a mock client that returns a count
+def test_scan_with_filter_condition(user_model):
+    """Model.scan() accepts filter_condition."""
+    condition = user_model.age > 18
+    result = user_model.scan(filter_condition=condition)
+    assert result._filter_condition is condition
+
+
+def test_scan_with_pagination(user_model):
+    """Model.scan() accepts last_evaluated_key for pagination."""
+    last_key = {"pk": "USER#123", "sk": "ORDER#999"}
+    result = user_model.scan(last_evaluated_key=last_key)
+    assert result._start_key == last_key
+
+
+@pytest.mark.asyncio
+async def test_async_scan_first_returns_none_when_empty(user_model, mock_client):
+    """AsyncModelScanResult.first() returns None when no results."""
+    mock_client._client.scan_page.return_value = {
+        "items": [],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0),
+    }
+
+    result = user_model.scan()
+    first = await result.first()
+
+    assert first is None
+
+
+@pytest.mark.asyncio
+async def test_async_scan_to_list(user_model, mock_client):
+    """AsyncModelScanResult collects all results via async iteration."""
+    mock_client._client.scan_page.return_value = {
+        "items": [
+            {"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 25},
+            {"pk": "USER#2", "sk": "PROFILE", "name": "Bob", "age": 30},
+        ],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=2),
+    }
+
+    result = user_model.scan()
+    users = [user async for user in result]
+
+    assert len(users) == 2
+    assert users[0].name == "Alice"
+    assert users[1].name == "Bob"
+
+
+@pytest.mark.asyncio
+async def test_async_scan_iteration(user_model, mock_client):
+    """AsyncModelScanResult can be iterated with async for."""
+    mock_client._client.scan_page.return_value = {
+        "items": [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 25}],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    }
+
+    result = user_model.scan()
+    users = []
+    async for user in result:
+        users.append(user)
+
+    assert len(users) == 1
+    assert isinstance(users[0], user_model)
+
+
+def test_scan_last_evaluated_key_before_iteration(user_model):
+    """AsyncModelScanResult.last_evaluated_key is None before iteration."""
+    result = user_model.scan()
+    assert result.last_evaluated_key is None
+
+
+# ========== ASYNC count tests ==========
+
+
+@pytest.mark.asyncio
+async def test_count_calls_client(user_model, mock_client):
+    """Model.count() calls client.count (async)."""
     mock_metrics = MagicMock()
     mock_metrics.duration_ms = 10.0
     mock_metrics.consumed_rcu = 5.0
     mock_client.count.return_value = (42, mock_metrics)
 
-    # WHEN calling count on the model
-    count, _ = user_model.count()
+    count, _ = await user_model.count()
 
-    # THEN the client is called and count is returned
     assert count == 42
     mock_client.count.assert_called_once()
 
 
-def test_count_with_filter(user_model, mock_client):
-    """Model.count accepts filter_condition."""
-    # GIVEN a mock client and a filter condition
+@pytest.mark.asyncio
+async def test_count_with_filter(user_model, mock_client):
+    """Model.count() accepts filter_condition (async)."""
     mock_metrics = MagicMock()
-    mock_metrics.duration_ms = 10.0
-    mock_metrics.consumed_rcu = 5.0
     mock_client.count.return_value = (10, mock_metrics)
     condition = user_model.age >= 18
 
-    # WHEN calling count with the filter
-    count, _ = user_model.count(filter_condition=condition)
+    count, _ = await user_model.count(filter_condition=condition)
 
-    # THEN the filter is passed to the client
     assert count == 10
     call_kwargs = mock_client.count.call_args[1]
     assert call_kwargs["filter_expression"] is not None
 
 
-def test_count_with_consistent_read(user_model, mock_client):
-    """Model.count accepts consistent_read parameter."""
-    # GIVEN a mock client
+@pytest.mark.asyncio
+async def test_count_with_consistent_read(user_model, mock_client):
+    """Model.count() accepts consistent_read (async)."""
     mock_metrics = MagicMock()
     mock_client.count.return_value = (5, mock_metrics)
 
-    # WHEN calling count with consistent_read=True
-    user_model.count(consistent_read=True)
+    await user_model.count(consistent_read=True)
 
-    # THEN consistent_read is passed to the client
     call_kwargs = mock_client.count.call_args[1]
     assert call_kwargs["consistent_read"] is True
 
 
-# ========== as_dict tests ==========
+# ========== ASYNC as_dict tests ==========
 
 
 def test_scan_as_dict_default_is_false(user_model):
     """scan() defaults as_dict to False."""
-    # WHEN calling scan without as_dict parameter
     result = user_model.scan()
-
-    # THEN as_dict defaults to False
     assert result._as_dict is False
 
 
 def test_scan_as_dict_stores_parameter(user_model):
-    """ModelScanResult stores as_dict parameter."""
-    # WHEN calling scan with as_dict=True
-    result = user_model.scan(as_dict=True)
-
-    # THEN the parameter is stored
-    assert result._as_dict is True
-
-
-def test_scan_as_dict_true_returns_dicts(user_model):
-    """scan(as_dict=True) returns plain dicts."""
-    # GIVEN a scan that returns items
-    with patch.object(ModelScanResult, "_build_result") as mock_build:
-        mock_scan_result = MagicMock()
-        items = [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}]
-        mock_scan_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_scan_result
-
-        # WHEN calling scan with as_dict=True
-        result = user_model.scan(as_dict=True)
-        users = list(result)
-
-        # THEN items are returned as plain dicts
-        assert len(users) == 1
-        assert isinstance(users[0], dict)
-        assert users[0]["name"] == "Alice"
-
-
-def test_scan_as_dict_false_returns_model_instances(user_model):
-    """scan(as_dict=False) returns Model instances."""
-    # GIVEN a scan that returns items
-    with patch.object(ModelScanResult, "_build_result") as mock_build:
-        mock_scan_result = MagicMock()
-        items = [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}]
-        mock_scan_result.__iter__ = MagicMock(return_value=iter(items))
-        mock_build.return_value = mock_scan_result
-
-        # WHEN calling scan with as_dict=False
-        result = user_model.scan(as_dict=False)
-        users = list(result)
-
-        # THEN items are returned as model instances
-        assert len(users) == 1
-        assert isinstance(users[0], user_model)
-
-
-def test_async_scan_as_dict_stores_parameter(user_model):
     """AsyncModelScanResult stores as_dict parameter."""
-    # WHEN calling async_scan with as_dict=True
-    result = user_model.async_scan(as_dict=True)
-
-    # THEN the parameter is stored
+    result = user_model.scan(as_dict=True)
     assert result._as_dict is True
 
 
-def test_parallel_scan_as_dict_true_returns_dicts(user_model, mock_client):
-    """parallel_scan(as_dict=True) returns plain dicts."""
-    # GIVEN a mock client that returns items
+@pytest.mark.asyncio
+async def test_scan_as_dict_true_returns_dicts(user_model, mock_client):
+    """scan(as_dict=True) returns plain dicts."""
+    mock_client._client.scan_page.return_value = {
+        "items": [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    }
+
+    result = user_model.scan(as_dict=True)
+    users = [user async for user in result]
+
+    assert len(users) == 1
+    assert isinstance(users[0], dict)
+    assert users[0]["name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_scan_as_dict_false_returns_model_instances(user_model, mock_client):
+    """scan(as_dict=False) returns Model instances."""
+    mock_client._client.scan_page.return_value = {
+        "items": [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}],
+        "last_evaluated_key": None,
+        "metrics": MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    }
+
+    result = user_model.scan(as_dict=False)
+    users = [user async for user in result]
+
+    assert len(users) == 1
+    assert isinstance(users[0], user_model)
+
+
+# ========== ASYNC parallel_scan tests ==========
+
+
+@pytest.mark.asyncio
+async def test_parallel_scan_as_dict_true_returns_dicts(user_model, mock_client):
+    """parallel_scan(as_dict=True) returns plain dicts (async)."""
     mock_metrics = MagicMock()
     mock_client.parallel_scan.return_value = (
         [
@@ -316,29 +266,201 @@ def test_parallel_scan_as_dict_true_returns_dicts(user_model, mock_client):
         mock_metrics,
     )
 
-    # WHEN calling parallel_scan with as_dict=True
-    users, _ = user_model.parallel_scan(total_segments=2, as_dict=True)
+    users, _ = await user_model.parallel_scan(total_segments=2, as_dict=True)
 
-    # THEN items are returned as plain dicts
     assert len(users) == 2
     assert isinstance(users[0], dict)
     assert isinstance(users[1], dict)
 
 
-def test_parallel_scan_as_dict_false_returns_model_instances(user_model, mock_client):
-    """parallel_scan(as_dict=False) returns Model instances."""
-    # GIVEN a mock client that returns items
+@pytest.mark.asyncio
+async def test_parallel_scan_as_dict_false_returns_model_instances(user_model, mock_client):
+    """parallel_scan(as_dict=False) returns Model instances (async)."""
     mock_metrics = MagicMock()
     mock_client.parallel_scan.return_value = (
+        [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}],
+        mock_metrics,
+    )
+
+    users, _ = await user_model.parallel_scan(total_segments=2, as_dict=False)
+
+    assert len(users) == 1
+    assert isinstance(users[0], user_model)
+
+
+# ========== SYNC TESTS (sync_scan) ==========
+
+
+def test_sync_scan_returns_model_scan_result(user_model):
+    """Model.sync_scan() returns a ModelScanResult (sync)."""
+    result = user_model.sync_scan()
+    assert isinstance(result, ModelScanResult)
+
+
+def test_sync_scan_stores_parameters(user_model):
+    """ModelScanResult stores all scan parameters."""
+    result = user_model.sync_scan(
+        limit=10,
+        consistent_read=True,
+        segment=1,
+        total_segments=4,
+    )
+    assert result._limit == 10
+    assert result._consistent_read is True
+    assert result._segment == 1
+    assert result._total_segments == 4
+
+
+def test_sync_scan_first_returns_none_when_empty(user_model, mock_client):
+    """ModelScanResult.first() returns None when no results."""
+    mock_client._client.sync_scan_page.return_value = (
+        [],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=0),
+    )
+
+    result = user_model.sync_scan()
+    first = result.first()
+
+    assert first is None
+
+
+def test_sync_scan_list(user_model, mock_client):
+    """list(ModelScanResult) collects all results."""
+    mock_client._client.sync_scan_page.return_value = (
+        [
+            {"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 25},
+            {"pk": "USER#2", "sk": "PROFILE", "name": "Bob", "age": 30},
+        ],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=2),
+    )
+
+    result = user_model.sync_scan()
+    users = list(result)
+
+    assert len(users) == 2
+    assert users[0].name == "Alice"
+    assert users[1].name == "Bob"
+
+
+def test_sync_scan_iteration(user_model, mock_client):
+    """ModelScanResult can be iterated."""
+    mock_client._client.sync_scan_page.return_value = (
+        [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 25}],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    )
+
+    result = user_model.sync_scan()
+    users = list(result)
+
+    assert len(users) == 1
+    assert isinstance(users[0], user_model)
+
+
+# ========== SYNC count tests ==========
+
+
+def test_sync_count_calls_client(user_model, mock_client):
+    """Model.sync_count() calls client.sync_count (sync)."""
+    mock_metrics = MagicMock()
+    mock_client.sync_count.return_value = (42, mock_metrics)
+
+    count, _ = user_model.sync_count()
+
+    assert count == 42
+    mock_client.sync_count.assert_called_once()
+
+
+def test_sync_count_with_filter(user_model, mock_client):
+    """Model.sync_count() accepts filter_condition (sync)."""
+    mock_metrics = MagicMock()
+    mock_client.sync_count.return_value = (10, mock_metrics)
+    condition = user_model.age >= 18
+
+    count, _ = user_model.sync_count(filter_condition=condition)
+
+    assert count == 10
+    call_kwargs = mock_client.sync_count.call_args[1]
+    assert call_kwargs["filter_expression"] is not None
+
+
+def test_sync_count_with_consistent_read(user_model, mock_client):
+    """Model.sync_count() accepts consistent_read (sync)."""
+    mock_metrics = MagicMock()
+    mock_client.sync_count.return_value = (5, mock_metrics)
+
+    user_model.sync_count(consistent_read=True)
+
+    call_kwargs = mock_client.sync_count.call_args[1]
+    assert call_kwargs["consistent_read"] is True
+
+
+# ========== SYNC as_dict tests ==========
+
+
+def test_sync_scan_as_dict_true_returns_dicts(user_model, mock_client):
+    """sync_scan(as_dict=True) returns plain dicts."""
+    mock_client._client.sync_scan_page.return_value = (
+        [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    )
+
+    result = user_model.sync_scan(as_dict=True)
+    users = list(result)
+
+    assert len(users) == 1
+    assert isinstance(users[0], dict)
+    assert users[0]["name"] == "Alice"
+
+
+def test_sync_scan_as_dict_false_returns_model_instances(user_model, mock_client):
+    """sync_scan(as_dict=False) returns Model instances."""
+    mock_client._client.sync_scan_page.return_value = (
+        [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}],
+        None,
+        MagicMock(duration_ms=1.0, consumed_rcu=1.0, items_count=1),
+    )
+
+    result = user_model.sync_scan(as_dict=False)
+    users = list(result)
+
+    assert len(users) == 1
+    assert isinstance(users[0], user_model)
+
+
+# ========== SYNC parallel_scan tests ==========
+
+
+def test_sync_parallel_scan_as_dict_true_returns_dicts(user_model, mock_client):
+    """sync_parallel_scan(as_dict=True) returns plain dicts."""
+    mock_metrics = MagicMock()
+    mock_client.sync_parallel_scan.return_value = (
         [
             {"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30},
+            {"pk": "USER#2", "sk": "PROFILE", "name": "Bob", "age": 25},
         ],
         mock_metrics,
     )
 
-    # WHEN calling parallel_scan with as_dict=False
-    users, _ = user_model.parallel_scan(total_segments=2, as_dict=False)
+    users, _ = user_model.sync_parallel_scan(total_segments=2, as_dict=True)
 
-    # THEN items are returned as model instances
+    assert len(users) == 2
+    assert isinstance(users[0], dict)
+    assert isinstance(users[1], dict)
+
+
+def test_sync_parallel_scan_as_dict_false_returns_model_instances(user_model, mock_client):
+    """sync_parallel_scan(as_dict=False) returns Model instances."""
+    mock_metrics = MagicMock()
+    mock_client.sync_parallel_scan.return_value = (
+        [{"pk": "USER#1", "sk": "PROFILE", "name": "Alice", "age": 30}],
+        mock_metrics,
+    )
+
+    users, _ = user_model.sync_parallel_scan(total_segments=2, as_dict=False)
+
     assert len(users) == 1
     assert isinstance(users[0], user_model)

--- a/tests/unit/test_size.py
+++ b/tests/unit/test_size.py
@@ -168,7 +168,7 @@ def test_calculate_item_size_nested():
 
 
 def test_item_too_large_error_on_save(monkeypatch):
-    """Model.save() raises ItemTooLargeException when item exceeds max_size."""
+    """Model.sync_save() raises ItemTooLargeException when item exceeds max_size."""
     from unittest.mock import MagicMock
 
     from pydynox import Model, ModelConfig
@@ -186,10 +186,10 @@ def test_item_too_large_error_on_save(monkeypatch):
     User._client_instance = None
     user = User(pk="USER#123", bio="x" * 200)
 
-    # WHEN saving the item
+    # WHEN saving the item (sync)
     # THEN ItemTooLargeException is raised with size details
     with pytest.raises(ItemTooLargeException) as exc_info:
-        user.save()
+        user.sync_save()
 
     assert exc_info.value.size > 100
     assert exc_info.value.max_size == 100


### PR DESCRIPTION
Closes #214 

Breaking change: model/client operations now follow async-first naming.