### PR TITLE
fix: update serialization

### DIFF
--- a/python/pydynox/_internal/_model/_helpers.py
+++ b/python/pydynox/_internal/_model/_helpers.py
@@ -337,11 +337,12 @@ def prepare_update(
                 raise ValueError(f"Unknown attribute: {attr_name}")
             setattr(self, attr_name, value)
 
-        # Translate update keys to DynamoDB alias names
+        # Translate update keys to DynamoDB alias names and serialize values
         aliased_kwargs = {}
         for attr_name, value in kwargs.items():
+            attr = self._attributes[attr_name]
             dynamo_name = self._py_to_dynamo.get(attr_name, attr_name)
-            aliased_kwargs[dynamo_name] = value
+            aliased_kwargs[dynamo_name] = attr.serialize(value)
 
         if condition is not None:
             cond_names: dict[str, str] = {}
@@ -392,11 +393,12 @@ def prepare_update_by_key(
         if attr_name not in cls._attributes:
             raise ValueError(f"Unknown attribute: {attr_name}")
 
-    # Translate update keys to DynamoDB alias names
+    # Translate update keys to DynamoDB alias names and serialize values
     aliased_updates = {}
     for attr_name, value in updates.items():
+        attr = cls._attributes[attr_name]
         dynamo_name = cls._py_to_dynamo.get(attr_name, attr_name)
-        aliased_updates[dynamo_name] = value
+        aliased_updates[dynamo_name] = attr.serialize(value)
 
     client = cls._get_client()
     table = cls._get_table()

--- a/python/pydynox/testing/memory.py
+++ b/python/pydynox/testing/memory.py
@@ -109,20 +109,26 @@ class MemoryBackend:
         ...     assert user.name == "John"
     """
 
-    def __init__(self, seed: dict[str, list[dict[str, Any]]] | None = None) -> None:
+    def __init__(
+        self,
+        seed: dict[str, list[dict[str, Any]]] | None = None,
+        strict: bool = True,
+    ) -> None:
         """Initialize the memory backend.
 
         Args:
             seed: Optional dict of table_name -> list of items to pre-populate.
+            strict: If True, reject values with types unsupported by DynamoDB.
         """
         self._seed = seed or {}
+        self._strict = strict
         self._previous_client: Any = None
         self._client: MemoryClient | None = None
 
     def __enter__(self) -> "MemoryBackend":
         """Enter context manager."""
         self._previous_client = get_default_client()
-        self._client = MemoryClient(seed=self._seed)
+        self._client = MemoryClient(seed=self._seed, strict=self._strict)
         # Clear cached clients so models use the new MemoryClient
         self._clear_model_caches()
         set_default_client(self._client)
@@ -179,11 +185,13 @@ class MemoryBackend:
 @contextmanager
 def memory_backend(
     seed: dict[str, list[dict[str, Any]]] | None = None,
+    strict: bool = True,
 ) -> Iterator[MemoryBackend]:
     """Context manager for in-memory testing.
 
     Args:
         seed: Optional dict of table_name -> list of items to pre-populate.
+        strict: If True, reject values with types unsupported by DynamoDB.
 
     Yields:
         MemoryBackend instance.
@@ -194,7 +202,7 @@ def memory_backend(
         ...     user.save()
         ...     assert "users" in backend.tables
     """
-    backend = MemoryBackend(seed=seed)
+    backend = MemoryBackend(seed=seed, strict=strict)
     with backend:
         yield backend
 
@@ -202,10 +210,17 @@ def memory_backend(
 class MemoryClient:
     """In-memory client that mimics DynamoDBClient interface."""
 
-    def __init__(self, seed: dict[str, list[dict[str, Any]]] | None = None) -> None:
+    _VALID_DYNAMO_TYPES = (str, int, float, bool, type(None), list, dict, bytes, set)
+
+    def __init__(
+        self,
+        seed: dict[str, list[dict[str, Any]]] | None = None,
+        strict: bool = True,
+    ) -> None:
         # tables[table_name][key_string] = item
         self._tables: dict[str, dict[str, dict[str, Any]]] = {}
         self._table_schemas: dict[str, dict[str, str]] = {}  # table -> {partition_key, sort_key}
+        self._strict = strict
         self._rate_limit = None
         self._diagnostics = None
         self._last_metrics: FakeMetrics | None = None
@@ -221,6 +236,37 @@ class MemoryClient:
                     # Infer key from first item
                     key_str = self._make_key_string(item)
                     self._tables[table_name][key_str] = copy.deepcopy(item)
+
+    def _validate_value(self, value: Any) -> None:
+        """Raise TypeError if value is not a valid DynamoDB type (recursive)."""
+        if not self._strict:
+            return
+        if isinstance(value, self._VALID_DYNAMO_TYPES):
+            if isinstance(value, dict):
+                for v in value.values():
+                    self._validate_value(v)
+            elif isinstance(value, list):
+                for v in value:
+                    self._validate_value(v)
+            elif isinstance(value, set):
+                for v in value:
+                    if not isinstance(v, (str, int, float, bytes)):
+                        raise TypeError(
+                            f"Unsupported type in set for DynamoDB: {type(v).__name__}. "
+                            f"Sets may only contain str, int, float, or bytes."
+                        )
+        else:
+            raise TypeError(
+                f"Unsupported type for DynamoDB: {type(value).__name__}. "
+                f"Supported types: str, int, float, bool, None, list, dict, bytes, set"
+            )
+
+    def _validate_item(self, item: dict[str, Any]) -> None:
+        """Validate all values in an item dict."""
+        if not self._strict:
+            return
+        for key, value in item.items():
+            self._validate_value(value)
 
     @property
     def diagnostics(self) -> None:
@@ -303,6 +349,7 @@ class MemoryClient:
         expression_attribute_values: dict[str, Any] | None = None,
     ) -> FakeMetrics:
         """Internal sync put item implementation."""
+        self._validate_item(item)
         start = time.time()
         tbl = self._get_table(table)
         key_str = self._make_key_string(item)
@@ -400,6 +447,7 @@ class MemoryClient:
 
         # Apply updates
         if updates:
+            self._validate_item(updates)
             for attr, value in updates.items():
                 existing[attr] = value
 

--- a/tests/integration/integrations/sync/test_update_serialization.py
+++ b/tests/integration/integrations/sync/test_update_serialization.py
@@ -1,0 +1,98 @@
+"""Integration tests for update/update_by_key serialization of typed attributes.
+
+Regression tests for https://github.com/ferrumio/pydynox/issues/377
+"""
+
+import dataclasses
+import uuid
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import MapAttribute, StringAttribute
+
+
+@dataclasses.dataclass
+class Address:
+    street: str
+    city: str
+    zip: str
+
+
+def _make_user_model(dynamo):
+    table = "test_table"
+
+    class User(Model):
+        model_config = ModelConfig(table=table, client=dynamo)
+        pk = StringAttribute(partition_key=True)
+        sk = StringAttribute(sort_key=True)
+        address = MapAttribute(Address)
+
+    return User
+
+
+def test_sync_update_serializes_typed_map(dynamo):
+    """sync_update correctly serializes a typed MapAttribute (dataclass)."""
+    User = _make_user_model(dynamo)
+    pk = f"UPD_SER#{uuid.uuid4().hex[:8]}"
+
+    # GIVEN a saved user with an address
+    user = User(
+        pk=pk,
+        sk="PROFILE",
+        address=Address(street="123 Main St", city="NYC", zip="10001"),
+    )
+    user.sync_save()
+
+    # WHEN updating the address via sync_update
+    new_address = Address(street="456 Elm St", city="Chicago", zip="60601")
+    user.sync_update(address=new_address)
+
+    # THEN the new address is persisted and deserialized correctly
+    retrieved = User.sync_get(pk=pk, sk="PROFILE")
+    assert retrieved.address == new_address
+    assert retrieved.address.city == "Chicago"
+    assert retrieved.address.street == "456 Elm St"
+
+
+def test_sync_update_by_key_serializes_typed_map(dynamo):
+    """sync_update_by_key correctly serializes a typed MapAttribute (dataclass)."""
+    User = _make_user_model(dynamo)
+    pk = f"UBK_SER#{uuid.uuid4().hex[:8]}"
+
+    # GIVEN a saved user with an address
+    user = User(
+        pk=pk,
+        sk="PROFILE",
+        address=Address(street="123 Main St", city="NYC", zip="10001"),
+    )
+    user.sync_save()
+
+    # WHEN updating via update_by_key
+    new_address = Address(street="789 Pine St", city="Seattle", zip="98101")
+    User.sync_update_by_key(pk=pk, sk="PROFILE", address=new_address)
+
+    # THEN the new address is persisted and deserialized correctly
+    retrieved = User.sync_get(pk=pk, sk="PROFILE")
+    assert retrieved.address == new_address
+    assert retrieved.address.city == "Seattle"
+    assert retrieved.address.zip == "98101"
+
+
+def test_sync_update_serializes_none_typed_map(dynamo):
+    """sync_update correctly handles setting a typed MapAttribute to None."""
+    User = _make_user_model(dynamo)
+    pk = f"UPD_NONE#{uuid.uuid4().hex[:8]}"
+
+    # GIVEN a saved user with an address
+    user = User(
+        pk=pk,
+        sk="PROFILE",
+        address=Address(street="123 Main St", city="NYC", zip="10001"),
+    )
+    user.sync_save()
+
+    # WHEN setting address to None
+    user.sync_update(address=None)
+
+    # THEN address is None
+    retrieved = User.sync_get(pk=pk, sk="PROFILE")
+    assert retrieved.address is None


### PR DESCRIPTION
Closes #377 

In this PR I fix the serialization bug in prepare_update() and prepare_update_by_key() — both were passing typed attribute values (like MapAttribute(Address)) raw to the client instead of calling attr.serialize(value) first. The save() path was already doing this correctly, these two just got missed.

I also made `MemoryBackend` strict by default so it rejects unsupported DynamoDB types on put/update, which means this kind of bug gets caught early in unit tests without needing LocalStack.