### PR TITLE
fix: feed throttle events back into the rate limiter

### DIFF
--- a/docs/guides/rate-limiting.md
+++ b/docs/guides/rate-limiting.md
@@ -47,9 +47,32 @@ Use `AdaptiveRate` when you don't know the right rate, or when capacity varies. 
 How adaptive rate works:
 
 1. Starts at 50% of max rate
-2. When throttled, reduces by 20%
+2. When throttled, reduces by 20% and retries
 3. When no throttle for 10 seconds, increases by 10%
 4. Never goes below min or above max
+
+### Retry on throttling
+
+When a rate limiter is configured, a throttled operation is retried instead of failing
+straight away. Each retry lowers the rate first, so the next attempt waits longer for
+capacity: the backoff doubles from 0.1s up to 5s, for at most 10 attempts.
+
+```python
+client = DynamoDBClient(
+    region="us-east-1",
+    rate_limit=AdaptiveRate(max_rcu=100, max_wcu=10),
+)
+
+# Throttling now lowers the rate and retries instead of raising
+client.sync_put_item("users", item)
+```
+
+This is different from the retries the AWS SDK does on its own. The SDK retries at the
+same rate, because it doesn't know about the limiter. These retries feed the throttle
+back into the limiter, so the client slows itself down.
+
+Without a rate limiter nothing changes: `ProvisionedThroughputExceededException` is
+raised on the first throttle, so code that handles it keeps working.
 
 `AdaptiveRate` is good for:
 

--- a/python/pydynox/_internal/_throttle_retry.py
+++ b/python/pydynox/_internal/_throttle_retry.py
@@ -1,0 +1,93 @@
+"""Adaptive retry for throttled operations.
+
+The AWS SDK already retries throttling, but it retries blind: every attempt goes
+out at the same rate because the SDK knows nothing about the rate limiter. These
+decorators close that loop. On throttle they call ``_on_throttle()``, which drops
+the limiter rate by 20%, then retry. Because the retry re-runs the whole
+operation it also re-acquires capacity, so the next attempt waits on the slower
+token bucket instead of hammering the table at the old rate.
+
+Retry only happens when a rate limiter is configured. Without one there is no
+rate to lower, so the error propagates immediately, as it did before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypeVar
+
+if TYPE_CHECKING:
+    from pydynox.client._typing import _MixinBase
+
+T = TypeVar("T")
+
+# Backoff doubles from this value up to the cap.
+_INITIAL_BACKOFF_SECONDS = 0.1
+_MAX_BACKOFF_SECONDS = 5.0
+_MAX_ATTEMPTS = 10
+
+__all__ = ["retry_on_throttle", "sync_retry_on_throttle"]
+
+
+def _backoff_for(attempt: int) -> float:
+    """Backoff for a zero-based attempt number, capped at the maximum."""
+    return min(_INITIAL_BACKOFF_SECONDS * (2**attempt), _MAX_BACKOFF_SECONDS)
+
+
+def retry_on_throttle(
+    method: Callable[..., Awaitable[T]],
+) -> Callable[..., Awaitable[T]]:
+    """Retry an async operation while DynamoDB throttles it.
+
+    Lowers the limiter rate before each retry, so later attempts run slower.
+    Passes the error straight through when no rate limiter is configured.
+    """
+
+    @wraps(method)
+    async def wrapper(self: _MixinBase, *args: Any, **kwargs: Any) -> T:
+        from pydynox.exceptions import ProvisionedThroughputExceededException
+
+        if self._rate_limit is None:
+            return await method(self, *args, **kwargs)
+
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                return await method(self, *args, **kwargs)
+            except ProvisionedThroughputExceededException:
+                self._on_throttle()
+                if attempt == _MAX_ATTEMPTS - 1:
+                    raise
+                await asyncio.sleep(_backoff_for(attempt))
+
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    return wrapper
+
+
+def sync_retry_on_throttle(method: Callable[..., T]) -> Callable[..., T]:
+    """Retry a sync operation while DynamoDB throttles it.
+
+    Sync counterpart of :func:`retry_on_throttle`.
+    """
+
+    @wraps(method)
+    def wrapper(self: _MixinBase, *args: Any, **kwargs: Any) -> T:
+        from pydynox.exceptions import ProvisionedThroughputExceededException
+
+        if self._rate_limit is None:
+            return method(self, *args, **kwargs)
+
+        for attempt in range(_MAX_ATTEMPTS):
+            try:
+                return method(self, *args, **kwargs)
+            except ProvisionedThroughputExceededException:
+                self._on_throttle()
+                if attempt == _MAX_ATTEMPTS - 1:
+                    raise
+                time.sleep(_backoff_for(attempt))
+
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    return wrapper

--- a/python/pydynox/client/_batch.py
+++ b/python/pydynox/client/_batch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from pydynox._internal._logging import _log_debug
+from pydynox._internal._throttle_retry import retry_on_throttle, sync_retry_on_throttle
 from pydynox.client._typing import _MixinBase
 
 
@@ -13,6 +14,7 @@ class BatchOperations(_MixinBase):
 
     # ========== BATCH WRITE (ASYNC - default, no prefix) ==========
 
+    @retry_on_throttle
     async def batch_write(
         self,
         table: str,
@@ -39,6 +41,7 @@ class BatchOperations(_MixinBase):
 
     # ========== BATCH GET (ASYNC - default, no prefix) ==========
 
+    @retry_on_throttle
     async def batch_get(
         self,
         table: str,
@@ -58,6 +61,7 @@ class BatchOperations(_MixinBase):
 
     # ========== BATCH WRITE (SYNC - with sync_ prefix) ==========
 
+    @sync_retry_on_throttle
     def sync_batch_write(
         self,
         table: str,
@@ -85,6 +89,7 @@ class BatchOperations(_MixinBase):
 
     # ========== BATCH GET (SYNC - with sync_ prefix) ==========
 
+    @sync_retry_on_throttle
     def sync_batch_get(
         self,
         table: str,
@@ -104,6 +109,7 @@ class BatchOperations(_MixinBase):
 
     # ========== TRANSACT WRITE (SYNC) ==========
 
+    @sync_retry_on_throttle
     def sync_transact_write(self, operations: list[dict[str, Any]]) -> None:
         """Sync version of transact_write. Blocks until complete.
 
