### PR TITLE
feat(config): rename ModelConfig to DynamoConfig with back-compat alias

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -13,7 +13,7 @@ Welcome! This folder has everything you need to contribute to pydynox.
 | File | What it covers |
 |------|----------------|
 | `project-context.md` | What is pydynox, tech stack, goals |
-| `coding-guidelines.md` | Python vs Rust decisions, code style |
+| `coding-guidelines.md` | Python vs Rust decisions, code style, DRY / avoiding duplication |
 | `testing-guidelines.md` | How to write and run tests |
 | `dependencies.md` | When to add dependencies |
 | `common-mistakes.md` | Things that break the build |

--- a/.ai/coding-guidelines.md
+++ b/.ai/coding-guidelines.md
@@ -314,6 +314,17 @@ pydynox/python/pydynox/
 └── integrations/        # Pydantic, etc.
 ```
 
+### Duplication (DRY) and code quality
+
+Duplicated code is **harder to keep correct** (fixes must be applied everywhere) and **noisier in review**. Automated checks and team standards often treat high duplication in new changes as a problem—plan for that up front when you add or change Python:
+
+1. **Do not copy-paste** the same control flow, conditionals, or config lookups in multiple modules. If you are about to paste a second time, **extract a helper** (module-level function, or a small method on the relevant base class like `ModelBase`).
+2. **Reuse existing hooks** where they exist — for example config resolution and hook behavior should go through the established paths (`_get_config()`, `_get_consistent_read`, `_run_after_load_hook`, etc.) instead of inlining new variants.
+3. **Similar tests** in one file: prefer **`@pytest.mark.parametrize`** or shared fixtures over many nearly identical test functions.
+4. If a change *must* look similar in two places (e.g. sync vs async), keep the **shared logic in one function** and keep the call sites as thin as possible.
+
+Refactor early when the same block appears more than once; do not wait for a failing check or a large follow-up PR.
+
 ### Type Hints
 
 Always use type hints. mypy MUST pass with zero errors.

--- a/python/pydynox/__init__.py
+++ b/python/pydynox/__init__.py
@@ -1,13 +1,16 @@
 """pydynox - A fast DynamoDB client for Python with a Rust core.
 
 Example:
-    >>> from pydynox import DynamoDBClient, Model, ModelConfig
+    >>> from typing import ClassVar
+    >>> from pydynox import DynamoDBClient, Model, DynamoConfig
     >>> from pydynox.attributes import StringAttribute
     >>>
     >>> client = DynamoDBClient(region="us-east-1")
     >>>
     >>> class User(Model):
-    ...     model_config = ModelConfig(table="users", client=client)
+    ...     dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(
+    ...         table="users", client=client
+    ...     )
     ...     pk = StringAttribute(partition_key=True)
     ...     name = StringAttribute()
     >>>
@@ -25,6 +28,7 @@ from pydynox.client import DynamoDBClient
 from pydynox.collection import Collection, CollectionResult
 from pydynox.conditions import Condition
 from pydynox.config import (
+    DynamoConfig,
     ModelConfig,
     clear_default_client,
     get_default_client,
@@ -43,6 +47,8 @@ __all__ = [
     # Core
     "DynamoDBClient",
     "Model",
+    "DynamoConfig",
+    # Back-compat alias for DynamoConfig
     "ModelConfig",
     # Operations
     "BatchWriter",

--- a/python/pydynox/_internal/_async_utils.py
+++ b/python/pydynox/_internal/_async_utils.py
@@ -1,0 +1,18 @@
+"""Small awaitable helpers (e.g. async context manager entry with no I/O)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def aidentity(value: T) -> T:
+    """Return *value* as a coroutine (for :meth:`__aenter__` with no I/O).
+
+    Uses a zero-length sleep so the coroutine is a no-op I/O-wise but still
+    suspends, satisfying static rules that require a real *await* in *async* bodies.
+    """
+    await asyncio.sleep(0)
+    return value

--- a/python/pydynox/_internal/_indexes.py
+++ b/python/pydynox/_internal/_indexes.py
@@ -45,7 +45,7 @@ class GlobalSecondaryIndex(Generic[M]):
 
     Example:
         >>> class User(Model):
-        ...     model_config = ModelConfig(table="users")
+        ...     dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(table="users")
         ...     pk = StringAttribute(partition_key=True)
         ...     email = StringAttribute()
         ...
@@ -465,11 +465,8 @@ class GSIQueryResult(Generic[M]):
         item = next(self._items_iter)
         instance = self._model_class.from_dict(item)
 
-        skip = (
-            self._model_class.model_config.skip_hooks
-            if hasattr(self._model_class, "model_config")
-            else False
-        )
+        _cfg = self._model_class._get_config()
+        skip = _cfg.skip_hooks if _cfg is not None else False
         if not skip:
             from pydynox.hooks import HookType
 
@@ -575,11 +572,8 @@ class AsyncGSIQueryResult(Generic[M]):
         item = await self._query_result.__anext__()
         instance = self._model_class.from_dict(item)
 
-        skip = (
-            self._model_class.model_config.skip_hooks
-            if hasattr(self._model_class, "model_config")
-            else False
-        )
+        _cfg = self._model_class._get_config()
+        skip = _cfg.skip_hooks if _cfg is not None else False
         if not skip:
             from pydynox.hooks import HookType
 
@@ -617,7 +611,7 @@ class LocalSecondaryIndex(Generic[M]):
 
     Example:
         >>> class User(Model):
-        ...     model_config = ModelConfig(table="users")
+        ...     dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(table="users")
         ...     pk = StringAttribute(partition_key=True)
         ...     sk = StringAttribute(sort_key=True)
         ...     status = StringAttribute()
@@ -906,11 +900,8 @@ class LSIQueryResult(Generic[M]):
         item = next(self._items_iter)
         instance = self._model_class.from_dict(item)
 
-        skip = (
-            self._model_class.model_config.skip_hooks
-            if hasattr(self._model_class, "model_config")
-            else False
-        )
+        _cfg = self._model_class._get_config()
+        skip = _cfg.skip_hooks if _cfg is not None else False
         if not skip:
             from pydynox.hooks import HookType
 
@@ -1017,11 +1008,8 @@ class AsyncLSIQueryResult(Generic[M]):
         item = await self._query_result.__anext__()
         instance = self._model_class.from_dict(item)
 
-        skip = (
-            self._model_class.model_config.skip_hooks
-            if hasattr(self._model_class, "model_config")
-            else False
-        )
+        _cfg = self._model_class._get_config()
+        skip = _cfg.skip_hooks if _cfg is not None else False
         if not skip:
             from pydynox.hooks import HookType
 

--- a/python/pydynox/_internal/_indexes.py
+++ b/python/pydynox/_internal/_indexes.py
@@ -465,12 +465,7 @@ class GSIQueryResult(Generic[M]):
         item = next(self._items_iter)
         instance = self._model_class.from_dict(item)
 
-        _cfg = self._model_class._get_config()
-        skip = _cfg.skip_hooks if _cfg is not None else False
-        if not skip:
-            from pydynox.hooks import HookType
-
-            instance._run_hooks(HookType.AFTER_LOAD)
+        self._model_class._run_after_load_hook(instance)
 
         return instance
 
@@ -572,12 +567,7 @@ class AsyncGSIQueryResult(Generic[M]):
         item = await self._query_result.__anext__()
         instance = self._model_class.from_dict(item)
 
-        _cfg = self._model_class._get_config()
-        skip = _cfg.skip_hooks if _cfg is not None else False
-        if not skip:
-            from pydynox.hooks import HookType
-
-            instance._run_hooks(HookType.AFTER_LOAD)
+        self._model_class._run_after_load_hook(instance)
 
         return instance
 
@@ -900,12 +890,7 @@ class LSIQueryResult(Generic[M]):
         item = next(self._items_iter)
         instance = self._model_class.from_dict(item)
 
-        _cfg = self._model_class._get_config()
-        skip = _cfg.skip_hooks if _cfg is not None else False
-        if not skip:
-            from pydynox.hooks import HookType
-
-            instance._run_hooks(HookType.AFTER_LOAD)
+        self._model_class._run_after_load_hook(instance)
 
         return instance
 
@@ -1008,12 +993,7 @@ class AsyncLSIQueryResult(Generic[M]):
         item = await self._query_result.__anext__()
         instance = self._model_class.from_dict(item)
 
-        _cfg = self._model_class._get_config()
-        skip = _cfg.skip_hooks if _cfg is not None else False
-        if not skip:
-            from pydynox.hooks import HookType
-
-            instance._run_hooks(HookType.AFTER_LOAD)
+        self._model_class._run_after_load_hook(instance)
 
         return instance
 

--- a/python/pydynox/_internal/_model/_base.py
+++ b/python/pydynox/_internal/_model/_base.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar, cast
 
 from pydynox._internal._indexes import GlobalSecondaryIndex, LocalSecondaryIndex
 from pydynox.attributes import Attribute
 from pydynox.attributes.special import JSONAttribute
-from pydynox.config import ModelConfig, get_default_client
+from pydynox.config import DynamoConfig, get_default_client
 from pydynox.generators import generate_value, is_auto_generate
 from pydynox.hooks import HookType
 from pydynox.size import ItemSize, calculate_item_size
@@ -17,6 +18,27 @@ if TYPE_CHECKING:
     from pydynox.client import DynamoDBClient
 
 M = TypeVar("M", bound="ModelBase")
+
+
+_LEGACY_CONFIG_WARNED: set[int] = set()
+
+
+def _warn_legacy_model_config(cls: type) -> None:
+    """Emit a DeprecationWarning for a class that uses the legacy
+    ``model_config`` attribute. Fires at most once per class to keep
+    logs quiet on hot paths.
+    """
+    key = id(cls)
+    if key in _LEGACY_CONFIG_WARNED:
+        return
+    _LEGACY_CONFIG_WARNED.add(key)
+    warnings.warn(
+        f"{cls.__name__}: `model_config = ModelConfig(...)` is deprecated; "
+        "rename to `dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(...)`. "
+        "See docs/refactor/pydantic-model/01-dynamoconfig-rename.md.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
 
 
 class _TemplateAttr(Protocol):
@@ -189,7 +211,10 @@ class ModelBase(metaclass=ModelMeta):
     _py_to_dynamo: ClassVar[dict[str, str]]
     _dynamo_to_py: ClassVar[dict[str, str]]
 
-    model_config: ClassVar[ModelConfig]
+    # New canonical name. Subclasses should set this instead of
+    # ``model_config``. The legacy name keeps working (see
+    # :meth:`_get_config`) with a one-time DeprecationWarning per class.
+    dynamodb_config: ClassVar[DynamoConfig]
 
     # Change tracking
     _original: dict[str, Any] | None
@@ -356,13 +381,42 @@ class ModelBase(metaclass=ModelMeta):
             setattr(self, attr_name, tattr.build_key(values))
 
     @classmethod
+    def _get_config(cls) -> DynamoConfig | None:
+        """Return the resolved DynamoDB config for this model, if any.
+
+        Resolution order:
+
+        1. ``cls.dynamodb_config`` — the canonical attribute.
+        2. ``cls.model_config`` — legacy name, kept for back-compat.
+           Emits a one-time :class:`DeprecationWarning` per class pointing
+           users at ``dynamodb_config``.
+        3. ``None`` — caller is responsible for raising or falling back.
+
+        The legacy branch requires the value to be a :class:`DynamoConfig`
+        instance so that a pydantic ``ConfigDict`` on a subclass cannot be
+        mistaken for pydynox configuration (relevant once
+        ``PydanticModel`` lands in PR 4).
+        """
+        new = getattr(cls, "dynamodb_config", None)
+        if isinstance(new, DynamoConfig):
+            return new
+
+        legacy = getattr(cls, "model_config", None)
+        if isinstance(legacy, DynamoConfig):
+            _warn_legacy_model_config(cls)
+            return legacy
+
+        return None
+
+    @classmethod
     def _get_client(cls) -> DynamoDBClient:
         """Get the DynamoDB client for this model."""
         if cls._client_instance is not None:
             return cls._client_instance
 
-        if hasattr(cls, "model_config") and cls.model_config.client is not None:
-            cls._client_instance = cls.model_config.client
+        config = cls._get_config()
+        if config is not None and config.client is not None:
+            cls._client_instance = config.client
             cls._apply_hot_partition_overrides()
             return cls._client_instance
 
@@ -374,12 +428,12 @@ class ModelBase(metaclass=ModelMeta):
 
         raise ValueError(
             f"No client configured for {cls.__name__}. "
-            "Either pass client to ModelConfig or call pydynox.set_default_client()"
+            "Either pass client to DynamoConfig or call pydynox.set_default_client()"
         )
 
     @classmethod
     def _apply_hot_partition_overrides(cls) -> None:
-        """Apply hot partition threshold overrides from ModelConfig."""
+        """Apply hot partition threshold overrides from the model config."""
         if cls._client_instance is None:
             return
 
@@ -387,28 +441,32 @@ class ModelBase(metaclass=ModelMeta):
         if diagnostics is None:
             return
 
-        if not hasattr(cls, "model_config"):
+        config = cls._get_config()
+        if config is None:
             return
 
-        writes = getattr(cls.model_config, "hot_partition_writes", None)
-        reads = getattr(cls.model_config, "hot_partition_reads", None)
+        writes = config.hot_partition_writes
+        reads = config.hot_partition_reads
 
         if writes is not None or reads is not None:
-            table = cls.model_config.table
-            diagnostics.set_table_thresholds(table, writes_threshold=writes, reads_threshold=reads)
+            diagnostics.set_table_thresholds(
+                config.table, writes_threshold=writes, reads_threshold=reads
+            )
 
     @classmethod
     def _get_table(cls) -> str:
-        """Get the table name from model_config."""
-        if not hasattr(cls, "model_config"):
-            raise ValueError(f"Model {cls.__name__} must define model_config")
-        return cls.model_config.table
+        """Get the table name from the model config."""
+        config = cls._get_config()
+        if config is None:
+            raise ValueError(f"Model {cls.__name__} must define dynamodb_config")
+        return config.table
 
     def _should_skip_hooks(self, skip_hooks: bool | None) -> bool:
         if skip_hooks is not None:
             return skip_hooks
-        if hasattr(self, "model_config"):
-            return self.model_config.skip_hooks
+        config = type(self)._get_config()
+        if config is not None:
+            return config.skip_hooks
         return False
 
     def _run_hooks(self, hook_type: HookType) -> None:

--- a/python/pydynox/_internal/_model/_base.py
+++ b/python/pydynox/_internal/_model/_base.py
@@ -461,13 +461,32 @@ class ModelBase(metaclass=ModelMeta):
             raise ValueError(f"Model {cls.__name__} must define dynamodb_config")
         return config.table
 
-    def _should_skip_hooks(self, skip_hooks: bool | None) -> bool:
-        if skip_hooks is not None:
-            return skip_hooks
-        config = type(self)._get_config()
+    @classmethod
+    def _config_skip_hooks(cls) -> bool:
+        """Return ``skip_hooks`` from DynamoConfig, or False when unconfigured."""
+        config = cls._get_config()
         if config is not None:
             return config.skip_hooks
         return False
+
+    def _should_skip_hooks(self, skip_hooks: bool | None) -> bool:
+        if skip_hooks is not None:
+            return skip_hooks
+        return type(self)._config_skip_hooks()
+
+    @classmethod
+    def _run_after_load_hook(cls, instance: M) -> None:
+        """Run AFTER_LOAD unless DynamoConfig has ``skip_hooks`` set."""
+        if not cls._config_skip_hooks():
+            instance._run_hooks(HookType.AFTER_LOAD)
+
+    @classmethod
+    def _run_after_load_hooks_batch(cls, instances: list[M]) -> None:
+        """Run AFTER_LOAD on instances unless the model config suppresses hooks."""
+        if cls._config_skip_hooks():
+            return
+        for instance in instances:
+            instance._run_hooks(HookType.AFTER_LOAD)
 
     def _run_hooks(self, hook_type: HookType) -> None:
         for hook in self._hooks.get(hook_type, []):

--- a/python/pydynox/_internal/_model/_batch.py
+++ b/python/pydynox/_internal/_model/_batch.py
@@ -45,7 +45,8 @@ async def batch_get(
     # Convert to model instances
     instances = [cls.from_dict(item) for item in items]
 
-    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
+    config = cls._get_config()
+    skip = config.skip_hooks if config is not None else False
     if not skip:
         for instance in instances:
             instance._run_hooks(HookType.AFTER_LOAD)
@@ -86,7 +87,8 @@ def sync_batch_get(
     # Convert to model instances
     instances = [cls.from_dict(item) for item in items]
 
-    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
+    config = cls._get_config()
+    skip = config.skip_hooks if config is not None else False
     if not skip:
         for instance in instances:
             instance._run_hooks(HookType.AFTER_LOAD)

--- a/python/pydynox/_internal/_model/_helpers.py
+++ b/python/pydynox/_internal/_model/_helpers.py
@@ -77,7 +77,8 @@ def prepare_get(
 
     use_consistent = consistent_read
     if use_consistent is None:
-        use_consistent = getattr(cls.model_config, "consistent_read", False)
+        config = cls._get_config()
+        use_consistent = config.consistent_read if config is not None else False
 
     return client, table, aliased_keys, use_consistent
 
@@ -88,7 +89,8 @@ def finalize_get(cls: type[M], item: dict[str, Any] | None) -> M | None:
         return None
 
     instance = cls.from_dict(item)
-    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
+    config = cls._get_config()
+    skip = config.skip_hooks if config is not None else False
     if not skip:
         instance._run_hooks(HookType.AFTER_LOAD)
     return instance
@@ -118,9 +120,8 @@ def prepare_save(self: Model, condition: Condition | None, skip_hooks: bool | No
     if version_attr is not None:
         setattr(self, version_attr, new_version)
 
-    max_size = (
-        getattr(self.model_config, "max_size", None) if hasattr(self, "model_config") else None
-    )
+    config = type(self)._get_config()
+    max_size = config.max_size if config is not None else None
     if max_size is not None:
         size = self.calculate_size()
         if size.bytes > max_size:
@@ -178,9 +179,8 @@ def prepare_smart_save(
     if version_attr is not None:
         setattr(self, version_attr, new_version)
 
-    max_size = (
-        getattr(self.model_config, "max_size", None) if hasattr(self, "model_config") else None
-    )
+    config = type(self)._get_config()
+    max_size = config.max_size if config is not None else None
     if max_size is not None:
         size = self.calculate_size()
         if size.bytes > max_size:

--- a/python/pydynox/_internal/_model/_query.py
+++ b/python/pydynox/_internal/_model/_query.py
@@ -9,8 +9,8 @@ from pydynox._internal._results import (
     AsyncModelScanResult,
     ModelQueryResult,
     ModelScanResult,
+    _get_consistent_read,
 )
-from pydynox.hooks import HookType
 
 if TYPE_CHECKING:
     from pydynox._internal._metrics import OperationMetrics
@@ -154,10 +154,7 @@ def sync_count(
 
     attr_names = {v: k for k, v in names.items()}
 
-    use_consistent = consistent_read
-    if use_consistent is None:
-        _cfg = cls._get_config()
-        use_consistent = _cfg.consistent_read if _cfg is not None else False
+    use_consistent = _get_consistent_read(cls, consistent_read)
 
     return client.sync_count(
         table,
@@ -204,10 +201,7 @@ def sync_parallel_scan(
 
     attr_names = {v: k for k, v in names.items()}
 
-    use_consistent = consistent_read
-    if use_consistent is None:
-        _cfg = cls._get_config()
-        use_consistent = _cfg.consistent_read if _cfg is not None else False
+    use_consistent = _get_consistent_read(cls, consistent_read)
 
     items, metrics = client.sync_parallel_scan(
         table,
@@ -223,11 +217,7 @@ def sync_parallel_scan(
 
     instances = [cls.from_dict(item) for item in items]
 
-    _cfg = cls._get_config()
-    skip = _cfg.skip_hooks if _cfg is not None else False
-    if not skip:
-        for instance in instances:
-            instance._run_hooks(HookType.AFTER_LOAD)
+    cls._run_after_load_hooks_batch(instances)
 
     return instances, metrics
 
@@ -324,10 +314,7 @@ async def count(
 
     attr_names = {v: k for k, v in names.items()}
 
-    use_consistent = consistent_read
-    if use_consistent is None:
-        _cfg = cls._get_config()
-        use_consistent = _cfg.consistent_read if _cfg is not None else False
+    use_consistent = _get_consistent_read(cls, consistent_read)
 
     return await client.count(
         table,
@@ -374,10 +361,7 @@ async def parallel_scan(
 
     attr_names = {v: k for k, v in names.items()}
 
-    use_consistent = consistent_read
-    if use_consistent is None:
-        _cfg = cls._get_config()
-        use_consistent = _cfg.consistent_read if _cfg is not None else False
+    use_consistent = _get_consistent_read(cls, consistent_read)
 
     items, metrics = await client.parallel_scan(
         table,
@@ -393,10 +377,6 @@ async def parallel_scan(
 
     instances = [cls.from_dict(item) for item in items]
 
-    _cfg = cls._get_config()
-    skip = _cfg.skip_hooks if _cfg is not None else False
-    if not skip:
-        for instance in instances:
-            instance._run_hooks(HookType.AFTER_LOAD)
+    cls._run_after_load_hooks_batch(instances)
 
     return instances, metrics

--- a/python/pydynox/_internal/_model/_query.py
+++ b/python/pydynox/_internal/_model/_query.py
@@ -156,7 +156,8 @@ def sync_count(
 
     use_consistent = consistent_read
     if use_consistent is None:
-        use_consistent = getattr(cls.model_config, "consistent_read", False)
+        _cfg = cls._get_config()
+        use_consistent = _cfg.consistent_read if _cfg is not None else False
 
     return client.sync_count(
         table,
@@ -205,7 +206,8 @@ def sync_parallel_scan(
 
     use_consistent = consistent_read
     if use_consistent is None:
-        use_consistent = getattr(cls.model_config, "consistent_read", False)
+        _cfg = cls._get_config()
+        use_consistent = _cfg.consistent_read if _cfg is not None else False
 
     items, metrics = client.sync_parallel_scan(
         table,
@@ -221,7 +223,8 @@ def sync_parallel_scan(
 
     instances = [cls.from_dict(item) for item in items]
 
-    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
+    _cfg = cls._get_config()
+    skip = _cfg.skip_hooks if _cfg is not None else False
     if not skip:
         for instance in instances:
             instance._run_hooks(HookType.AFTER_LOAD)
@@ -323,7 +326,8 @@ async def count(
 
     use_consistent = consistent_read
     if use_consistent is None:
-        use_consistent = getattr(cls.model_config, "consistent_read", False)
+        _cfg = cls._get_config()
+        use_consistent = _cfg.consistent_read if _cfg is not None else False
 
     return await client.count(
         table,
@@ -372,7 +376,8 @@ async def parallel_scan(
 
     use_consistent = consistent_read
     if use_consistent is None:
-        use_consistent = getattr(cls.model_config, "consistent_read", False)
+        _cfg = cls._get_config()
+        use_consistent = _cfg.consistent_read if _cfg is not None else False
 
     items, metrics = await client.parallel_scan(
         table,
@@ -388,7 +393,8 @@ async def parallel_scan(
 
     instances = [cls.from_dict(item) for item in items]
 
-    skip = cls.model_config.skip_hooks if hasattr(cls, "model_config") else False
+    _cfg = cls._get_config()
+    skip = _cfg.skip_hooks if _cfg is not None else False
     if not skip:
         for instance in instances:
             instance._run_hooks(HookType.AFTER_LOAD)

--- a/python/pydynox/_internal/_results.py
+++ b/python/pydynox/_internal/_results.py
@@ -29,7 +29,8 @@ def _get_consistent_read(model_class: type[M], explicit: bool | None) -> bool:
     """Get consistent_read value, falling back to model config."""
     if explicit is not None:
         return explicit
-    return getattr(model_class.model_config, "consistent_read", False)
+    config = model_class._get_config()
+    return config.consistent_read if config is not None else False
 
 
 def _build_query_params(
@@ -167,7 +168,8 @@ class BaseModelResult(ABC, Generic[T]):
     def _to_instance(self, item: dict[str, Any]) -> Any:
         """Convert dict to model instance and run hooks."""
         instance = self._model_class.from_dict(item)
-        skip = getattr(self._model_class.model_config, "skip_hooks", False)
+        config = self._model_class._get_config()
+        skip = config.skip_hooks if config is not None else False
         if not skip:
             instance._run_hooks(HookType.AFTER_LOAD)
         return instance

--- a/python/pydynox/_internal/_results.py
+++ b/python/pydynox/_internal/_results.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
-from pydynox.hooks import HookType
 from pydynox.query import AsyncQueryResult, AsyncScanResult, QueryResult, ScanResult
 
 if TYPE_CHECKING:
@@ -168,10 +167,7 @@ class BaseModelResult(ABC, Generic[T]):
     def _to_instance(self, item: dict[str, Any]) -> Any:
         """Convert dict to model instance and run hooks."""
         instance = self._model_class.from_dict(item)
-        config = self._model_class._get_config()
-        skip = config.skip_hooks if config is not None else False
-        if not skip:
-            instance._run_hooks(HookType.AFTER_LOAD)
+        self._model_class._run_after_load_hook(instance)
         return instance
 
     def _to_result(self, item: dict[str, Any]) -> T:

--- a/python/pydynox/batch_operations.py
+++ b/python/pydynox/batch_operations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from pydynox._internal._async_utils import aidentity
+
 if TYPE_CHECKING:
     from pydynox.client import DynamoDBClient
 
@@ -36,7 +38,7 @@ class BatchWriter:
 
     async def __aenter__(self) -> BatchWriter:
         """Enter the async context manager."""
-        return self
+        return await aidentity(self)
 
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: Any

--- a/python/pydynox/collection.py
+++ b/python/pydynox/collection.py
@@ -39,7 +39,8 @@ class CollectionResult:
                 disc_attr = model_cls._discriminator_attr
                 if disc_attr and item.get(disc_attr) == model_name:
                     instance = model_cls.from_dict(item)
-                    skip = getattr(model_cls.model_config, "skip_hooks", False)
+                    config = model_cls._get_config()
+                    skip = config.skip_hooks if config is not None else False
                     if not skip:
                         instance._run_hooks(HookType.AFTER_LOAD)
                     self._items_by_type[model_name].append(instance)
@@ -115,9 +116,10 @@ class Collection:
         tables = set()
         for model in self._models:
             # Check table
-            if not hasattr(model, "model_config"):
-                raise ValueError(f"Model {model.__name__} has no model_config")
-            tables.add(model.model_config.table)
+            config = model._get_config()
+            if config is None:
+                raise ValueError(f"Model {model.__name__} has no dynamodb_config")
+            tables.add(config.table)
 
             # Check discriminator
             if not model._discriminator_attr:
@@ -151,7 +153,7 @@ class Collection:
 
     def _get_table(self) -> str:
         """Get the shared table name."""
-        return self._models[0].model_config.table
+        return self._models[0]._get_table()
 
     def _get_client(self) -> Any:
         """Get the DynamoDB client from the first model."""

--- a/python/pydynox/config.py
+++ b/python/pydynox/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 if TYPE_CHECKING:
     from pydynox.client import DynamoDBClient
@@ -56,10 +56,13 @@ def clear_default_client() -> None:
 
 
 @dataclass
-class ModelConfig:
-    """Type-safe model configuration.
+class DynamoConfig:
+    """Type-safe model configuration for DynamoDB behavior.
 
-    Use this instead of class Meta for better IDE support and type checking.
+    Assigned to the ``dynamodb_config`` class attribute on a
+    :class:`pydynox.Model` subclass. The legacy name ``model_config`` still
+    works for back-compat but emits a :class:`DeprecationWarning` the first
+    time pydynox reads it.
 
     Args:
         table: DynamoDB table name (required).
@@ -74,13 +77,14 @@ class ModelConfig:
             If set, overrides the client's detector threshold for this model.
 
     Example:
-        >>> from pydynox import DynamoDBClient, Model, ModelConfig
+        >>> from typing import ClassVar
+        >>> from pydynox import DynamoDBClient, Model, DynamoConfig
         >>> from pydynox.attributes import StringAttribute
         >>>
         >>> client = DynamoDBClient(region="us-east-1")
         >>>
         >>> class User(Model):
-        ...     model_config = ModelConfig(
+        ...     dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(
         ...         table="users",
         ...         client=client,
         ...     )
@@ -89,7 +93,7 @@ class ModelConfig:
         >>>
         >>> # Model with higher hot partition thresholds (high traffic expected)
         >>> class Event(Model):
-        ...     model_config = ModelConfig(
+        ...     dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(
         ...         table="events",
         ...         hot_partition_writes=2000,
         ...         hot_partition_reads=5000,
@@ -104,3 +108,12 @@ class ModelConfig:
     consistent_read: bool = field(default=False)
     hot_partition_writes: int | None = field(default=None)
     hot_partition_reads: int | None = field(default=None)
+
+
+# Back-compat alias. ``ModelConfig`` used to be the canonical name; it now
+# resolves to :class:`DynamoConfig` so existing imports and isinstance
+# checks keep working. The name itself is not deprecated at the class
+# level because dropping the import would break every current user.
+# The deprecation only fires when a Model subclass sets the legacy
+# ``model_config`` class attribute instead of the new ``dynamodb_config``.
+ModelConfig: TypeAlias = DynamoConfig

--- a/python/pydynox/model.py
+++ b/python/pydynox/model.py
@@ -108,11 +108,12 @@ class Model(ModelBase, metaclass=ModelMeta):
     """Base class for DynamoDB models with ORM-style CRUD.
 
     Example:
-        >>> from pydynox import Model, ModelConfig
+        >>> from typing import ClassVar
+        >>> from pydynox import Model, DynamoConfig
         >>> from pydynox.attributes import StringAttribute
         >>>
         >>> class User(Model):
-        ...     model_config = ModelConfig(table="users")
+        ...     dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(table="users")
         ...     pk = StringAttribute(partition_key=True)
         ...     sk = StringAttribute(sort_key=True)
         ...     name = StringAttribute()

--- a/python/pydynox/transaction.py
+++ b/python/pydynox/transaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from pydynox._internal._async_utils import aidentity
 from pydynox._internal._logging import _log_debug
 
 if TYPE_CHECKING:
@@ -52,7 +53,7 @@ class Transaction:
 
     async def __aenter__(self) -> Transaction:
         """Enter the async context manager."""
-        return self
+        return await aidentity(self)
 
     async def __aexit__(
         self,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,9 +1,12 @@
-"""Tests for ModelConfig and default client."""
+"""Tests for DynamoConfig / ModelConfig and default client."""
 
+import warnings
+from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
 from pydynox import (
+    DynamoConfig,
     Model,
     ModelConfig,
     clear_default_client,
@@ -217,10 +220,10 @@ async def test_model_raises_error_when_no_client():
 
 
 @pytest.mark.asyncio
-async def test_model_raises_error_when_no_model_config():
-    """Model raises error when model_config is not defined."""
+async def test_model_raises_error_when_no_dynamodb_config():
+    """Model raises error when neither dynamodb_config nor model_config is defined."""
 
-    # GIVEN a model without model_config
+    # GIVEN a model without any config
     class User(Model):
         pk = StringAttribute(partition_key=True)
         name = StringAttribute()
@@ -230,8 +233,8 @@ async def test_model_raises_error_when_no_model_config():
     set_default_client(mock_client)
 
     # WHEN we try to call get (async)
-    # THEN ValueError should be raised
-    with pytest.raises(ValueError, match="must define model_config"):
+    # THEN ValueError should be raised pointing at dynamodb_config
+    with pytest.raises(ValueError, match="must define dynamodb_config"):
         await User.get(pk="USER#1")
 
 
@@ -265,4 +268,161 @@ def test_model_get_table_from_config():
         pk = StringAttribute(partition_key=True)
 
     # THEN _get_table should return the configured table name
-    assert User._get_table() == "my_users_table"
+    with warnings.catch_warnings():
+        # Silence the legacy model_config deprecation for this assertion
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert User._get_table() == "my_users_table"
+
+
+# --------------------------------------------------------------------------
+# PR 1: DynamoConfig / dynamodb_config rename
+# --------------------------------------------------------------------------
+
+
+def test_modelconfig_is_alias_for_dynamoconfig():
+    """ModelConfig is a runtime alias of DynamoConfig."""
+    # Both names point at the same class object.
+    assert ModelConfig is DynamoConfig
+
+
+def test_dynamodb_config_field_names_unchanged():
+    """DynamoConfig keeps the same field names and defaults as the legacy ModelConfig."""
+    # GIVEN a DynamoConfig with defaults
+    config = DynamoConfig(table="users")
+
+    # THEN every documented field is present with the expected default
+    assert config.table == "users"
+    assert config.client is None
+    assert config.skip_hooks is False
+    assert config.max_size is None
+    assert config.consistent_read is False
+    assert config.hot_partition_writes is None
+    assert config.hot_partition_reads is None
+
+
+@pytest.mark.asyncio
+async def test_dynamodb_config_resolves_client():
+    """A class with dynamodb_config only resolves its client without a warning."""
+    # GIVEN a model declared with dynamodb_config
+    mock_client = MagicMock()
+
+    async def mock_get_item(table, key, consistent_read=False):
+        return {"pk": "USER#1", "name": "John"}
+
+    mock_client.get_item = mock_get_item
+
+    class User(Model):
+        dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(
+            table="users", client=mock_client
+        )
+        pk = StringAttribute(partition_key=True)
+        name = StringAttribute()
+
+    User._client_instance = None
+
+    # WHEN we resolve the client and fetch an item
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        result = await User.get(pk="USER#1")
+
+    # THEN the new-style config is used and no deprecation is emitted
+    assert result is not None
+    assert result.pk == "USER#1"
+    assert User._get_table() == "users"
+
+
+def test_legacy_model_config_still_works_with_warning():
+    """A class with legacy model_config still works but triggers a deprecation warning."""
+    # GIVEN a model declared with the legacy model_config attribute
+    mock_client = MagicMock()
+
+    class User(Model):
+        model_config = ModelConfig(table="users", client=mock_client)
+        pk = StringAttribute(partition_key=True)
+
+    # WHEN we read the config for the first time
+    with pytest.warns(DeprecationWarning, match="dynamodb_config"):
+        table = User._get_table()
+
+    # THEN the legacy value is still returned
+    assert table == "users"
+
+
+def test_legacy_model_config_warning_fires_once_per_class():
+    """The deprecation warning for legacy model_config is emitted at most once per class."""
+    # GIVEN a model declared with the legacy attribute
+    class User(Model):
+        model_config = ModelConfig(table="users")
+        pk = StringAttribute(partition_key=True)
+
+    # WHEN we access the config multiple times
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        for _ in range(5):
+            User._get_config()
+
+    # THEN only one DeprecationWarning is emitted for this class
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecations) == 1
+
+
+def test_dynamodb_config_wins_over_legacy_model_config():
+    """When both are set, dynamodb_config takes precedence and no warning fires."""
+    # GIVEN a model with both attributes set
+    class User(Model):
+        dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(table="new_table")
+        model_config = ModelConfig(table="old_table")
+        pk = StringAttribute(partition_key=True)
+
+    # WHEN we resolve the config
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        resolved = User._get_config()
+
+    # THEN the new attribute wins and no deprecation fires
+    assert resolved is not None
+    assert resolved.table == "new_table"
+
+
+def test_hot_partition_overrides_resolve_under_dynamodb_config():
+    """Hot-partition thresholds configured via dynamodb_config are applied."""
+    # GIVEN a client with diagnostics and a model using dynamodb_config thresholds
+    mock_client = MagicMock()
+    diagnostics = MagicMock()
+    mock_client.diagnostics = diagnostics
+
+    class Event(Model):
+        dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(
+            table="events",
+            client=mock_client,
+            hot_partition_writes=2000,
+            hot_partition_reads=5000,
+        )
+        pk = StringAttribute(partition_key=True)
+
+    Event._client_instance = None
+
+    # WHEN the client is resolved for the first time
+    assert Event._get_client() is mock_client
+
+    # THEN the diagnostics thresholds are wired using the values from the config
+    diagnostics.set_table_thresholds.assert_called_with(
+        "events", writes_threshold=2000, reads_threshold=5000
+    )
+
+
+def test_skip_hooks_resolves_under_dynamodb_config():
+    """skip_hooks set on dynamodb_config is respected by _should_skip_hooks."""
+    # GIVEN a model with skip_hooks=True under the new attribute
+    class User(Model):
+        dynamodb_config: ClassVar[DynamoConfig] = DynamoConfig(
+            table="users", skip_hooks=True
+        )
+        pk = StringAttribute(partition_key=True)
+
+    # WHEN the instance is asked whether to skip hooks
+    user = User(pk="USER#1")
+
+    # THEN the stored value is respected and can still be overridden per-call
+    assert user._should_skip_hooks(None) is True
+    assert user._should_skip_hooks(False) is False


### PR DESCRIPTION
Introduce `DynamoConfig` as the canonical name for DynamoDB-specific model configuration and `dynamodb_config` as the preferred class attribute. Keep `ModelConfig` as a TypeAlias and allow `model_config` as a legacy attribute that triggers a one-time DeprecationWarning per class.

All internal reads now go through `ModelBase._get_config()`, which resolves `dynamodb_config` first, falls back to `model_config`, and emits the warning. This unblocks the upcoming PydanticModel work where `model_config` collides with Pydantic's own attribute of the same name.

See docs/refactor/pydantic-model/01-dynamoconfig-rename.md.

Made-with: Cursor