### PR TITLE
docs: revise PydanticModel rollout plan (issue #364 pivot)

### DIFF
--- a/ADR/021-pydantic-base-model.md
+++ b/ADR/021-pydantic-base-model.md
@@ -1,0 +1,136 @@
+# ADR 021: Optional Pydantic integration via `PydanticModel`
+
+## Status
+
+Proposed (revised May 2026 after maintainer feedback on
+[issue #364](https://github.com/ferrumio/pydynox/issues/364); Pydantic stays
+optional and plain `Model` is not changed).
+
+## Context
+
+pydynox currently offers two overlapping ways to declare a DynamoDB-backed
+model:
+
+1. The **`Model` class** in [python/pydynox/model.py](../python/pydynox/model.py)
+   with `Attribute` descriptors in [python/pydynox/attributes/](../python/pydynox/attributes/).
+   Full DynamoDB feature set (GSI/LSI, templates, aliases, encryption, TTL,
+   version, S3 offload, discriminator, hooks, auto-generate, dirty tracking,
+   transactions, batch). No Pydantic-level features: no `Field(description=...)`,
+   no validators, no JSON schema, no `model_dump_json()`.
+
+2. The **`@dynamodb_model` decorator** in
+   [python/pydynox/integrations/pydantic.py](../python/pydynox/integrations/pydantic.py).
+   Wraps an arbitrary `BaseModel` and adds `save`/`get`/`delete`/`update` only.
+   Loses almost every pydynox DynamoDB feature listed above.
+
+Users who want both a rich Pydantic schema (descriptions, validators,
+constraints, JSON schema) and pydynox's DynamoDB features today have no path.
+
+### Constraint: Pydantic must remain optional
+
+pydynox's core value is speed and a minimal dependency footprint. The Rust
+core handles serialization, compression, encryption, and all AWS SDK calls.
+Making Pydantic a required runtime dependency goes against that principle.
+Pydantic is installed today via the `pydynox[pydantic]` extra and must stay
+optional.
+
+This rules out evolving `Model` into a `pydantic.BaseModel` subclass, which
+would force every user to depend on Pydantic.
+
+### Plan pivot (May 2026)
+
+An earlier rollout proposed preparatory PRs: global `ModelConfig` rename,
+`Annotated` markers on plain `Model`, and `cls.F` on both classes. After
+production-user feedback, the maintainer closed
+[PR #365](https://github.com/ferrumio/pydynox/pull/365) and
+[PR #366](https://github.com/ferrumio/pydynox/pull/366) and directed work
+toward **`PydanticModel` first**, with markers and config naming scoped to
+that class. See
+[docs/refactor/pydantic-model/00-plan-pivot.md](../docs/refactor/pydantic-model/00-plan-pivot.md).
+
+## Decision
+
+Introduce a new, **opt-in** `PydanticModel` class that inherits from both
+`Model` and `pydantic.BaseModel`:
+
+```python
+from pydynox import Model          # no Pydantic; works exactly as today
+from pydynox import PydanticModel  # Model + BaseModel; requires pydynox[pydantic]
+```
+
+`PydanticModel` lives in a new module
+[python/pydynox/pydantic_model.py](../python/pydynox/pydantic_model.py) and is
+lazily imported: a user without Pydantic installed can still
+`import pydynox` and use `Model` as today; only `from pydynox import
+PydanticModel` triggers the import and raises a clear `ImportError` with a
+pointer to `pip install pydynox[pydantic]` if Pydantic is missing.
+
+Supporting changes, scoped to **`PydanticModel` only** (plain `Model` unchanged):
+
+- **`Annotated[T, Dynamo.*]` markers** with full attribute-type coverage,
+  consumed by `_collect_dynamodb_schema` from Pydantic `FieldInfo.metadata`.
+  Not wired into `ModelMeta` for plain `Model`. See
+  [02-dynamo-markers.md](../docs/refactor/pydantic-model/02-dynamo-markers.md).
+- **`dynamodb_config: ClassVar[ModelConfig]`** on `PydanticModel` subclasses
+  so Pydantic's `model_config = ConfigDict(...)` remains available. Plain
+  `Model` keeps `model_config = ModelConfig(...)` with no rename.
+- **`cls.F` namespace** for conditions and atomic ops on `PydanticModel`
+  because Pydantic owns class-level field access. Plain `Model` keeps
+  `User.pk == "x"` with no deprecation. See
+  [04-fields-namespace.md](../docs/refactor/pydantic-model/04-fields-namespace.md).
+- **Deprecate `@dynamodb_model`** and point users at `PydanticModel`. See
+  [07-deprecate-decorator.md](../docs/refactor/pydantic-model/07-deprecate-decorator.md).
+
+Implementation rolls out in seven small PRs documented in
+[docs/refactor/pydantic-model/README.md](../docs/refactor/pydantic-model/README.md).
+
+## Reasons
+
+- **Zero impact on non-Pydantic users.** No global renames, no second field
+  declaration style on plain `Model`, no new required dependencies.
+- **Single codebase for the DynamoDB feature set.** `PydanticModel`
+  inherits from `Model`, so GSI/LSI, transactions, batch, hooks, metrics,
+  `create_table`, atomic ops, version, TTL, encryption, compression, S3
+  offload, discriminator, and auto-generate are all shared.
+- **No breaking changes.** All PRs ship on minor versions.
+- **Clean deprecation path for `@dynamodb_model`.** Users migrate to
+  `PydanticModel` and gain the full DynamoDB feature set at the same time.
+
+## Alternatives considered
+
+- **Make `Model` a `BaseModel` directly**: rejected. Forces Pydantic as a
+  required dependency and breaks every existing user.
+- **Global `ModelConfig` → `DynamoConfig` rename**: rejected (PR #365).
+  Warns all `Model` users for a collision that only affects `PydanticModel`.
+- **`Annotated` markers on plain `Model`**: rejected (PR #366). Second
+  declaration style without benefit to descriptor users; incomplete type
+  coverage in the prototype.
+- **Leave the two worlds as-is**: rejected. The decorator path keeps
+  accumulating feature gaps.
+- **Extend the decorator to feature parity**: rejected. Two parallel
+  implementations of the same `Attribute` pipeline.
+
+## Consequences
+
+Positive:
+
+- Plain `Model` users see no change.
+- `PydanticModel` users get Pydantic features **and** every pydynox DynamoDB
+  feature via inheritance.
+- One class to maintain for DynamoDB logic; `PydanticModel` is a thin layer.
+
+Negative / trade-offs:
+
+- Two public model base classes. Documentation must explain when to pick which.
+- `PydanticModel` users must use `Annotated[...]` and `cls.F` — Pydantic
+  constraints, not pydynox's preference.
+- `__setattr__`-based dirty tracking must cooperate with
+  `validate_assignment` on `PydanticModel`.
+
+## References
+
+- [docs/refactor/pydantic-model/overview.md](../docs/refactor/pydantic-model/overview.md)
+- [docs/refactor/pydantic-model/00-plan-pivot.md](../docs/refactor/pydantic-model/00-plan-pivot.md)
+- [issue #364](https://github.com/ferrumio/pydynox/issues/364#issuecomment-4416367765)
+- PR specs: [01](../docs/refactor/pydantic-model/01-extract-schema-collection.md) –
+  [07](../docs/refactor/pydantic-model/07-deprecate-decorator.md)

--- a/ADR/README.md
+++ b/ADR/README.md
@@ -30,6 +30,7 @@ An ADR is a short document that describes a decision, why it was made, and what 
 | 018 | [Async-first design](018-async-first-design.md) | Accepted |
 | 019 | [Release GIL during sync block_on](019-gil-release-sync-operations.md) | Accepted |
 | 020 | [Split client.rs into domain modules](020-split-client-into-modules.md) | Accepted |
+| 021 | [Optional Pydantic integration via `PydanticModel`](021-pydantic-base-model.md) | Proposed |
 
 ## Adding a new ADR
 

--- a/docs/refactor/pydantic-model/00-plan-pivot.md
+++ b/docs/refactor/pydantic-model/00-plan-pivot.md
@@ -1,0 +1,66 @@
+# Plan pivot (May 2026)
+
+**Summary**: the original five-PR rollout is superseded. Implementation
+starts from upstream `main` with `PydanticModel` as the central deliverable,
+not preparatory changes on plain `Model`.
+
+## What changed
+
+In early 2026 the plan was:
+
+1. Rename `ModelConfig` → `DynamoConfig` globally (PR #365).
+2. Add `Annotated[T, Dynamo.*]` on plain `Model` (PR #366).
+3. Add `cls.F` namespace on both classes.
+4. Introduce `PydanticModel`.
+5. Deprecate `@dynamodb_model`.
+
+After production-user feedback, the maintainer revised direction in
+[issue #364](https://github.com/ferrumio/pydynox/issues/364#issuecomment-4416367765):
+
+### PR #365 — global `DynamoConfig` rename — **not merging**
+
+The rename only existed to free `model_config` for Pydantic's `ConfigDict`.
+Since `Model` does **not** inherit from `BaseModel`, there is no naming
+collision for existing `Model` users. Renaming would warn every current user
+for a problem that does not affect them.
+
+If `PydanticModel` needs a separate config attribute (e.g.
+`dynamodb_config: ClassVar[ModelConfig]`), that is handled **inside
+`PydanticModel` only**, not via a global rename.
+
+### PR #366 — `Annotated` markers on plain `Model` — **not merging**
+
+The markers are required on `PydanticModel` (Pydantic owns the class body),
+but a second declaration style on plain `Model` adds ~840 lines without
+helping users who already have explicit `Attribute` descriptors. The
+prototype also covered only String/Number/Boolean/Binary, not the complex
+types (Map, JSON, List, Enum, Datetime, S3, encrypted, ...) where
+`Annotated` actually shines.
+
+Markers ship as part of the `PydanticModel` work with **full attribute type
+coverage from day one**, not wired into `ModelMeta` for plain `Model`.
+
+### `cls.F` on plain `Model`
+
+Not rejected in principle, but **deferred**. `User.pk == "x"` stays on plain
+`Model` with no deprecation. `cls.F` is implemented on **`PydanticModel`
+only**, where Pydantic owns class-level field access.
+
+## New rollout
+
+See [README.md](README.md) for the seven implementation PRs (PRs 1–7 after
+this docs PR). The maintainer offered to **pair on metaclass wiring** for
+PR 3 (`PydanticModel` core).
+
+## Salvage from closed work
+
+Useful pieces from the closed PR branches may be cherry-picked into the new
+sequence:
+
+- Marker → `Attribute` builder logic (into PR 2), without `ModelMeta`
+  integration on plain `Model`.
+- Internal helper extraction patterns (into PR 1).
+- `cls.F` / `AttributeRef` prototype (into PR 4), scoped to
+  `PydanticModel`.
+
+Do **not** resubmit PR #365 or #366 as-is.

--- a/docs/refactor/pydantic-model/01-extract-schema-collection.md
+++ b/docs/refactor/pydantic-model/01-extract-schema-collection.md
@@ -1,0 +1,64 @@
+# PR 1: Extract schema collection helpers
+
+**Summary**: factor index, hook, and discriminator collection out of
+`ModelMeta.__new__` into reusable helpers. Zero user-visible change on
+`Model`; enables `PydanticModel` metaclass to populate the same class
+dunders without duplicating logic.
+
+## Motivation
+
+`ModelMeta.__new__` today scans the class body for `Attribute` descriptors,
+GSI/LSI declarations, hook methods, and discriminator metadata, then
+populates `_attributes`, `_indexes`, `_hooks`, and related dunders.
+
+`PydanticModel` (PR 3) will populate those same dunders from Pydantic
+`model_fields` instead of class-body descriptors, but still needs identical
+index/hook/discriminator handling. Extracting shared helpers first keeps PR 3
+focused on metaclass cooperation rather than copy-paste.
+
+## Scope
+
+In:
+
+- New helpers in
+  [python/pydynox/_internal/_model/_base.py](../../../python/pydynox/_internal/_model/_base.py)
+  (or a sibling module), e.g.:
+  - `_collect_indexes(namespace, bases) -> (indexes, local_indexes)`
+  - `_collect_hooks(namespace, bases) -> hooks`
+  - `_collect_discriminator(attributes) -> (discriminator_attr, registry)`
+  - `_finalize_schema(cls, attributes, ...) -> None` (populate dunders)
+- `ModelMeta.__new__` calls the helpers; behavior unchanged.
+
+Out:
+
+- Any new public API.
+- `PydanticModel`, markers, or `cls.F`.
+- Changing how attributes are discovered on plain `Model`.
+
+## Files touched
+
+- [python/pydynox/_internal/_model/_base.py](../../../python/pydynox/_internal/_model/_base.py)
+- Existing `Model` unit/integration tests (must pass unchanged).
+
+## Public API changes
+
+None.
+
+## Back-compat
+
+Identical `Model` behavior. No deprecations.
+
+## Test plan
+
+- Full existing test suite green.
+- Optional: add a narrow unit test asserting helper outputs match pre-refactor
+  dunders for a fixture model with GSI, LSI, hooks, and discriminator.
+
+## Size
+
+S. Roughly 80–150 LOC moved/refactored.
+
+## Depends on / unblocks
+
+- Depends on: nothing (first implementation PR after docs).
+- Unblocks: PR 3 (`PydanticModel` metaclass reuses helpers).

--- a/docs/refactor/pydantic-model/02-dynamo-markers.md
+++ b/docs/refactor/pydantic-model/02-dynamo-markers.md
@@ -1,0 +1,112 @@
+# PR 2: `Dynamo.*` markers (Pydantic path only)
+
+**Summary**: add a `pydynox.Dynamo` namespace of frozen metadata markers and
+an `attribute_from_annotated()` builder that synthesizes existing
+`Attribute` subclasses from `Annotated[T, Dynamo.*]`. Used by
+`PydanticModel` only — **not** wired into `ModelMeta` for plain `Model`.
+
+## Motivation
+
+`PydanticModel` cannot use class-body `Attribute` descriptors; Pydantic owns
+class-body assignments. PEP 593 `Annotated[T, ...]` is the canonical way to
+attach pydynox metadata while preserving the underlying type for Pydantic and
+type checkers.
+
+Closed PR #366 proved the builder pattern but was rejected because it (a)
+depended on a global config rename, (b) only covered four primitive types, and
+(c) added a second declaration style on plain `Model` that did not help
+existing users. This PR delivers **full attribute coverage** and keeps the
+markers **private to the Pydantic path** until PR 3 wires them in.
+
+## Scope
+
+In:
+
+- New module [python/pydynox/dynamo.py](../../../python/pydynox/dynamo.py)
+  (or `markers.py`) exporting `Dynamo` as a namespace of frozen dataclasses.
+- Internal builder
+  [python/pydynox/_internal/_dynamo_annotated.py](../../../python/pydynox/_internal/_dynamo_annotated.py)
+  with `attribute_from_annotated(name, annotation) -> Attribute`.
+- Full marker inventory (see table below).
+- Unit tests per marker and type-inference rule.
+- Export `Dynamo` from `pydynox` (markers are harmless without `PydanticModel`).
+
+Out:
+
+- `ModelMeta` scanning `__annotations__` on plain `Model`.
+- `PydanticModel` class itself (PR 3).
+- Global `ModelConfig` → `DynamoConfig` rename.
+
+## Marker inventory
+
+| Marker | Maps to | Key parameters |
+|--------|---------|----------------|
+| `Dynamo.partition_key` | `partition_key=True` | `template`, `alias` |
+| `Dynamo.sort_key` | `sort_key=True` | `template`, `alias` |
+| `Dynamo.alias` | DynamoDB attribute name | `name` |
+| `Dynamo.template` | template on non-key field | `template` |
+| `Dynamo.auto_gen` | `AutoGenerate` default | `strategy` |
+| `Dynamo.required` | `required=True` | — |
+| `Dynamo.discriminator` | `discriminator=True` | — |
+| `Dynamo.ttl` | `TTLAttribute` | `ttl_seconds` |
+| `Dynamo.version` | `VersionAttribute` | — |
+| `Dynamo.encrypted` | `EncryptedAttribute` | `key_id`, `mode`, ... |
+| `Dynamo.compressed` | `CompressedAttribute` | `algorithm`, `level` |
+| `Dynamo.s3` | `S3Attribute` | `bucket`, `key_prefix`, ... |
+| `Dynamo.json` | `JSONAttribute` | optional typed model |
+| `Dynamo.enum` | `EnumAttribute` | `enum` type |
+| `Dynamo.datetime` | `DatetimeAttribute` | `format` |
+| `Dynamo.string_set` | `StringSetAttribute` | — |
+| `Dynamo.number_set` | `NumberSetAttribute` | — |
+
+Multiple markers combine on one field:
+`Annotated[str, Dynamo.partition_key(), Dynamo.alias("PK")]`.
+
+## Type inference
+
+When no explicit type marker is present, infer `Attribute` subclass from `T`:
+
+- `str` → `StringAttribute`
+- `int` / `float` → `NumberAttribute`
+- `bool` → `BooleanAttribute`
+- `bytes` → `BinaryAttribute`
+- `list[...]` → `ListAttribute`
+- `dict[str, ...]` → `MapAttribute`
+- `set[str]` → `StringSetAttribute`
+- `set[int|float]` → `NumberSetAttribute`
+- `Enum` subclass → `EnumAttribute`
+- `datetime` → `DatetimeAttribute`
+- `BaseModel` subclass → `JSONAttribute[That]`
+
+Unknown types raise `TypeError` at build time with a pointer to these docs.
+
+## Public API
+
+```python
+from typing import Annotated
+from pydynox import Dynamo
+
+pk: Annotated[str, Dynamo.partition_key(template="USER#{user_id}")]
+```
+
+Markers are inert until PR 3 connects them to `PydanticModel`.
+
+## Back-compat
+
+Plain `Model` unchanged. No new declaration path on `Model`.
+
+## Test plan
+
+- Unit test each marker → correct `Attribute` subclass and kwargs.
+- Combined markers (partition key + alias + auto_gen).
+- Type inference for every row in the inference table.
+- Negative cases: unknown type, conflicting markers.
+
+## Size
+
+M. Roughly 300–500 LOC including tests.
+
+## Depends on / unblocks
+
+- Depends on: PR 1 (optional; can land in parallel).
+- Unblocks: PR 3 (`_collect_dynamodb_schema` reads markers).

--- a/docs/refactor/pydantic-model/03-pydantic-model-core.md
+++ b/docs/refactor/pydantic-model/03-pydantic-model-core.md
@@ -1,0 +1,115 @@
+# PR 3: `PydanticModel` core + combined metaclass
+
+**Summary**: introduce the opt-in `PydanticModel(Model, BaseModel)` class with
+`_PydanticModelMeta`, wire DynamoDB schema from Pydantic `model_fields` +
+PR 2 markers, and prove a minimal save/get vertical slice. **Pair with
+maintainer on metaclass wiring before opening upstream.**
+
+## Motivation
+
+This is the deliverable that unblocks everything else. Once `PydanticModel`
+exists:
+
+- `Annotated[T, Dynamo.*]` markers have a real consumer.
+- Config naming (`dynamodb_config` vs `model_config`) is scoped to this class.
+- `@dynamodb_model` has a migration target (PR 7).
+
+The hard part is metaclass cooperation: Pydantic's `ModelMetaclass` must run
+first to populate `model_fields`, then pydynox must populate the same class
+dunders that CRUD, indexes, transactions, and batch read today.
+
+## Scope
+
+In:
+
+- New module
+  [python/pydynox/pydantic_model.py](../../../python/pydynox/pydantic_model.py):
+  - Lazy pydantic import; clear `ImportError` naming `pip install pydynox[pydantic]`.
+  - `_PydanticModelMeta(ModelMeta, ModelMetaclass)`.
+  - `_collect_dynamodb_schema(cls)` walking `cls.model_fields`, reading
+    `FieldInfo.metadata` for `Dynamo.*` markers, calling PR 2 builder.
+  - Reuse PR 1 helpers for indexes, hooks, discriminator.
+  - `PydanticModel(Model, BaseModel)` with:
+    - `dynamodb_config: ClassVar[ModelConfig]` for table/client settings.
+    - Default `model_config = ConfigDict(validate_assignment=True, ...)`.
+- Lazy export from [python/pydynox/__init__.py](../../../python/pydynox/__init__.py).
+- Minimal docs snippet in a new `docs/guides/pydantic.md` (expanded later).
+- Tests: import guards; metaclass dunders; one save/get with partition key +
+  primitive fields.
+
+Out (follow-up PRs):
+
+- `cls.F` namespace (PR 4).
+- Dirty tracking / `to_dict` / `from_dict` shims (PR 5).
+- Full parity matrix (PR 6).
+- Deprecating `@dynamodb_model` (PR 7).
+
+## Metaclass wiring
+
+```python
+from pydantic._internal._model_construction import ModelMetaclass
+from pydynox._internal._model._base import ModelMeta
+
+class _PydanticModelMeta(ModelMeta, ModelMetaclass):
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        # 1. Pydantic first: model_fields, validators, ConfigDict.
+        cls = ModelMetaclass.__new__(mcs, name, bases, namespace, **kwargs)
+
+        # 2. Skip base PydanticModel class itself.
+        if name == "PydanticModel" and namespace.get("__module__") == "pydynox.pydantic_model":
+            return cls
+
+        # 3. DynamoDB schema from model_fields + Dynamo.* metadata.
+        _collect_dynamodb_schema(cls)
+        return cls
+```
+
+Exact MRO and hook ordering to be validated with maintainer pairing.
+
+## Public API
+
+```python
+from typing import Annotated, ClassVar
+from pydantic import ConfigDict, Field
+from pydynox import PydanticModel, ModelConfig, Dynamo
+
+class User(PydanticModel):
+    dynamodb_config: ClassVar[ModelConfig] = ModelConfig(table="users")
+    model_config = ConfigDict(validate_assignment=True)
+
+    pk:   Annotated[str, Dynamo.partition_key()]
+    name: str = Field(description="Display name")
+
+user = await User(name="Ada").save()
+found = await User.get(pk=user.pk)
+```
+
+## Back-compat
+
+`Model` unchanged. `import pydynox` without Pydantic installed still works.
+
+## Test plan
+
+- `import pydynox` succeeds without pydantic extra.
+- `from pydynox import PydanticModel` without pydantic raises clear
+  `ImportError`.
+- Subclass dunders: `_attributes`, `_partition_key`, `_py_to_dynamo` match
+  expectations for a fixture model.
+- Integration: save + get round-trip for primitives (mock or local DynamoDB).
+
+## Size
+
+L. Roughly 200–350 LOC implementation + 150–250 LOC tests.
+
+## Depends on / unblocks
+
+- Depends on: PR 2 (markers); PR 1 strongly recommended.
+- Unblocks: PRs 4, 5, 6, 7.
+
+## Maintainer pairing
+
+Schedule a pairing session **before** opening the upstream PR. Focus areas:
+
+- Metaclass MRO and `ModelMetaclass` kwargs forwarding.
+- Interaction with user-defined metaclass subclasses.
+- Ordering: Pydantic validators vs pydynox hook registration.

--- a/docs/refactor/pydantic-model/04-fields-namespace.md
+++ b/docs/refactor/pydantic-model/04-fields-namespace.md
@@ -1,0 +1,75 @@
+# PR 4: `cls.F` condition / atomic namespace on `PydanticModel`
+
+**Summary**: add `PydanticModel.F` exposing one `AttributeRef` per field for
+conditions and atomic operations. Plain `Model` is unchanged — descriptor
+style `User.pk == "x"` stays the only path on `Model`.
+
+## Motivation
+
+On `PydanticModel`, class-level `User.pk` is a `FieldInfo`. Operator
+overloads on `Attribute` cannot run. `User.F.pk == "x"` and
+`User.F.counter.add(1)` delegate to the same `Condition*` and `Atomic*`
+classes used today, so transactions, updates, and queries need no changes.
+
+The original plan added `cls.F` to both classes. The revised plan scopes it
+to **`PydanticModel` only** to avoid adding API surface plain `Model` users
+do not need.
+
+## Scope
+
+In:
+
+- `AttributeRef` in
+  [python/pydynox/_internal/_model/_refs.py](../../../python/pydynox/_internal/_model/_refs.py)
+  wrapping an `Attribute`:
+  - Comparison operators → `ConditionComparison`.
+  - `exists()`, `not_exists()`, `begins_with()`, `contains()`, `between()`,
+    `is_in()`, nested `__getitem__`.
+  - `set()`, `add()`, `remove()`, `append()`, `prepend()`, `if_not_exists()`.
+- `_FieldsNamespace` built lazily from `cls._attributes`, exposed as `cls.F`.
+- Optional `cls.F["pk"]` string lookup.
+- Wired in `_PydanticModelMeta` after schema collection (PR 3).
+
+Out:
+
+- Adding `cls.F` to plain `Model` or deprecating `User.pk == "x"`.
+- Changes to transaction/query modules beyond accepting existing condition types.
+
+## Design
+
+```mermaid
+flowchart LR
+    PyUser["PyUser(PydanticModel)"] -->|"cls.F"| FNS["_FieldsNamespace"]
+    FNS -->|"cls.F.pk"| RefPk["AttributeRef"]
+    RefPk -->|"== 'x'"| Cond["ConditionComparison"]
+    RefPk -->|"add(1)"| Atom["AtomicAdd"]
+    Cond --> Tx["Transaction / query\n(unchanged)"]
+    Atom --> Tx
+```
+
+## Public API
+
+```python
+cond = Order.F.status == "SHIPPED"
+tx.update(Order, key={"pk": order.pk}, atomic=[Order.F.total_cents.add(100)])
+```
+
+## Back-compat
+
+Plain `Model` unchanged.
+
+## Test plan
+
+- `Order.F.pk == "x"` serializes identically to equivalent `Model` condition
+  built via descriptor style (reference fixture).
+- Atomic ops in a transaction commit successfully.
+- `cls.F["field_name"]` dynamic lookup.
+
+## Size
+
+M. Roughly 150–250 LOC.
+
+## Depends on / unblocks
+
+- Depends on: PR 3.
+- Unblocks: PR 6 (parity tests for conditions/atomics on `PydanticModel`).

--- a/docs/refactor/pydantic-model/05-lifecycle-shims.md
+++ b/docs/refactor/pydantic-model/05-lifecycle-shims.md
@@ -1,0 +1,68 @@
+# PR 5: Lifecycle shims on `PydanticModel`
+
+**Summary**: implement dirty tracking that cooperates with Pydantic
+`validate_assignment`, plus `to_dict` / `from_dict` shims and
+auto-generate / template key hooks via `@model_validator`.
+
+## Motivation
+
+`ModelBase` tracks changes via `_original` and `_changed_fields` in
+`__setattr__`. Pydantic's `validate_assignment=True` must run first so invalid
+assignments raise `ValidationError` without polluting dirty state.
+
+CRUD, transactions, and batch call `to_dict` / `from_dict` today. Keeping
+those names on `PydanticModel` preserves call-site compatibility while
+internally delegating to `model_dump` / `model_validate` plus
+`Attribute.serialize` / `deserialize` for custom wire formats.
+
+## Scope
+
+In:
+
+- `PydanticModel.__setattr__`:
+  1. Delegate to `BaseModel.__setattr__` (validation).
+  2. On success, update `_original` / `_changed_fields` like `ModelBase`.
+- `to_dict(self, *, for_dynamo: bool = True)`:
+  1. `model_dump(mode="python", by_alias=True)`.
+  2. Apply `Attribute.serialize` where needed (encryption, S3, datetime, ...).
+  3. Merge templated partition/sort keys via `_build_template_keys`.
+- `from_dict(cls, data)`:
+  1. Apply `Attribute.deserialize`.
+  2. `cls.model_validate(...)`.
+- `@model_validator(mode="after")` calling `_apply_auto_generate()` and
+  template key preparation where appropriate.
+
+Out:
+
+- Changing `ModelBase` dirty tracking on plain `Model`.
+- Removing `to_dict` / `from_dict` from plain `Model`.
+
+## `__setattr__` sketch
+
+```python
+def __setattr__(self, name: str, value: object) -> None:
+    had_value = name in self.__dict__
+    old = self.__dict__.get(name)
+    super().__setattr__(name, value)  # BaseModel: validates if enabled
+    attr = type(self)._attributes.get(name)
+    if attr is not None and (not had_value or old != self.__dict__[name]):
+        self._changed_fields.add(name)
+        self._original.setdefault(name, old)
+```
+
+## Test plan
+
+- Invalid assignment raises `ValidationError`; `_changed_fields` unchanged.
+- Valid assignment updates dirty state once.
+- `to_dict` / `from_dict` round-trip matches `Model` wire format for same data.
+- AutoGenerate + template keys produce correct partition key on `save()`.
+- `is_dirty` / `changed_fields` / skip-save-when-clean behavior.
+
+## Size
+
+M. Roughly 150–250 LOC + tests.
+
+## Depends on / unblocks
+
+- Depends on: PR 3.
+- Unblocks: PR 6 (parity relies on correct serialization path).

--- a/docs/refactor/pydantic-model/06-parity-tests.md
+++ b/docs/refactor/pydantic-model/06-parity-tests.md
@@ -1,0 +1,70 @@
+# PR 6: Feature parity tests
+
+**Summary**: expand the test matrix so every pydynox DynamoDB feature works
+on `PydanticModel` with byte-identical wire format and equivalent behavior
+to plain `Model`. Fix gaps discovered in the `PydanticModel` path only.
+
+## Motivation
+
+PR 3 proves a vertical slice. Production confidence requires parity across
+the full feature surface: indexes, transactions, security attributes, hooks,
+discriminator, TTL, version conflicts, and more.
+
+This PR is primarily tests plus targeted fixes in
+`pydantic_model.py` / marker builder — not changes to plain `Model` or shared
+CRUD modules unless a genuine bug is found.
+
+## Scope
+
+In:
+
+- New test directory e.g.
+  [tests/unit/pydantic_model/](../../../tests/unit/pydantic_model/) or
+  [tests/integration/pydantic_model/](../../../tests/integration/pydantic_model/).
+- Parity fixtures: paired `Model` and `PydanticModel` classes with equivalent
+  declarations for each scenario.
+- Scenarios (minimum):
+
+| Area | Scenarios |
+|------|-----------|
+| Keys | partition, sort, composite templates, aliases |
+| Indexes | GSI query, LSI query, INCLUDE projection |
+| Transactions | put, update, delete, condition_check |
+| Batch | batch read / write |
+| Hooks | `@before_save`, `@after_get`, ... |
+| Conditions / atomics | via `cls.F` (PR 4) |
+| Discriminator | polymorphic read/write |
+| TTL / Version | expiry, optimistic locking conflict |
+| Secure attrs | encrypted, compressed, S3 offload |
+| AutoGenerate | ULID, UUID4, created_at, updated_at |
+| Dirty tracking | `is_dirty`, changed_fields, clean save skip |
+
+- Pydantic-specific tests:
+  - `Field(description=...)` in `model_json_schema()`.
+  - `@field_validator` rejects bad input on `save()`.
+  - Nested `BaseModel` round-trip.
+  - `validate_assignment` + dirty tracking (PR 5).
+
+Out:
+
+- New features not already supported on `Model`.
+- Parity work on plain `Model` (regression bar only).
+
+## Splitting
+
+If review size is too large, split into stacked PRs:
+
+- `test/pydantic-model-parity-keys-indexes`
+- `test/pydantic-model-parity-tx-batch`
+- `test/pydantic-model-parity-secure-hooks`
+
+Each must keep the full suite green.
+
+## Size
+
+M–L. Roughly 400–800 LOC tests; fixes as needed.
+
+## Depends on / unblocks
+
+- Depends on: PRs 3, 4, 5 (minimum 3; 4–5 for full matrix).
+- Unblocks: PR 7 (migration equivalence test).

--- a/docs/refactor/pydantic-model/07-deprecate-decorator.md
+++ b/docs/refactor/pydantic-model/07-deprecate-decorator.md
@@ -1,0 +1,58 @@
+# PR 7: Deprecate `@dynamodb_model` and consolidate docs
+
+**Summary**: now that `PydanticModel` reaches feature parity, the
+`@dynamodb_model` decorator is redundant. Add `DeprecationWarning`, update
+docs/examples, and publish a migration guide. Do **not** remove the decorator.
+
+## Motivation
+
+Before `PydanticModel`, the decorator was the only Pydantic path — at the cost
+of almost every DynamoDB feature. After PRs 3–6 that trade-off is gone.
+Keeping two Pydantic integration paths splits documentation and maintenance.
+
+## Scope
+
+In:
+
+- `DeprecationWarning` at decorator call time in:
+  - [python/pydynox/integrations/pydantic.py](../../../python/pydynox/integrations/pydantic.py)
+  - [python/pydynox/integrations/functions.py](../../../python/pydynox/integrations/functions.py)
+- Docstring deprecation notes on integration modules.
+- Migration guide: "Migrating from `@dynamodb_model` to `PydanticModel`".
+- Update [docs/guides/pydantic.md](../../../docs/guides/pydantic.md),
+  getting-started examples, README headline example where applicable.
+- Paired equivalence test: decorator model vs `PydanticModel` with equivalent
+  fields produces equivalent save/get behavior.
+- [CHANGELOG.md](../../../CHANGELOG.md) entry.
+
+Out:
+
+- Removing `@dynamodb_model` (future major).
+- Deprecating `JSONAttribute[M]` on plain `Model`.
+- Any change to plain `Model` API.
+
+## Warning message (sketch)
+
+```text
+@dynamodb_model is deprecated; subclass pydynox.PydanticModel instead.
+See docs/guides/pydantic.md#migrating-from-dynamodb_model
+```
+
+## Back-compat
+
+Decorator continues to work; warnings only.
+
+## Test plan
+
+- Warning emitted once per decorator application (or documented policy).
+- Existing decorator integration tests still pass.
+- Migration equivalence test from PR 6 scope.
+
+## Size
+
+S–M. Roughly 100–200 LOC code + docs.
+
+## Depends on / unblocks
+
+- Depends on: PR 6 (parity proven).
+- Unblocks: future major removal of decorator (not scheduled).

--- a/docs/refactor/pydantic-model/README.md
+++ b/docs/refactor/pydantic-model/README.md
@@ -1,0 +1,71 @@
+# Optional Pydantic integration refactor
+
+This folder collects the planning documents for giving pydynox users an
+**opt-in** path to Pydantic features (`Field(description=...)`, validators,
+JSON schema, `model_dump_json()`, ...) without changing the existing
+`Model` class and without forcing Pydantic as a required dependency.
+
+The refactor introduces a new `PydanticModel(Model, BaseModel)` sibling
+class. `Model` itself stays exactly as today. Pydantic stays behind the
+`pydynox[pydantic]` extra.
+
+## Status
+
+**Revised May 2026** after maintainer feedback on
+[issue #364](https://github.com/ferrumio/pydynox/issues/364). The original
+five-PR plan (global `DynamoConfig` rename, `Annotated` markers on plain
+`Model`, then `PydanticModel`) is superseded. See
+[00-plan-pivot.md](00-plan-pivot.md).
+
+Proposed. See [ADR 021](../../../ADR/021-pydantic-base-model.md).
+
+## Reading order
+
+1. **[overview.md](overview.md)** — motivation, architecture, rollout,
+   risks.
+2. **[00-plan-pivot.md](00-plan-pivot.md)** — why the plan changed; what
+   happened to closed PRs #365 and #366.
+3. **[01-extract-schema-collection.md](01-extract-schema-collection.md)** —
+   PR 1: internal refactor; extract helpers from `ModelMeta`.
+4. **[02-dynamo-markers.md](02-dynamo-markers.md)** — PR 2: full
+   `Annotated[T, Dynamo.*]` marker library for `PydanticModel` only.
+5. **[03-pydantic-model-core.md](03-pydantic-model-core.md)** — PR 3:
+   `PydanticModel` + combined metaclass + basic CRUD (pair with maintainer).
+6. **[04-fields-namespace.md](04-fields-namespace.md)** — PR 4: `cls.F`
+   on `PydanticModel` for conditions and atomic ops.
+7. **[05-lifecycle-shims.md](05-lifecycle-shims.md)** — PR 5: dirty
+   tracking, `to_dict`/`from_dict`, auto-generate hooks.
+8. **[06-parity-tests.md](06-parity-tests.md)** — PR 6: feature parity
+   matrix and gap fixes.
+9. **[07-deprecate-decorator.md](07-deprecate-decorator.md)** — PR 7:
+   deprecate `@dynamodb_model` and point users at `PydanticModel`.
+
+## At a glance
+
+| PR | Title | Breaking? | Size | Touches plain `Model`? |
+|----|-------|-----------|------|------------------------|
+| 0  | Revise plan docs (this PR) | no | S | no |
+| 1  | Extract schema collection helpers | no | S | internal only |
+| 2  | `Dynamo.*` markers (Pydantic path) | no | M | no |
+| 3  | `PydanticModel` core + metaclass | no | L | no (new class) |
+| 4  | `cls.F` namespace | no | M | no |
+| 5  | Lifecycle shims | no | M | no |
+| 6  | Parity tests | no | M–L | no |
+| 7  | Deprecate `@dynamodb_model` | no | S–M | warnings only |
+
+Every implementation PR ships on a minor version. No major-version bump
+required.
+
+## Conventions for these docs
+
+Each PR document uses the same sections:
+
+- **Title** + one-line summary
+- **Motivation**
+- **Scope** (in / out)
+- **Files touched**
+- **Public API changes** (before / after)
+- **Back-compat + deprecation notes**
+- **Test plan**
+- **Size estimate**
+- **Depends on / unblocks**

--- a/docs/refactor/pydantic-model/overview.md
+++ b/docs/refactor/pydantic-model/overview.md
@@ -1,0 +1,255 @@
+# Overview: Optional Pydantic integration via `PydanticModel`
+
+## Executive summary
+
+pydynox's `Model` today is a hand-rolled schema system built on class-body
+`Attribute` descriptors. It gives users a rich DynamoDB-aware API but no
+Pydantic ergonomics: you cannot attach `Field(description=...)`, you cannot
+add a `@field_validator`, you cannot emit a JSON schema, you cannot nest
+ordinary `BaseModel`s.
+
+The **sibling decorator path** (`@dynamodb_model` in
+[python/pydynox/integrations/pydantic.py](../../../python/pydynox/integrations/pydantic.py))
+gives you a real `BaseModel` but strips almost every DynamoDB feature:
+no aliases, no templates, no indexes, no hooks, no encryption, no TTL, no
+version, no discriminator, no atomic ops, no conditions, no `ModelConfig`.
+
+This refactor resolves the gap **without forcing Pydantic on users who do
+not want it**. `Model` stays exactly as today — no renames, no second field
+declaration style, no deprecation warnings. A new opt-in
+`PydanticModel(Model, BaseModel)` class gives Pydantic users the full
+DynamoDB feature set plus everything Pydantic provides. Pydantic itself
+stays behind the `pydynox[pydantic]` extra.
+
+## Motivation
+
+Concrete pain points this refactor addresses, for users who opt into
+Pydantic:
+
+1. **Docs and schema**: `Field(description=..., examples=..., json_schema_extra=...)`
+   for OpenAPI / MkDocs / admin UIs.
+2. **Validation**: `Field(pattern=..., ge=..., max_length=...)` and
+   `@field_validator` / `@model_validator` without writing custom Attribute
+   subclasses.
+3. **Serialization**: `model_dump_json()` / `model_validate_json()` out
+   of the box, without the current JSON re-serialization dance.
+4. **Nested models**: a Pydantic `BaseModel` can contain another `BaseModel`
+   directly; today you need `JSONAttribute[SomeModel]` and extra plumbing.
+5. **One canonical way for Pydantic users**: removes the recurring "should
+   I subclass `Model` or use `@dynamodb_model`?" question by deprecating
+   the decorator in favor of `PydanticModel`.
+
+Users who do not want Pydantic see **no dependency change and no API change**.
+
+## Current architecture
+
+```mermaid
+flowchart TD
+    UserClass["class User(Model)"] --> Meta["ModelMeta.__new__"]
+    Meta --> Collect["collect class body:\n- Attribute descriptors\n- GSI / LSI\n- @hook methods"]
+    Collect --> Dunders["populate class dunders:\n_attributes\n_partition_key / _sort_key\n_py_to_dynamo / _dynamo_to_py\n_indexes / _local_indexes\n_hooks\n_discriminator_registry"]
+
+    Dunders --> CRUD["CRUD\nmodel.py\n_internal/_model/*.py"]
+    Dunders --> GSILSI["GSI / LSI query\n_internal/_indexes.py"]
+    Dunders --> Tx["Transactions\ntransaction.py"]
+    Dunders --> Batch["Batch\nbatch_operations.py\n_internal/_model/_batch.py"]
+    Dunders --> TableOps["create_table / table_exists\nmodel.py"]
+    Dunders --> Metrics["Metrics / Collections"]
+
+    subgraph attrs [Attribute subclasses carry per-field behavior]
+      AttrBase["Attribute\nbase.py"]
+      AttrBase --> Prim["StringAttribute, NumberAttribute, ..."]
+      AttrBase --> Special["JSON / Enum / Datetime / TTL / Version"]
+      AttrBase --> Secure["Encrypted / Compressed / S3"]
+      AttrBase --> Sets["StringSet / NumberSet"]
+    end
+
+    Collect -.reads.-> attrs
+```
+
+Key properties we want to keep:
+
+- Downstream consumers (CRUD, GSI/LSI, transactions, batch, table ops,
+  metrics, hooks) read **only** the class dunders. They never touch the
+  descriptor protocol.
+- `Attribute.serialize` / `deserialize` is the only per-field customization
+  point that matters for DynamoDB wire format.
+- Indexes (`GlobalSecondaryIndex` / `LocalSecondaryIndex`) are plain class
+  attributes that `__set_name__` / `_bind_to_model` wire up.
+
+## Target architecture
+
+```mermaid
+flowchart TD
+    ModelBaseCls["ModelBase\nmetaclass ModelMeta"] --> Model["Model\nunchanged"]
+    BaseModel["pydantic.BaseModel\noptional install"]
+
+    Model --> PydMod["PydanticModel\nModel + BaseModel"]
+    BaseModel --> PydMod
+    PydMod --> CombMeta["_PydanticModelMeta\nModelMeta + ModelMetaclass"]
+
+    subgraph shared [Shared DynamoDB consumers, inherited from Model]
+      CRUD[CRUD]
+      GSILSI[GSI / LSI]
+      Tx[Transactions]
+      Batch[Batch]
+      TableOps[create_table]
+      Hooks[Hooks]
+      Metrics[Metrics]
+    end
+
+    Model --> shared
+    PydMod -.inherits.-> shared
+
+    subgraph collection [schema collection on PydanticModel only]
+      PydMeta["ModelMetaclass\npopulates model_fields"]
+      DynCollect["_collect_dynamodb_schema\nreads FieldInfo.metadata + Dynamo.*"]
+    end
+
+    PydMod --> PydMeta
+    PydMeta --> DynCollect
+    DynCollect --> DundersM["same class dunders\n_attributes, _py_to_dynamo,\n_indexes, _hooks, ..."]
+```
+
+Invariants after the refactor:
+
+- `Model` runs unchanged. Its existing users see zero behavior change.
+- `PydanticModel` populates the same class dunders `Model` consumers rely
+  on, so CRUD, GSI/LSI, transactions, batch, hooks, metrics, and
+  `create_table` all work without changes to those modules.
+- The same internal `Attribute` subclasses run for both paths. Nothing
+  about the wire format changes.
+- Pydantic is imported lazily only when `PydanticModel` is imported.
+
+## Feature mapping
+
+| Feature | `Model` (today and after) | `PydanticModel` (opt-in) |
+|---------|---------------------------|--------------------------|
+| Field declaration | Class-body `Attribute` descriptors | `Annotated[T, Dynamo.*]` + `Field(...)` |
+| DynamoDB config | `model_config = ModelConfig(...)` | `dynamodb_config: ClassVar[ModelConfig]` (name scoped to `PydanticModel`; plain `Model` unchanged) |
+| Pydantic config | n/a | `model_config = ConfigDict(...)` |
+| Conditions / atomic ops | `User.pk == "x"` | `User.F.pk == "x"` only |
+| `Field(description=...)`, validators, JSON schema | no | yes |
+| `model_dump_json()` / `model_validate_json()` | no | yes |
+| Nested `BaseModel` as a field | via `JSONAttribute[M]` | native |
+| GSI / LSI, composite keys, INCLUDE projection | yes | yes (inherited) |
+| Aliases, templates, AutoGenerate | yes | yes |
+| Encrypted / Compressed / S3 / Version / TTL / Sets / JSON / Enum / Datetime | yes | yes |
+| Discriminator, hooks, metrics, collections, transactions, batch | yes | yes (inherited) |
+| Dirty tracking (`is_dirty`, `changed_fields`) | yes | yes, cooperates with `validate_assignment` |
+
+## Config naming on `PydanticModel`
+
+Pydantic v2 reserves `model_config` on every `BaseModel` subclass. Its type
+is `ConfigDict`. Assigning pydynox's `ModelConfig(table="users")` there would
+be rejected or misread.
+
+`PydanticModel` subclasses therefore use a **separate** class attribute for
+DynamoDB settings:
+
+```python
+from typing import Annotated, ClassVar
+from pydantic import ConfigDict, Field
+from pydynox import PydanticModel, ModelConfig, Dynamo
+
+class User(PydanticModel):
+    dynamodb_config: ClassVar[ModelConfig] = ModelConfig(table="users")
+    model_config = ConfigDict(validate_assignment=True)
+
+    pk:   Annotated[str, Dynamo.partition_key()] = Field(description="User PK")
+    name: str = Field(description="Display name")
+```
+
+Plain `Model` users keep `model_config = ModelConfig(...)` with **no**
+rename and **no** deprecation warning.
+
+## Why `cls.F` for conditions and atomics
+
+Today `Attribute` is a class-level descriptor. `User.pk == "x"` returns a
+`ConditionComparison` via
+[attributes/base.py](../../../python/pydynox/attributes/base.py).
+
+Under Pydantic, class-level `User.pk` is a `FieldInfo` (or `AttributeError`)
+and the operator overloads are unavailable. `PydanticModel` cannot support
+the descriptor syntax.
+
+`PydanticModel` exposes `cls.F.pk == "x"` and `cls.F.counter.add(1)` via an
+`AttributeRef` namespace built from `_attributes`. Downstream consumers
+(`Transaction`, query builders, ...) already accept `Condition` and
+`AtomicOp` objects and need no changes.
+
+Plain `Model` keeps `User.pk == "x"` indefinitely. No `cls.F` requirement
+on `Model`.
+
+## Rollout
+
+All implementation PRs ship on minor versions. No breaking changes.
+
+```mermaid
+gantt
+    title Revised rollout (May 2026)
+    dateFormat X
+    axisFormat %s
+
+    section Prep
+    PR0 Docs pivot           : 0, 1
+    PR1 Extract helpers      : 1, 2
+
+    section PydanticModel
+    PR2 Dynamo markers       : 2, 3
+    PR3 Core + metaclass     : 3, 4
+    PR4 cls.F namespace      : 4, 5
+    PR5 Lifecycle shims       : 5, 6
+    PR6 Parity tests         : 6, 7
+
+    section Cleanup
+    PR7 Deprecate decorator  : 7, 8
+```
+
+- **PR 1** is an internal refactor with zero user-visible change.
+- **PRs 2–6** add and harden `PydanticModel` only.
+- **PR 7** deprecates `@dynamodb_model` once `PydanticModel` is proven.
+
+## Test strategy
+
+Cross-cutting rules:
+
+- Existing `Model` integration tests must pass unchanged after every PR.
+- **PR 3+**: add a parity suite (expanded in PR 6) comparing `Model` and
+  `PydanticModel` for byte-identical wire format and equivalent behavior.
+- **PR 5**: dirty tracking + `validate_assignment` regression tests.
+- **PR 7**: paired `@dynamodb_model` vs `PydanticModel` migration test.
+
+## Risk matrix
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Metaclass MRO conflict | High | Medium | Pair with maintainer on PR 3; expose `_PydanticModelMeta` for power users |
+| Dirty tracking breaks under `validate_assignment` | High | Medium | PR 5 `__setattr__` design + dedicated tests |
+| Template PK build ordering on `PydanticModel` | Medium | Medium | Reuse `_apply_auto_generate` + `_build_template_keys` via `@model_validator` |
+| Incomplete marker coverage | Medium | Medium | PR 2 ships full inventory before PR 3 merges |
+| Pydantic version float | Medium | Low | Pin `pydantic >= 2.5` in the `pydantic` extra |
+| Users forgetting `pydynox[pydantic]` extra | Low | Medium | Lazy import + clear `ImportError` naming the extra |
+
+## Out of scope
+
+- Schema migrations. The on-disk DynamoDB format does not change.
+- Changing anything in the Rust core ([src/](../../../src/)).
+- Global `ModelConfig` rename or `Annotated` markers on plain `Model`.
+- Modifying `Model` to use pydantic internally.
+
+## Open questions
+
+1. **`Dynamo.*` marker shape**: plain `@dataclass(frozen=True)` (no Pydantic
+   dependency in the marker module). Decide in PR 2.
+2. **`cls.F["pk"]` string lookup**: proposed yes for dynamic builders.
+   Decide in PR 4.
+3. **Keep `to_dict` / `from_dict` on `PydanticModel`?** Proposed yes as thin
+   wrappers for `Model` call-site compatibility. Decide in PR 5.
+4. **`PyDataclassModel`**: not now. Revisit only if requested.
+
+## References
+
+- Plan pivot: [00-plan-pivot.md](00-plan-pivot.md)
+- Maintainer feedback: [issue #364](https://github.com/ferrumio/pydynox/issues/364#issuecomment-4416367765)
+- ADR: [021-pydantic-base-model.md](../../../ADR/021-pydantic-base-model.md)


### PR DESCRIPTION
## Summary

- Adds ADR 021 and a revised refactor plan under `docs/refactor/pydantic-model/` aligned with maintainer feedback on #364.
- Supersedes the closed PR #365 / #366 approach (no global `DynamoConfig` rename, no `Annotated` markers on plain `Model`).
- Defines seven small implementation PRs centered on opt-in `PydanticModel` as a sibling class, with `cls.F`, markers, and config naming scoped to that class only.

## Test plan

- [x] Documentation-only change; no code or tests affected.
- [ ] Maintainer review of rollout sequence and PR boundaries before implementation PR 1.

Closes planning gap for #364.


Made with [Cursor](https://cursor.com)