@@ -114,6 +120,7 @@ class BatchOperations(_MixinBase):
 
     # ========== TRANSACT GET (SYNC) ==========
 
+    @sync_retry_on_throttle
     def sync_transact_get(self, gets: list[dict[str, Any]]) -> list[dict[str, Any] | None]:
         """Sync version of transact_get. Blocks until complete.
 
@@ -141,6 +148,7 @@ class BatchOperations(_MixinBase):
 
     # ========== TRANSACT WRITE (ASYNC - default) ==========
 
+    @retry_on_throttle
     async def transact_write(self, operations: list[dict[str, Any]]) -> None:
         """Execute a transactional write operation.
 
@@ -151,6 +159,7 @@ class BatchOperations(_MixinBase):
 
     # ========== TRANSACT GET (ASYNC - default) ==========
 
+    @retry_on_throttle
     async def transact_get(self, gets: list[dict[str, Any]]) -> list[dict[str, Any] | None]:
         """Execute a transactional get operation.
 

--- a/python/pydynox/client/_crud.py
+++ b/python/pydynox/client/_crud.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, overload
 
 from pydynox._internal._logging import _log_debug, _log_operation, _log_warning
 from pydynox._internal._metrics import OperationMetrics
+from pydynox._internal._throttle_retry import retry_on_throttle, sync_retry_on_throttle
 from pydynox._internal._tracing import add_response_attributes, trace_operation
 from pydynox.client._typing import _MixinBase
 
@@ -104,6 +105,7 @@ class CrudOperations(_MixinBase):
         return_values: Literal["ALL_OLD"],
     ) -> dict[str, Any] | None: ...
 
+    @retry_on_throttle
     async def put_item(
         self,
         table: str,
@@ -188,6 +190,7 @@ class CrudOperations(_MixinBase):
         return_values: Literal["ALL_OLD"],
     ) -> dict[str, Any] | None: ...
 
+    @sync_retry_on_throttle
     def sync_put_item(
         self,
         table: str,
@@ -249,6 +252,7 @@ class CrudOperations(_MixinBase):
 
     # ========== GET ==========
 
+    @retry_on_throttle
     async def get_item(
         self,
         table: str,
@@ -296,6 +300,7 @@ class CrudOperations(_MixinBase):
         self._record_metrics(metrics, "get")
         return result["item"]
 
+    @sync_retry_on_throttle
     def sync_get_item(
         self,
         table: str,
@@ -373,6 +378,7 @@ class CrudOperations(_MixinBase):
         return_values: Literal["ALL_OLD"],
     ) -> dict[str, Any] | None: ...
 
+    @retry_on_throttle
     async def delete_item(
         self,
         table: str,
@@ -457,6 +463,7 @@ class CrudOperations(_MixinBase):
         return_values: Literal["ALL_OLD"],
     ) -> dict[str, Any] | None: ...
 
+    @sync_retry_on_throttle
     def sync_delete_item(
         self,
         table: str,
@@ -546,6 +553,7 @@ class CrudOperations(_MixinBase):
         return_values: Literal["ALL_OLD", "UPDATED_OLD", "ALL_NEW", "UPDATED_NEW"],
     ) -> dict[str, Any] | None: ...
 
+    @retry_on_throttle
     async def update_item(
         self,
         table: str,
@@ -640,6 +648,7 @@ class CrudOperations(_MixinBase):
         return_values: Literal["ALL_OLD", "UPDATED_OLD", "ALL_NEW", "UPDATED_NEW"],
     ) -> dict[str, Any] | None: ...
 
+    @sync_retry_on_throttle
     def sync_update_item(
         self,
         table: str,

--- a/python/pydynox/client/_typing.py
+++ b/python/pydynox/client/_typing.py
@@ -11,11 +11,13 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pydynox._internal._metrics import ModelMetrics, OperationMetrics
+    from pydynox.rate_limit import AdaptiveRate, FixedRate
 
     class _MixinBase:
         _client: Any  # pydynox_core.DynamoDBClient (Rust extension)
         _last_metrics: OperationMetrics | None
         _total_metrics: ModelMetrics
+        _rate_limit: FixedRate | AdaptiveRate | None
 
         def _acquire_rcu(self, rcu: float = 1.0) -> None: ...
         def _acquire_wcu(self, wcu: float = 1.0) -> None: ...

--- a/tests/unit/test_throttle_retry.py
+++ b/tests/unit/test_throttle_retry.py
@@ -1,0 +1,187 @@
+"""Tests for adaptive retry on throttling."""
+
+import pytest
+from pydynox._internal import _throttle_retry
+from pydynox._internal._throttle_retry import (
+    _MAX_ATTEMPTS,
+    _backoff_for,
+    retry_on_throttle,
+    sync_retry_on_throttle,
+)
+from pydynox.exceptions import ProvisionedThroughputExceededException
+from pydynox.rate_limit import AdaptiveRate
+
+
+class FakeClient:
+    """Minimal stand-in for a client with a rate limiter."""
+
+    def __init__(self, rate_limit=None, fail_times=0):
+        self._rate_limit = rate_limit
+        self._fail_times = fail_times
+        self.calls = 0
+        self.throttles = 0
+
+    def _on_throttle(self):
+        self.throttles += 1
+        if self._rate_limit is not None:
+            self._rate_limit._on_throttle()
+
+    @sync_retry_on_throttle
+    def sync_op(self):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise ProvisionedThroughputExceededException("throttled")
+        return "ok"
+
+    @retry_on_throttle
+    async def async_op(self):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise ProvisionedThroughputExceededException("throttled")
+        return "ok"
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Skip the real backoff waits so tests stay fast."""
+    monkeypatch.setattr(_throttle_retry.time, "sleep", lambda _: None)
+
+    async def fake_async_sleep(_):
+        return None
+
+    monkeypatch.setattr(_throttle_retry.asyncio, "sleep", fake_async_sleep)
+
+
+def test_sync_retries_until_success():
+    # GIVEN a client with a limiter whose first two calls are throttled
+    client = FakeClient(rate_limit=AdaptiveRate(max_rcu=100), fail_times=2)
+
+    # WHEN we run the operation
+    result = client.sync_op()
+
+    # THEN it retried and eventually succeeded
+    assert result == "ok"
+    assert client.calls == 3
+
+
+def test_sync_lowers_rate_before_retrying():
+    # GIVEN an adaptive limiter starting at half of max
+    limiter = AdaptiveRate(max_rcu=100)
+    assert limiter.current_rcu == 50.0
+    client = FakeClient(rate_limit=limiter, fail_times=2)
+
+    # WHEN two attempts are throttled
+    client.sync_op()
+
+    # THEN the rate dropped 20% per throttle (50 -> 40 -> 32)
+    assert limiter.current_rcu == 32.0
+    assert limiter.throttle_count == 2
+
+
+def test_sync_without_rate_limit_fails_fast():
+    # GIVEN a client with no rate limiter
+    client = FakeClient(rate_limit=None, fail_times=1)
+
+    # WHEN the operation is throttled
+    with pytest.raises(ProvisionedThroughputExceededException):
+        client.sync_op()
+
+    # THEN it was tried once, with no throttle feedback
+    assert client.calls == 1
+    assert client.throttles == 0
+
+
+def test_sync_gives_up_after_max_attempts():
+    # GIVEN a client that is always throttled
+    client = FakeClient(rate_limit=AdaptiveRate(max_rcu=100), fail_times=999)
+
+    # WHEN we run the operation
+    with pytest.raises(ProvisionedThroughputExceededException):
+        client.sync_op()
+
+    # THEN it stopped at the attempt limit and reported every throttle
+    assert client.calls == _MAX_ATTEMPTS
+    assert client.throttles == _MAX_ATTEMPTS
+
+
+def test_sync_passes_through_when_not_throttled():
+    # GIVEN a client that never fails
+    client = FakeClient(rate_limit=AdaptiveRate(max_rcu=100))
+
+    # WHEN we run the operation
+    result = client.sync_op()
+
+    # THEN it ran once with no retries
+    assert result == "ok"
+    assert client.calls == 1
+    assert client.throttles == 0
+
+
+@pytest.mark.asyncio
+async def test_async_retries_until_success():
+    # GIVEN a client with a limiter whose first two calls are throttled
+    client = FakeClient(rate_limit=AdaptiveRate(max_rcu=100), fail_times=2)
+
+    # WHEN we await the operation
+    result = await client.async_op()
+
+    # THEN it retried and eventually succeeded
+    assert result == "ok"
+    assert client.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_async_without_rate_limit_fails_fast():
+    # GIVEN a client with no rate limiter
+    client = FakeClient(rate_limit=None, fail_times=1)
+
+    # WHEN the operation is throttled
+    with pytest.raises(ProvisionedThroughputExceededException):
+        await client.async_op()
+
+    # THEN it was tried once
+    assert client.calls == 1
+    assert client.throttles == 0
+
+
+@pytest.mark.asyncio
+async def test_async_gives_up_after_max_attempts():
+    # GIVEN a client that is always throttled
+    client = FakeClient(rate_limit=AdaptiveRate(max_rcu=100), fail_times=999)
+
+    # WHEN we await the operation
+    with pytest.raises(ProvisionedThroughputExceededException):
+        await client.async_op()
+
+    # THEN it stopped at the attempt limit
+    assert client.calls == _MAX_ATTEMPTS
+
+
+def test_backoff_doubles_then_caps():
+    # GIVEN the documented backoff schedule
+    # WHEN we compute the first attempts
+    # THEN it doubles from 0.1s
+    assert _backoff_for(0) == 0.1
+    assert _backoff_for(1) == 0.2
+    assert _backoff_for(2) == 0.4
+
+    # AND it never exceeds the 5s cap
+    assert _backoff_for(20) == 5.0
+
+
+def test_other_errors_are_not_retried():
+    # GIVEN a client whose operation raises an unrelated error
+    class Boom(FakeClient):
+        @sync_retry_on_throttle
+        def sync_op(self):
+            self.calls += 1
+            raise ValueError("not a throttle")
+
+    client = Boom(rate_limit=AdaptiveRate(max_rcu=100))
+
+    # WHEN we run it
+    with pytest.raises(ValueError):
+        client.sync_op()
+
+    # THEN it was not retried
+    assert client.calls == 1


### PR DESCRIPTION
_on_throttle() was defined on the client and exposed from Rust, but never called from any operation. Only 1 of the 4 documented AdaptiveRate steps worked: the rate went up after 10 quiet seconds, never down, and throttle_count stayed at 0. AdaptiveRate was not adaptive.

Add retry_on_throttle / sync_retry_on_throttle and apply them to the 16 CRUD, batch and transact operations. On throttle they call _on_throttle() to drop the rate 20%, then retry with backoff doubling from 0.1s to 5s, for at most 10 attempts.

The decorators wrap the whole method rather than just the Rust call, so a retry also re-acquires capacity. Otherwise the lowered rate would never be felt by the next attempt. This is what separates it from the AWS SDK retries, which go out at the same rate because the SDK knows nothing about the limiter.

Retry only happens when a rate limiter is configured. Without one the exception propagates on the first throttle, as before.

Closes #32