### PR TITLE
feat: add DynamoDB vector search support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "pydynox"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.18"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
+checksum = "47712fde1909402600ccfbb26e47d482d2e58bb9e9e603d9f17e67cc435a6319"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -106,11 +106,11 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -161,15 +161,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-eventstream 0.61.2",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -189,19 +189,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.115.0"
+version = "1.120.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715fd8729709daa491b2d4aeed33e576d76031c164ad34b65062ea585d97ad5e"
+checksum = "f578638cafe182113da770e9798e7063d6de96cbbfe06f647d0026f197c9b97c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -210,6 +211,7 @@ dependencies = [
  "http 1.4.0",
  "regex-lite",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -222,9 +224,9 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -248,14 +250,14 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-checksums",
- "aws-smithy-eventstream",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.7",
+ "aws-smithy-observability 0.2.6",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-xml 0.60.15",
  "aws-types",
  "bytes",
  "fastrand",
@@ -274,19 +276,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.101.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
+checksum = "c15301b04372832947916607983b114b3374b9db0be058a00fb7513800de1f05"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -299,19 +302,20 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.103.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
+checksum = "72cc2c205cb27108183cf1856333f7d584c2ba0f505421b4209ca5828f9ea899"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "aws-types",
  "bytes",
@@ -324,22 +328,23 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.106.0"
+version = "1.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
+checksum = "68182ecb449f7537db0f4d5d25917789cf41e32074a9fe47b6a0b847fe1d2032"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-observability",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json 0.63.0",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-query",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
- "aws-smithy-xml",
+ "aws-smithy-xml 0.62.0",
  "aws-types",
  "fastrand",
  "http 0.2.12",
@@ -350,13 +355,13 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-eventstream 0.61.2",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -377,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -392,7 +397,7 @@ version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -419,12 +424,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6de526c7b567420a31bc283657a7921b45c4cafe0827fdf2490713dcc770c28f"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
- "aws-smithy-eventstream",
+ "aws-smithy-eventstream 0.60.20",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -442,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -471,7 +508,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.1.0",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
 ]
 
@@ -485,27 +533,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-query"
-version = "0.60.15"
+name = "aws-smithy-observability"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
 dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
+ "aws-smithy-xml 0.62.0",
  "urlencoding",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.64.0",
  "aws-smithy-http-client",
- "aws-smithy-observability",
+ "aws-smithy-observability 0.3.0",
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "bytes",
  "fastrand",
@@ -522,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -540,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -561,10 +621,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.9"
+name = "aws-smithy-schema"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -596,15 +667,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-types"
-version = "1.3.16"
+name = "aws-smithy-xml"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema 0.2.0",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
- "aws-smithy-schema",
+ "aws-smithy-schema 0.2.0",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -1880,6 +1963,7 @@ dependencies = [
  "aws-sdk-kms",
  "aws-sdk-s3",
  "aws-sdk-sts",
+ "aws-types",
  "base64 0.23.1",
  "chrono",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pydynox"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.94.1"
 authors = ["Leandro Cavalcante Damascena <leandro.damascena@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pydynox"
 version = "1.3.1"
 edition = "2024"
+rust-version = "1.94.1"
 authors = ["Leandro Cavalcante Damascena <leandro.damascena@gmail.com>"]
 description = "A fast DynamoDB ORM for Python with a Rust core"
 license = "Apache-2.0"
@@ -20,11 +21,12 @@ path = "src/lib.rs"
 [dependencies]
 pyo3 = { version = "0.29", features = ["extension-module", "multiple-pymethods"] }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
-aws-sdk-dynamodb = { version = "1.113", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-sdk-dynamodb = { version = "=1.120.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-kms = { version = "1.109", default-features = false, features = ["default-https-client", "rt-tokio"] }
 aws-sdk-s3 = { version = "1.134", default-features = false, features = ["default-https-client", "rt-tokio", "sigv4a"] }
 aws-sdk-sts = { version = "1.105", default-features = false, features = ["default-https-client", "rt-tokio"] }
-aws-config = { version = "1.8", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
+aws-types = "1.5"
+aws-config = { version = "=1.9.0", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio", "credentials-process", "sso"] }
 tokio = { version = "1", features = [
     "rt-multi-thread",
     "sync",

--- a/docs/examples/vector/vector_search.py
+++ b/docs/examples/vector/vector_search.py
@@ -1,0 +1,47 @@
+"""Store embeddings and run a filtered vector search."""
+
+import asyncio
+
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute, VectorAttribute
+from pydynox.indexes import VectorDistance, VectorIndex
+
+
+class Product(Model):
+    model_config = ModelConfig(table="products")
+
+    pk = StringAttribute(partition_key=True)
+    tenant_id = StringAttribute()
+    category = StringAttribute()
+    language = StringAttribute()
+    name = StringAttribute()
+    embedding = VectorAttribute(dimensions=3, required=True)
+
+    semantic = VectorIndex(
+        index_name="semantic-index",
+        vector_attribute="embedding",
+        distance=VectorDistance.COSINE,
+        partition_key="tenant_id",
+        inline_filters=["category", "language"],
+        projection=["name", "category", "language"],
+    )
+
+
+async def main() -> None:
+    query_vector = [0.12, -0.44, 0.91]
+    matches = await Product.semantic.search(
+        query_vector,
+        partition_key="TENANT#acme",
+        where=(Product.category == "books") & (Product.language == "en"),
+        top_k=10,
+        as_dict=True,
+    )
+
+    for match in matches:
+        print(match.item["name"], match.score)
+
+    print(matches.metrics.vector_search_bytes)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/guides/attributes.md
+++ b/docs/guides/attributes.md
@@ -12,6 +12,7 @@ Attributes define the fields in your model. Each attribute maps to a DynamoDB ty
 | `BinaryAttribute` | B | bytes | Files, images |
 | `ListAttribute` | L | list | Ordered items |
 | `MapAttribute` | M | dict | Nested objects |
+| `VectorAttribute` | L | list[float] | Embeddings for vector search |
 | `JSONAttribute` | S | dict, list | Complex JSON |
 | `EnumAttribute` | S | Enum | Status, types |
 | `DatetimeAttribute` | S | datetime | Timestamps (ISO) |
@@ -164,6 +165,30 @@ user = User(
     address={"street": "123 Main St", "city": "NYC", "zip": "10001"}
 )
 ```
+
+### VectorAttribute
+
+Store a fixed-size vector as a DynamoDB list of numbers. Values are validated
+against the declared dimensions and converted to 32-bit floating-point
+precision.
+
+```python
+from pydynox.attributes import VectorAttribute
+
+
+class Document(Model):
+    model_config = ModelConfig(table="documents")
+
+    pk = StringAttribute(partition_key=True)
+    embedding = VectorAttribute(dimensions=1024, required=True, alias="emb")
+```
+
+`VectorAttribute` rejects incorrect dimensions, booleans, non-numeric values,
+`NaN`, infinity, and values outside the float32 range. Objects with a
+one-dimensional `tolist()` result are accepted without requiring NumPy.
+
+See [Vector search](vector-search.md) to define a `VectorIndex` and search the
+stored embeddings.
 
 ## JSON and enum types
 

--- a/docs/guides/operations-metrics.md
+++ b/docs/guides/operations-metrics.md
@@ -1,6 +1,34 @@
 # Operations metrics
 
-Track KMS and S3 API calls alongside your DynamoDB operations. When you use encryption or large object storage, pydynox measures the time and calls to these services.
+Track DynamoDB vector capacity, KMS calls, and S3 API calls alongside your
+operations.
+
+## Vector metrics
+
+Vector search and vector index writes use separate capacity measurements.
+`OperationMetrics` exposes both values:
+
+```python
+matches = await Product.semantic.search(query_vector, top_k=10)
+
+print(matches.metrics.vector_search_bytes)
+print(matches.metrics.duration_ms)
+print(matches.metrics.request_id)
+
+await product.save()
+metrics = Product.get_last_metrics()
+if metrics:
+    print(metrics.vector_write_bytes)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `vector_search_bytes` | float \| None | Search request bytes consumed |
+| `vector_write_bytes` | float \| None | Vector index write bytes consumed |
+
+Search results expose metrics through `VectorSearchResult.metrics`. Put,
+update, and delete operations expose vector write capacity through their
+normal operation metrics.
 
 ## Why track operations metrics
 
@@ -172,4 +200,5 @@ def handler(event, context):
 
 - [Encryption](encryption.md) - Field-level encryption with KMS
 - [S3 attribute](s3-attribute.md) - Store large objects in S3
+- [Vector search](vector-search.md) - Store and search embeddings
 - [Observability](observability.md) - DynamoDB metrics and logging

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -160,11 +160,40 @@ The memory backend supports:
 | `scan()` | ✓ |
 | `batch_write()` | ✓ |
 | `batch_get()` | ✓ |
+| Vector search | ✓ |
+| Vector index lifecycle | ✓ |
 | Conditions | ✓ |
 | Atomic updates | ✓ |
 
 !!! note
     Some advanced features like transactions and GSI queries are not yet supported in the memory backend. Use localstack for those cases.
+
+### Vector search
+
+The memory backend performs exact, deterministic vector search for cosine
+distance, Euclidean distance, and dot product. It also supports vector
+partition keys, equality-only inline filters, projections, and `top_k`.
+
+```python
+with MemoryBackend():
+    Product(
+        pk="PRODUCT#1",
+        tenant_id="TENANT#acme",
+        embedding=[1.0, 0.0],
+    ).sync_save()
+
+    matches = Product.semantic.sync_search(
+        [0.9, 0.1],
+        partition_key="TENANT#acme",
+        top_k=1,
+    )
+
+    assert matches[0].item.pk == "PRODUCT#1"
+```
+
+The memory backend uses exact search. Production vector indexes may not return
+the same ordering for vectors with nearly identical scores, so tests should
+avoid near-ties.
 
 ## Comparison with alternatives
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -176,6 +176,8 @@ partition keys, equality-only inline filters, projections, and `top_k`.
 
 ```python
 with MemoryBackend():
+    Product.sync_create_table()
+
     Product(
         pk="PRODUCT#1",
         tenant_id="TENANT#acme",
@@ -193,7 +195,8 @@ with MemoryBackend():
 
 The memory backend uses exact search. Production vector indexes may not return
 the same ordering for vectors with nearly identical scores, so tests should
-avoid near-ties.
+avoid near-ties. Create the table or index in the test before searching; model
+declarations are not auto-discovered as live indexes.
 
 ## Comparison with alternatives
 

--- a/docs/guides/vector-search.md
+++ b/docs/guides/vector-search.md
@@ -41,7 +41,9 @@ semantic = VectorIndex(
 | `projection` | `"ALL"`, `"KEYS_ONLY"`, or a list of attributes |
 
 Aliases are applied when pydynox builds the index definition and search
-expressions.
+expressions. Vector partition keys and inline filters must use scalar DynamoDB
+types (`S`, `N`, or `B`). Their values are serialized through the model
+attribute before a search request is sent.
 
 ## Create the table
 
@@ -55,7 +57,12 @@ Vector indexes require `PAY_PER_REQUEST` billing. Passing
 `billing_mode="PROVISIONED"` fails before the request is sent.
 
 With `wait=True`, pydynox waits for the table and vector indexes to become
-active and for index backfill to finish.
+active and for index backfill to finish. Set `timeout_seconds` to override the
+default wait timeout:
+
+```python
+await Product.create_table(wait=True, timeout_seconds=1200)
+```
 
 ## Search
 
@@ -126,8 +133,10 @@ Unsupported expressions fail locally before pydynox sends a request.
 
 ## Partial projections
 
-Search returns model instances by default. Use `as_dict=True` when the index
-projection does not contain every field required to construct the model:
+Search returns model instances by default and explicitly requests the vector
+attribute plus every model field available through the index projection. If a
+required model field is not available, pydynox raises before sending the
+request. Use `as_dict=True` for intentionally partial results:
 
 ```python
 matches = await Product.semantic.search(
@@ -140,12 +149,16 @@ matches = await Product.semantic.search(
 print(matches[0].item["name"])
 ```
 
+Raw dictionary searches use DynamoDB's default vector-search projection, which
+does not include the vector attribute unless it is explicitly requested through
+the client-level `projection_expression`.
+
 ## Existing tables
 
 Create, inspect, or delete a declared vector index on an existing table:
 
 ```python
-await Product.semantic.create(wait=True)
+await Product.semantic.create(wait=True, timeout_seconds=1200)
 
 info = await Product.semantic.describe()
 print(info.status)
@@ -153,7 +166,7 @@ print(info.backfilling)
 print(info.item_count)
 print(info.size_bytes)
 
-await Product.semantic.delete(wait=True)
+await Product.semantic.delete(wait=True, timeout_seconds=1200)
 ```
 
 Sync equivalents are available:
@@ -184,6 +197,30 @@ result = await client.search_vectors(
 `sync_search_vectors()` provides the synchronous equivalent. Client-level
 matches contain dictionaries instead of model instances.
 
+For client-level index creation, include the DynamoDB scalar types for every
+partition key and inline filter:
+
+```python
+await client.create_vector_index(
+    "products",
+    {
+        "index_name": "semantic-index",
+        "vector_attribute": "embedding",
+        "dimensions": 1536,
+        "distance_function": "COSINE",
+        "partition_key": "tenant_id",
+        "inline_filters": ["category"],
+        "attribute_definitions": [
+            ("tenant_id", "S"),
+            ("category", "S"),
+        ],
+        "projection": "ALL",
+    },
+    wait=True,
+    timeout_seconds=1200,
+)
+```
+
 ## Testing
 
 `MemoryBackend` performs exact vector search without DynamoDB:
@@ -193,6 +230,8 @@ from pydynox.testing import MemoryBackend
 
 
 with MemoryBackend():
+    Product.sync_create_table()
+
     Product(
         pk="PRODUCT#1",
         tenant_id="TENANT#acme",
@@ -210,7 +249,9 @@ with MemoryBackend():
 ```
 
 The memory backend supports cosine distance, Euclidean distance, dot product,
-partition keys, equality filters, projections, and `top_k`.
+partition keys, equality filters, projections, and `top_k`. Vector indexes are
+registered only by table creation or explicit index lifecycle calls; merely
+declaring an index on a model does not create it.
 
 ## Validation and limits
 

--- a/docs/guides/vector-search.md
+++ b/docs/guides/vector-search.md
@@ -1,0 +1,239 @@
+# Vector search
+
+pydynox can store fixed-size embeddings, define DynamoDB vector indexes, and
+run similarity searches through the model or client APIs. It stores and
+searches vectors; it does not generate embeddings.
+
+## Define a vector model
+
+Use `VectorAttribute` for the embedding and `VectorIndex` for the search
+configuration:
+
+=== "vector_search.py"
+    ```python
+    --8<-- "docs/examples/vector/vector_search.py"
+    ```
+
+`dimensions` must match the embedding model output. The attribute accepts
+sequences of integers or floats and objects with a one-dimensional
+`tolist()` result.
+
+## Vector index options
+
+```python
+semantic = VectorIndex(
+    index_name="semantic-index",
+    vector_attribute="embedding",
+    distance=VectorDistance.COSINE,
+    partition_key="tenant_id",
+    inline_filters=["category"],
+    projection=["name", "category"],
+)
+```
+
+| Option | Description |
+|--------|-------------|
+| `index_name` | DynamoDB vector index name |
+| `vector_attribute` | Model attribute containing the vector |
+| `distance` | `COSINE`, `EUCLIDEAN`, or `DOT_PRODUCT` |
+| `partition_key` | Optional vector partition key |
+| `inline_filters` | Attributes allowed in search filters |
+| `projection` | `"ALL"`, `"KEYS_ONLY"`, or a list of attributes |
+
+Aliases are applied when pydynox builds the index definition and search
+expressions.
+
+## Create the table
+
+Declared vector indexes are included in model table creation:
+
+```python
+await Product.create_table(wait=True)
+```
+
+Vector indexes require `PAY_PER_REQUEST` billing. Passing
+`billing_mode="PROVISIONED"` fails before the request is sent.
+
+With `wait=True`, pydynox waits for the table and vector indexes to become
+active and for index backfill to finish.
+
+## Search
+
+Async is the default API:
+
+```python
+matches = await Product.semantic.search(
+    query_vector,
+    partition_key="TENANT#acme",
+    where=Product.category == "books",
+    top_k=10,
+)
+
+for match in matches:
+    print(match.item.name, match.score)
+```
+
+Use the `sync_` prefix in synchronous code:
+
+```python
+matches = Product.semantic.sync_search(
+    query_vector,
+    partition_key="TENANT#acme",
+    where=Product.category == "books",
+    top_k=10,
+)
+```
+
+If an index defines `partition_key`, every search must provide a value. An
+index without a vector partition key searches the complete index.
+
+`top_k` must be between 1 and 100. Results preserve the score and ordering
+returned by DynamoDB:
+
+```python
+match = matches[0]
+match.item
+match.score
+
+matches.metrics.duration_ms
+matches.metrics.request_id
+matches.metrics.vector_search_bytes
+```
+
+For cosine and Euclidean distance, smaller scores are closer. For dot product,
+larger scores rank first.
+
+## Inline filters
+
+`where` uses the normal pydynox condition API:
+
+```python
+matches = await Product.semantic.search(
+    query_vector,
+    partition_key="TENANT#acme",
+    where=(Product.category == "books") & (Product.language == "en"),
+)
+```
+
+The initial filter support accepts:
+
+- Equality comparisons
+- `AND` combinations
+- Top-level attributes
+- Attributes declared in `inline_filters`
+
+Unsupported expressions fail locally before pydynox sends a request.
+
+## Partial projections
+
+Search returns model instances by default. Use `as_dict=True` when the index
+projection does not contain every field required to construct the model:
+
+```python
+matches = await Product.semantic.search(
+    query_vector,
+    partition_key="TENANT#acme",
+    top_k=5,
+    as_dict=True,
+)
+
+print(matches[0].item["name"])
+```
+
+## Existing tables
+
+Create, inspect, or delete a declared vector index on an existing table:
+
+```python
+await Product.semantic.create(wait=True)
+
+info = await Product.semantic.describe()
+print(info.status)
+print(info.backfilling)
+print(info.item_count)
+print(info.size_bytes)
+
+await Product.semantic.delete(wait=True)
+```
+
+Sync equivalents are available:
+
+```python
+Product.semantic.sync_create(wait=True)
+info = Product.semantic.sync_describe()
+Product.semantic.sync_delete(wait=True)
+```
+
+## Client-level API
+
+Use `DynamoDBClient` directly when no model is involved:
+
+```python
+result = await client.search_vectors(
+    table="products",
+    index_name="semantic-index",
+    vector=query_vector,
+    top_k=10,
+    search_condition_expression="#tenant = :tenant",
+    expression_attribute_names={"#tenant": "tenant_id"},
+    expression_attribute_values={":tenant": "TENANT#acme"},
+    projection_expression="pk, #name",
+)
+```
+
+`sync_search_vectors()` provides the synchronous equivalent. Client-level
+matches contain dictionaries instead of model instances.
+
+## Testing
+
+`MemoryBackend` performs exact vector search without DynamoDB:
+
+```python
+from pydynox.testing import MemoryBackend
+
+
+with MemoryBackend():
+    Product(
+        pk="PRODUCT#1",
+        tenant_id="TENANT#acme",
+        category="books",
+        embedding=[1.0, 0.0],
+    ).sync_save()
+
+    matches = Product.semantic.sync_search(
+        [0.9, 0.1],
+        partition_key="TENANT#acme",
+        top_k=1,
+    )
+
+    assert matches[0].item.pk == "PRODUCT#1"
+```
+
+The memory backend supports cosine distance, Euclidean distance, dot product,
+partition keys, equality filters, projections, and `top_k`.
+
+## Validation and limits
+
+- Dimensions: 1 to 4096
+- `top_k`: 1 to 100
+- Inline filters: up to 18 per index
+- Vector indexes per table: 5 by default
+- Vector values: finite numbers representable as float32
+- Capacity mode: on-demand
+- Search consistency: eventual
+- Search pagination: not supported
+- Search response size: up to 16 MB
+
+Applications need `dynamodb:SearchVectors` permission for searches and the
+normal DynamoDB table permissions for index lifecycle and writes.
+
+Vector search and vector index writes are billed by their dedicated byte
+capacity metrics. See the
+[DynamoDB pricing page](https://aws.amazon.com/dynamodb/pricing/) for current
+rates.
+
+## Next steps
+
+- [Attribute types](attributes.md) - Vector validation and aliases
+- [Operations metrics](operations-metrics.md) - Search and write capacity
+- [Testing](testing.md) - Exact in-memory vector search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pydynox"
-version = "1.3.1"
+version = "1.4.0"
 description = "A fast DynamoDB ORM for Python with a Rust core"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/pydynox/_internal/_model/_base.py
+++ b/python/pydynox/_internal/_model/_base.py
@@ -98,6 +98,15 @@ class ModelMeta(type):
             if base_vector_indexes is not None:
                 vector_indexes.update(base_vector_indexes)
 
+        for attr_name, index in list(vector_indexes.items()):
+            if attr_name in namespace:
+                if not isinstance(namespace[attr_name], VectorIndex):
+                    vector_indexes.pop(attr_name)
+                continue
+            cloned_index = index._clone_unbound()
+            namespace[attr_name] = cloned_index
+            vector_indexes[attr_name] = cloned_index
+
         for attr_name, attr_value in namespace.items():
             if isinstance(attr_value, Attribute):
                 attr_value.attr_name = attr_name

--- a/python/pydynox/_internal/_model/_base.py
+++ b/python/pydynox/_internal/_model/_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar, cast
 
 from pydynox._internal._indexes import GlobalSecondaryIndex, LocalSecondaryIndex
+from pydynox._internal._vector import VectorIndex
 from pydynox.attributes import Attribute
 from pydynox.config import ModelConfig, get_default_client
 from pydynox.generators import generate_value, is_auto_generate
@@ -38,6 +39,7 @@ class ModelMeta(type):
     _hooks: dict[HookType, list[Any]]
     _indexes: dict[str, GlobalSecondaryIndex[Any]]
     _local_indexes: dict[str, LocalSecondaryIndex[Any]]
+    _vector_indexes: dict[str, VectorIndex[Any]]
     _metrics_storage: "MetricsStorage"
     _py_to_dynamo: dict[str, str]
     _dynamo_to_py: dict[str, str]
@@ -51,6 +53,7 @@ class ModelMeta(type):
         hooks: dict[HookType, list[Any]] = {hook_type: [] for hook_type in HookType}
         indexes: dict[str, GlobalSecondaryIndex[Any]] = {}
         local_indexes: dict[str, LocalSecondaryIndex[Any]] = {}
+        vector_indexes: dict[str, VectorIndex[Any]] = {}
 
         for base in bases:
             base_attrs = getattr(base, "_attributes", None)
@@ -91,6 +94,9 @@ class ModelMeta(type):
             base_local_indexes = getattr(base, "_local_indexes", None)
             if base_local_indexes is not None:
                 local_indexes.update(base_local_indexes)
+            base_vector_indexes = getattr(base, "_vector_indexes", None)
+            if base_vector_indexes is not None:
+                vector_indexes.update(base_vector_indexes)
 
         for attr_name, attr_value in namespace.items():
             if isinstance(attr_value, Attribute):
@@ -113,6 +119,9 @@ class ModelMeta(type):
             if isinstance(attr_value, LocalSecondaryIndex):
                 local_indexes[attr_name] = attr_value
 
+            if isinstance(attr_value, VectorIndex):
+                vector_indexes[attr_name] = attr_value
+
         cls = super().__new__(mcs, name, bases, namespace)
 
         cls._attributes = attributes
@@ -123,6 +132,7 @@ class ModelMeta(type):
         cls._hooks = hooks
         cls._indexes = indexes
         cls._local_indexes = local_indexes
+        cls._vector_indexes = vector_indexes
 
         # Build alias lookup dicts
         py_to_dynamo: dict[str, str] = {}
@@ -165,6 +175,9 @@ class ModelMeta(type):
         for idx in local_indexes.values():
             idx._bind_to_model(cls)
 
+        for idx in vector_indexes.values():
+            idx._bind_to_model(cls)
+
         return cls
 
 
@@ -183,6 +196,7 @@ class ModelBase(metaclass=ModelMeta):
     _hooks: ClassVar[dict[HookType, list[Any]]]
     _indexes: ClassVar[dict[str, GlobalSecondaryIndex[Any]]]
     _local_indexes: ClassVar[dict[str, LocalSecondaryIndex[Any]]]
+    _vector_indexes: ClassVar[dict[str, VectorIndex[Any]]]
     _client_instance: ClassVar[DynamoDBClient | None] = None
     _metrics_storage: ClassVar["MetricsStorage"]
     _py_to_dynamo: ClassVar[dict[str, str]]

--- a/python/pydynox/_internal/_tracing.py
+++ b/python/pydynox/_internal/_tracing.py
@@ -24,6 +24,7 @@ OPERATION_NAMES = {
     "batch_get": "BatchGetItem",
     "transact_write": "TransactWriteItems",
     "transact_get": "TransactGetItems",
+    "search_vectors": "SearchVectors",
 }
 
 
@@ -245,6 +246,9 @@ def add_response_attributes(
     consumed_rcu: float | None = None,
     consumed_wcu: float | None = None,
     request_id: str | None = None,
+    vector_search_bytes: float | None = None,
+    vector_write_bytes: float | None = None,
+    returned_rows: int | None = None,
 ) -> None:
     """Add response attributes to a span.
 
@@ -253,6 +257,9 @@ def add_response_attributes(
         consumed_rcu: Read capacity units consumed.
         consumed_wcu: Write capacity units consumed.
         request_id: AWS request ID.
+        vector_search_bytes: Vector search request bytes consumed.
+        vector_write_bytes: Vector write request bytes consumed.
+        returned_rows: Number of rows returned.
     """
     if span is None:
         return
@@ -267,3 +274,9 @@ def add_response_attributes(
         span.set_attribute("aws.dynamodb.consumed_capacity.write", consumed_wcu)
     if request_id is not None:
         span.set_attribute("aws.request_id", request_id)
+    if vector_search_bytes is not None:
+        span.set_attribute("aws.dynamodb.vector_search_bytes", vector_search_bytes)
+    if vector_write_bytes is not None:
+        span.set_attribute("aws.dynamodb.vector_write_bytes", vector_write_bytes)
+    if returned_rows is not None:
+        span.set_attribute("db.response.returned_rows", returned_rows)

--- a/python/pydynox/_internal/_vector.py
+++ b/python/pydynox/_internal/_vector.py
@@ -1,0 +1,365 @@
+"""Internal vector index implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from pydynox._internal._conditions import ConditionAnd, ConditionComparison
+from pydynox.attributes.vector import VectorAttribute
+
+if TYPE_CHECKING:
+    from pydynox._internal._metrics import OperationMetrics
+    from pydynox.conditions import Condition
+    from pydynox.model import Model
+
+M = TypeVar("M", bound="Model")
+T = TypeVar("T")
+
+
+class VectorDistance(StrEnum):
+    """Distance functions supported by DynamoDB vector indexes."""
+
+    COSINE = "COSINE"
+    EUCLIDEAN = "EUCLIDEAN"
+    DOT_PRODUCT = "DOT_PRODUCT"
+
+
+@dataclass(frozen=True)
+class VectorMatch(Generic[T]):
+    """One item returned by a vector search."""
+
+    item: T
+    score: float
+
+
+class VectorSearchResult(list[VectorMatch[T]], Generic[T]):
+    """Vector matches with operation metrics."""
+
+    def __init__(
+        self,
+        matches: list[VectorMatch[T]],
+        metrics: OperationMetrics,
+    ) -> None:
+        super().__init__(matches)
+        self.metrics = metrics
+
+
+@dataclass(frozen=True)
+class VectorIndexInfo:
+    """Current state of a DynamoDB vector index."""
+
+    index_name: str
+    status: str | None
+    backfilling: bool | None
+    item_count: int | None
+    size_bytes: int | None
+    index_arn: str | None
+    dimensions: int | None
+    distance: VectorDistance | None
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> VectorIndexInfo:
+        raw_distance = value.get("distance")
+        return cls(
+            index_name=value["index_name"],
+            status=value.get("status"),
+            backfilling=value.get("backfilling"),
+            item_count=value.get("item_count"),
+            size_bytes=value.get("size_bytes"),
+            index_arn=value.get("index_arn"),
+            dimensions=value.get("dimensions"),
+            distance=VectorDistance(raw_distance) if raw_distance else None,
+        )
+
+
+class VectorIndex(Generic[M]):
+    """A DynamoDB vector index bound to a model."""
+
+    def __init__(
+        self,
+        index_name: str,
+        vector_attribute: str,
+        *,
+        distance: VectorDistance | str = VectorDistance.COSINE,
+        partition_key: str | None = None,
+        inline_filters: list[str] | None = None,
+        projection: str | list[str] = "ALL",
+    ) -> None:
+        if not index_name:
+            raise ValueError("index_name is required")
+        if not vector_attribute:
+            raise ValueError("vector_attribute is required")
+
+        self.index_name = index_name
+        self.vector_attribute = vector_attribute
+        self.distance = VectorDistance(distance)
+        self.partition_key = partition_key
+        self.inline_filters = list(inline_filters or [])
+        self.projection = projection
+
+        if len(self.inline_filters) > 18:
+            raise ValueError(f"Vector index '{index_name}' supports at most 18 inline filters")
+        if len(set(self.inline_filters)) != len(self.inline_filters):
+            raise ValueError(f"Vector index '{index_name}' contains duplicate inline filters")
+        if partition_key is not None and partition_key in self.inline_filters:
+            raise ValueError(
+                f"Vector index '{index_name}' cannot use '{partition_key}' as both "
+                "partition key and inline filter"
+            )
+        if not (projection in ("ALL", "KEYS_ONLY") or isinstance(projection, list)):
+            raise ValueError("projection must be 'ALL', 'KEYS_ONLY', or a list of attributes")
+        if isinstance(projection, list) and not projection:
+            raise ValueError("projection attribute list cannot be empty")
+        if isinstance(projection, list) and len(set(projection)) != len(projection):
+            raise ValueError(
+                f"Vector index '{index_name}' contains duplicate projection attributes"
+            )
+
+        self._model_class: type[M] | None = None
+        self._attr_name: str | None = None
+
+    def __set_name__(self, owner: type[M], name: str) -> None:
+        self._attr_name = name
+
+    def _bind_to_model(self, model_class: type[M]) -> None:
+        attributes = model_class._attributes
+        vector_attr = attributes.get(self.vector_attribute)
+        if vector_attr is None:
+            raise ValueError(
+                f"Vector index '{self.index_name}' references unknown attribute "
+                f"'{self.vector_attribute}'"
+            )
+        if not isinstance(vector_attr, VectorAttribute):
+            raise ValueError(
+                f"Vector index '{self.index_name}' attribute '{self.vector_attribute}' "
+                "must be a VectorAttribute"
+            )
+        if self.partition_key == self.vector_attribute:
+            raise ValueError(
+                f"Vector index '{self.index_name}' cannot use its vector attribute "
+                "as the partition key"
+            )
+        if self.vector_attribute in self.inline_filters:
+            raise ValueError(
+                f"Vector index '{self.index_name}' cannot use its vector attribute "
+                "as an inline filter"
+            )
+
+        referenced = [
+            value for value in [self.partition_key, *self.inline_filters] if value is not None
+        ]
+        if isinstance(self.projection, list):
+            referenced.extend(self.projection)
+        for attr_name in referenced:
+            if attr_name not in attributes:
+                raise ValueError(
+                    f"Vector index '{self.index_name}' references unknown attribute '{attr_name}'"
+                )
+
+        self._model_class = model_class
+
+    def _get_model_class(self) -> type[M]:
+        if self._model_class is None:
+            raise RuntimeError(f"Vector index '{self.index_name}' is not bound to a model")
+        return self._model_class
+
+    def to_create_table_definition(self, model_class: type[M]) -> dict[str, Any]:
+        vector_attr = model_class._attributes[self.vector_attribute]
+        assert isinstance(vector_attr, VectorAttribute)
+
+        result: dict[str, Any] = {
+            "index_name": self.index_name,
+            "vector_attribute": model_class._py_to_dynamo.get(
+                self.vector_attribute, self.vector_attribute
+            ),
+            "dimensions": vector_attr.dimensions,
+            "distance_function": self.distance.value,
+        }
+
+        if self.partition_key is not None:
+            result["partition_key"] = model_class._py_to_dynamo.get(
+                self.partition_key, self.partition_key
+            )
+        if self.inline_filters:
+            result["inline_filters"] = [
+                model_class._py_to_dynamo.get(name, name) for name in self.inline_filters
+            ]
+
+        if isinstance(self.projection, list):
+            result["projection"] = "INCLUDE"
+            result["non_key_attributes"] = [
+                model_class._py_to_dynamo.get(name, name) for name in self.projection
+            ]
+        else:
+            result["projection"] = self.projection
+
+        return result
+
+    def _validate_filter(self, condition: Condition) -> None:
+        allowed = {
+            self._get_model_class()._py_to_dynamo.get(name, name) for name in self.inline_filters
+        }
+
+        def visit(node: Any) -> None:
+            if isinstance(node, ConditionAnd):
+                visit(node.left)
+                visit(node.right)
+                return
+            if not isinstance(node, ConditionComparison) or node.operator != "=":
+                raise ValueError("Vector search filters support equality comparisons joined by AND")
+            if len(node.path.path) != 1 or node.path.path[0] not in allowed:
+                name = node.path.path[0] if node.path.path else "<unknown>"
+                raise ValueError(f"Filter attribute '{name}' is not declared as an inline filter")
+
+        visit(condition)
+
+    def _prepare_search(
+        self,
+        query_vector: Any,
+        partition_key: Any,
+        where: Condition | None,
+        top_k: int,
+    ) -> tuple[list[float], str | None, dict[str, str] | None, dict[str, Any] | None]:
+        model_class = self._get_model_class()
+        vector_attr = model_class._attributes[self.vector_attribute]
+        assert isinstance(vector_attr, VectorAttribute)
+        vector = vector_attr.serialize(query_vector)
+        assert vector is not None
+
+        if isinstance(top_k, bool) or not isinstance(top_k, int) or not 1 <= top_k <= 100:
+            raise ValueError("top_k must be between 1 and 100")
+        if self.partition_key is not None and partition_key is None:
+            raise ValueError(
+                f"Vector index '{self.index_name}' requires partition_key='{self.partition_key}'"
+            )
+        if self.partition_key is None and partition_key is not None:
+            raise ValueError(f"Vector index '{self.index_name}' does not define a partition key")
+
+        names: dict[str, str] = {}
+        values: dict[str, Any] = {}
+        expressions: list[str] = []
+
+        if self.partition_key is not None:
+            dynamo_name = model_class._py_to_dynamo.get(self.partition_key, self.partition_key)
+            names[dynamo_name] = "#vector_pk"
+            values[":vector_pk"] = partition_key
+            expressions.append("#vector_pk = :vector_pk")
+
+        if where is not None:
+            self._validate_filter(where)
+            expressions.append(where.serialize(names, values))
+
+        expression = " AND ".join(expressions) if expressions else None
+        attr_names = {placeholder: name for name, placeholder in names.items()} if names else None
+        return vector, expression, attr_names, values or None
+
+    def _convert_result(
+        self,
+        result: VectorSearchResult[dict[str, Any]],
+        as_dict: bool,
+    ) -> VectorSearchResult[M] | VectorSearchResult[dict[str, Any]]:
+        if as_dict:
+            return result
+
+        model_class = self._get_model_class()
+        matches = [
+            VectorMatch(item=model_class.from_dict(match.item), score=match.score)
+            for match in result
+        ]
+        return VectorSearchResult(matches, result.metrics)
+
+    async def search(
+        self,
+        query_vector: Any,
+        *,
+        partition_key: Any = None,
+        where: Condition | None = None,
+        top_k: int = 10,
+        as_dict: bool = False,
+    ) -> VectorSearchResult[M] | VectorSearchResult[dict[str, Any]]:
+        model_class = self._get_model_class()
+        vector, expression, names, values = self._prepare_search(
+            query_vector, partition_key, where, top_k
+        )
+        result = await model_class._get_client().search_vectors(
+            model_class._get_table(),
+            self.index_name,
+            vector,
+            top_k=top_k,
+            search_condition_expression=expression,
+            expression_attribute_names=names,
+            expression_attribute_values=values,
+        )
+        return self._convert_result(result, as_dict)
+
+    def sync_search(
+        self,
+        query_vector: Any,
+        *,
+        partition_key: Any = None,
+        where: Condition | None = None,
+        top_k: int = 10,
+        as_dict: bool = False,
+    ) -> VectorSearchResult[M] | VectorSearchResult[dict[str, Any]]:
+        model_class = self._get_model_class()
+        vector, expression, names, values = self._prepare_search(
+            query_vector, partition_key, where, top_k
+        )
+        result = model_class._get_client().sync_search_vectors(
+            model_class._get_table(),
+            self.index_name,
+            vector,
+            top_k=top_k,
+            search_condition_expression=expression,
+            expression_attribute_names=names,
+            expression_attribute_values=values,
+        )
+        return self._convert_result(result, as_dict)
+
+    async def create(self, *, wait: bool = False) -> None:
+        model_class = self._get_model_class()
+        await model_class._get_client().create_vector_index(
+            model_class._get_table(),
+            self.to_create_table_definition(model_class),
+            wait=wait,
+        )
+
+    def sync_create(self, *, wait: bool = False) -> None:
+        model_class = self._get_model_class()
+        model_class._get_client().sync_create_vector_index(
+            model_class._get_table(),
+            self.to_create_table_definition(model_class),
+            wait=wait,
+        )
+
+    async def delete(self, *, wait: bool = False) -> None:
+        model_class = self._get_model_class()
+        await model_class._get_client().delete_vector_index(
+            model_class._get_table(),
+            self.index_name,
+            wait=wait,
+        )
+
+    def sync_delete(self, *, wait: bool = False) -> None:
+        model_class = self._get_model_class()
+        model_class._get_client().sync_delete_vector_index(
+            model_class._get_table(),
+            self.index_name,
+            wait=wait,
+        )
+
+    async def describe(self) -> VectorIndexInfo:
+        model_class = self._get_model_class()
+        value = await model_class._get_client().describe_vector_index(
+            model_class._get_table(), self.index_name
+        )
+        return VectorIndexInfo.from_dict(value)
+
+    def sync_describe(self) -> VectorIndexInfo:
+        model_class = self._get_model_class()
+        value = model_class._get_client().sync_describe_vector_index(
+            model_class._get_table(), self.index_name
+        )
+        return VectorIndexInfo.from_dict(value)

--- a/python/pydynox/_internal/_vector.py
+++ b/python/pydynox/_internal/_vector.py
@@ -123,6 +123,19 @@ class VectorIndex(Generic[M]):
     def __set_name__(self, owner: type[M], name: str) -> None:
         self._attr_name = name
 
+    def _clone_unbound(self) -> VectorIndex[M]:
+        """Return an independent descriptor for an inherited model."""
+        return VectorIndex(
+            index_name=self.index_name,
+            vector_attribute=self.vector_attribute,
+            distance=self.distance,
+            partition_key=self.partition_key,
+            inline_filters=self.inline_filters,
+            projection=(
+                list(self.projection) if isinstance(self.projection, list) else self.projection
+            ),
+        )
+
     def _bind_to_model(self, model_class: type[M]) -> None:
         attributes = model_class._attributes
         vector_attr = attributes.get(self.vector_attribute)
@@ -147,15 +160,23 @@ class VectorIndex(Generic[M]):
                 "as an inline filter"
             )
 
-        referenced = [
+        search_schema_attributes = [
             value for value in [self.partition_key, *self.inline_filters] if value is not None
         ]
+        referenced = list(search_schema_attributes)
         if isinstance(self.projection, list):
             referenced.extend(self.projection)
         for attr_name in referenced:
             if attr_name not in attributes:
                 raise ValueError(
                     f"Vector index '{self.index_name}' references unknown attribute '{attr_name}'"
+                )
+        for attr_name in search_schema_attributes:
+            attr_type = attributes[attr_name].attr_type
+            if attr_type not in {"S", "N", "B"}:
+                raise ValueError(
+                    f"Vector index '{self.index_name}' search schema attribute "
+                    f"'{attr_name}' must use scalar DynamoDB type S, N, or B"
                 )
 
         self._model_class = model_class
@@ -176,6 +197,19 @@ class VectorIndex(Generic[M]):
             ),
             "dimensions": vector_attr.dimensions,
             "distance_function": self.distance.value,
+            "attribute_definitions": [
+                (
+                    model_class._py_to_dynamo.get(name, name),
+                    model_class._attributes[name].attr_type,
+                )
+                for name in [self.partition_key, *self.inline_filters]
+                if name is not None
+            ],
+            "table_key_attributes": [
+                model_class._py_to_dynamo.get(name, name)
+                for name in [model_class._partition_key, model_class._sort_key]
+                if name is not None
+            ],
         }
 
         if self.partition_key is not None:
@@ -215,13 +249,89 @@ class VectorIndex(Generic[M]):
 
         visit(condition)
 
+    def _serialize_filter(
+        self,
+        condition: Condition,
+        names: dict[str, str],
+        values: dict[str, Any],
+    ) -> str:
+        if isinstance(condition, ConditionAnd):
+            left = self._serialize_filter(condition.left, names, values)
+            right = self._serialize_filter(condition.right, names, values)
+            return f"({left} AND {right})"
+
+        assert isinstance(condition, ConditionComparison)
+        attribute = condition.path.attribute
+        assert attribute is not None
+        path = condition.path._serialize_path(names)
+        placeholder = f":v{len(values)}"
+        values[placeholder] = attribute.serialize(condition.value)
+        return f"{path} = {placeholder}"
+
+    def _prepare_projection(
+        self,
+        names: dict[str, str],
+        as_dict: bool,
+    ) -> str | None:
+        if as_dict:
+            return None
+
+        model_class = self._get_model_class()
+        if self.projection == "ALL":
+            selected = set(model_class._attributes)
+        else:
+            selected = {
+                name
+                for name in [
+                    model_class._partition_key,
+                    model_class._sort_key,
+                    self.vector_attribute,
+                    self.partition_key,
+                    *self.inline_filters,
+                ]
+                if name is not None
+            }
+            if isinstance(self.projection, list):
+                selected.update(self.projection)
+
+        missing_required = [
+            name
+            for name, attribute in model_class._attributes.items()
+            if attribute.required and name not in selected
+        ]
+        if missing_required:
+            missing = ", ".join(sorted(missing_required))
+            raise ValueError(
+                f"Vector index '{self.index_name}' projection does not include required "
+                f"model attributes: {missing}. Use as_dict=True or include them in the projection"
+            )
+
+        placeholders: list[str] = []
+        for name in model_class._attributes:
+            if name not in selected:
+                continue
+            dynamo_name = model_class._py_to_dynamo.get(name, name)
+            placeholder = names.get(dynamo_name)
+            if placeholder is None:
+                placeholder = f"#vector_projection_{len(placeholders)}"
+                names[dynamo_name] = placeholder
+            placeholders.append(placeholder)
+        return ", ".join(placeholders)
+
     def _prepare_search(
         self,
         query_vector: Any,
         partition_key: Any,
         where: Condition | None,
         top_k: int,
-    ) -> tuple[list[float], str | None, dict[str, str] | None, dict[str, Any] | None]:
+        as_dict: bool = False,
+    ) -> tuple[
+        list[float],
+        str | None,
+        dict[str, str] | None,
+        dict[str, Any] | None,
+        str | None,
+    ]:
         model_class = self._get_model_class()
         vector_attr = model_class._attributes[self.vector_attribute]
         assert isinstance(vector_attr, VectorAttribute)
@@ -244,16 +354,19 @@ class VectorIndex(Generic[M]):
         if self.partition_key is not None:
             dynamo_name = model_class._py_to_dynamo.get(self.partition_key, self.partition_key)
             names[dynamo_name] = "#vector_pk"
-            values[":vector_pk"] = partition_key
+            values[":vector_pk"] = model_class._attributes[self.partition_key].serialize(
+                partition_key
+            )
             expressions.append("#vector_pk = :vector_pk")
 
         if where is not None:
             self._validate_filter(where)
-            expressions.append(where.serialize(names, values))
+            expressions.append(self._serialize_filter(where, names, values))
 
         expression = " AND ".join(expressions) if expressions else None
+        projection_expression = self._prepare_projection(names, as_dict)
         attr_names = {placeholder: name for name, placeholder in names.items()} if names else None
-        return vector, expression, attr_names, values or None
+        return vector, expression, attr_names, values or None, projection_expression
 
     def _convert_result(
         self,
@@ -280,8 +393,8 @@ class VectorIndex(Generic[M]):
         as_dict: bool = False,
     ) -> VectorSearchResult[M] | VectorSearchResult[dict[str, Any]]:
         model_class = self._get_model_class()
-        vector, expression, names, values = self._prepare_search(
-            query_vector, partition_key, where, top_k
+        vector, expression, names, values, projection = self._prepare_search(
+            query_vector, partition_key, where, top_k, as_dict
         )
         result = await model_class._get_client().search_vectors(
             model_class._get_table(),
@@ -291,6 +404,7 @@ class VectorIndex(Generic[M]):
             search_condition_expression=expression,
             expression_attribute_names=names,
             expression_attribute_values=values,
+            projection_expression=projection,
         )
         return self._convert_result(result, as_dict)
 
@@ -304,8 +418,8 @@ class VectorIndex(Generic[M]):
         as_dict: bool = False,
     ) -> VectorSearchResult[M] | VectorSearchResult[dict[str, Any]]:
         model_class = self._get_model_class()
-        vector, expression, names, values = self._prepare_search(
-            query_vector, partition_key, where, top_k
+        vector, expression, names, values, projection = self._prepare_search(
+            query_vector, partition_key, where, top_k, as_dict
         )
         result = model_class._get_client().sync_search_vectors(
             model_class._get_table(),
@@ -315,39 +429,64 @@ class VectorIndex(Generic[M]):
             search_condition_expression=expression,
             expression_attribute_names=names,
             expression_attribute_values=values,
+            projection_expression=projection,
         )
         return self._convert_result(result, as_dict)
 
-    async def create(self, *, wait: bool = False) -> None:
+    async def create(
+        self,
+        *,
+        wait: bool = False,
+        timeout_seconds: int | None = None,
+    ) -> None:
         model_class = self._get_model_class()
         await model_class._get_client().create_vector_index(
             model_class._get_table(),
             self.to_create_table_definition(model_class),
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
-    def sync_create(self, *, wait: bool = False) -> None:
+    def sync_create(
+        self,
+        *,
+        wait: bool = False,
+        timeout_seconds: int | None = None,
+    ) -> None:
         model_class = self._get_model_class()
         model_class._get_client().sync_create_vector_index(
             model_class._get_table(),
             self.to_create_table_definition(model_class),
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
-    async def delete(self, *, wait: bool = False) -> None:
+    async def delete(
+        self,
+        *,
+        wait: bool = False,
+        timeout_seconds: int | None = None,
+    ) -> None:
         model_class = self._get_model_class()
         await model_class._get_client().delete_vector_index(
             model_class._get_table(),
             self.index_name,
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
-    def sync_delete(self, *, wait: bool = False) -> None:
+    def sync_delete(
+        self,
+        *,
+        wait: bool = False,
+        timeout_seconds: int | None = None,
+    ) -> None:
         model_class = self._get_model_class()
         model_class._get_client().sync_delete_vector_index(
             model_class._get_table(),
             self.index_name,
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
     async def describe(self) -> VectorIndexInfo:

--- a/python/pydynox/attributes/__init__.py
+++ b/python/pydynox/attributes/__init__.py
@@ -23,6 +23,7 @@ from pydynox.attributes.special import (
     JSONAttribute,
 )
 from pydynox.attributes.ttl import ExpiresIn, TTLAttribute
+from pydynox.attributes.vector import VectorAttribute
 from pydynox.attributes.version import VersionAttribute
 
 __all__ = [
@@ -56,4 +57,6 @@ __all__ = [
     "S3File",
     # Version
     "VersionAttribute",
+    # Vector
+    "VectorAttribute",
 ]

--- a/python/pydynox/attributes/vector.py
+++ b/python/pydynox/attributes/vector.py
@@ -1,0 +1,93 @@
+"""Vector attribute support."""
+
+from __future__ import annotations
+
+import math
+import struct
+from collections.abc import Sequence
+from typing import Any
+
+from pydynox.attributes.base import Attribute
+
+
+class VectorAttribute(Attribute[list[float]]):
+    """A fixed-size vector stored as a DynamoDB list of numbers."""
+
+    attr_type = "L"
+
+    def __init__(
+        self,
+        dimensions: int,
+        *,
+        default: list[float] | None = None,
+        required: bool = False,
+        alias: str | None = None,
+    ) -> None:
+        if isinstance(dimensions, bool) or not isinstance(dimensions, int):
+            raise TypeError("dimensions must be an integer")
+        if not 1 <= dimensions <= 4096:
+            raise ValueError("dimensions must be between 1 and 4096")
+
+        super().__init__(
+            default=default,
+            required=required,
+            alias=alias,
+        )
+        self.dimensions = dimensions
+
+    def __set__(self, instance: Any, value: Any) -> None:
+        if value is not None:
+            value = self._validate(value)
+        super().__set__(instance, value)
+
+    def serialize(self, value: Any) -> list[float] | None:
+        if value is None:
+            return None
+        return self._validate(value)
+
+    def deserialize(self, value: Any) -> list[float] | None:
+        if value is None:
+            return None
+        return self._validate(value)
+
+    def _validate(self, value: Any) -> list[float]:
+        if hasattr(value, "tolist"):
+            value = value.tolist()
+
+        if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+            name = self.attr_name or "<unbound>"
+            raise TypeError(f"VectorAttribute '{name}' requires a one-dimensional sequence")
+
+        if len(value) != self.dimensions:
+            name = self.attr_name or "<unbound>"
+            raise ValueError(
+                f"VectorAttribute '{name}' requires {self.dimensions} dimensions, got {len(value)}"
+            )
+
+        result: list[float] = []
+        for index, item in enumerate(value):
+            if isinstance(item, bool) or not isinstance(item, (int, float)):
+                name = self.attr_name or "<unbound>"
+                raise TypeError(
+                    f"VectorAttribute '{name}' requires numeric values, "
+                    f"got {type(item).__name__} at index {index}"
+                )
+
+            number = float(item)
+            if not math.isfinite(number):
+                name = self.attr_name or "<unbound>"
+                raise ValueError(
+                    f"VectorAttribute '{name}' contains a non-finite value at index {index}"
+                )
+
+            try:
+                number = struct.unpack("!f", struct.pack("!f", number))[0]
+            except OverflowError as exc:
+                name = self.attr_name or "<unbound>"
+                raise ValueError(
+                    f"VectorAttribute '{name}' contains a value outside float32 range "
+                    f"at index {index}"
+                ) from exc
+            result.append(number)
+
+        return result

--- a/python/pydynox/client/_client.py
+++ b/python/pydynox/client/_client.py
@@ -9,6 +9,7 @@ from pydynox.client._partiql import PartiqlOperations
 from pydynox.client._query import QueryOperations
 from pydynox.client._scan import ScanOperations
 from pydynox.client._table import TableOperations
+from pydynox.client._vector import VectorOperations
 
 
 class DynamoDBClient(
@@ -19,6 +20,7 @@ class DynamoDBClient(
     BatchOperations,
     TableOperations,
     PartiqlOperations,
+    VectorOperations,
 ):
     """DynamoDB client with flexible credential configuration.
 

--- a/python/pydynox/client/_crud.py
+++ b/python/pydynox/client/_crud.py
@@ -153,7 +153,10 @@ class CrudOperations(_MixinBase):
             )
             attributes, metrics = result
             add_response_attributes(
-                span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
+                span,
+                consumed_wcu=metrics.consumed_wcu,
+                request_id=metrics.request_id,
+                vector_write_bytes=metrics.vector_write_bytes,
             )
 
         _log_operation("put_item", table, metrics.duration_ms, consumed_wcu=metrics.consumed_wcu)
@@ -238,7 +241,10 @@ class CrudOperations(_MixinBase):
                 return_values=return_values,
             )
             add_response_attributes(
-                span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
+                span,
+                consumed_wcu=metrics.consumed_wcu,
+                request_id=metrics.request_id,
+                vector_write_bytes=metrics.vector_write_bytes,
             )
 
         _log_operation("put_item", table, metrics.duration_ms, consumed_wcu=metrics.consumed_wcu)
@@ -426,7 +432,10 @@ class CrudOperations(_MixinBase):
             )
             attributes, metrics = result
             add_response_attributes(
-                span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
+                span,
+                consumed_wcu=metrics.consumed_wcu,
+                request_id=metrics.request_id,
+                vector_write_bytes=metrics.vector_write_bytes,
             )
 
         _log_operation("delete_item", table, metrics.duration_ms, consumed_wcu=metrics.consumed_wcu)
@@ -510,7 +519,10 @@ class CrudOperations(_MixinBase):
                 return_values=return_values,
             )
             add_response_attributes(
-                span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
+                span,
+                consumed_wcu=metrics.consumed_wcu,
+                request_id=metrics.request_id,
+                vector_write_bytes=metrics.vector_write_bytes,
             )
 
         _log_operation("delete_item", table, metrics.duration_ms, consumed_wcu=metrics.consumed_wcu)
@@ -607,7 +619,10 @@ class CrudOperations(_MixinBase):
             )
             attributes, metrics = result
             add_response_attributes(
-                span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
+                span,
+                consumed_wcu=metrics.consumed_wcu,
+                request_id=metrics.request_id,
+                vector_write_bytes=metrics.vector_write_bytes,
             )
 
         _log_operation("update_item", table, metrics.duration_ms, consumed_wcu=metrics.consumed_wcu)
@@ -701,7 +716,10 @@ class CrudOperations(_MixinBase):
                 return_values=return_values,
             )
             add_response_attributes(
-                span, consumed_wcu=metrics.consumed_wcu, request_id=metrics.request_id
+                span,
+                consumed_wcu=metrics.consumed_wcu,
+                request_id=metrics.request_id,
+                vector_write_bytes=metrics.vector_write_bytes,
             )
 
         _log_operation("update_item", table, metrics.duration_ms, consumed_wcu=metrics.consumed_wcu)

--- a/python/pydynox/client/_table.py
+++ b/python/pydynox/client/_table.py
@@ -48,6 +48,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
         kms_key_id: str | None = None,
         global_secondary_indexes: list[dict[str, Any]] | None = None,
         local_secondary_indexes: list[dict[str, Any]] | None = None,
+        vector_indexes: list[dict[str, Any]] | None = None,
         wait: bool = False,
     ) -> Coroutine[Any, Any, None]:
         """Create a new DynamoDB table. Returns an awaitable.
@@ -64,6 +65,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             kms_key_id: KMS key ARN (required for CUSTOMER_MANAGED).
             global_secondary_indexes: List of GSI definitions.
             local_secondary_indexes: List of LSI definitions.
+            vector_indexes: List of vector index definitions.
             wait: If True, wait for table to become active.
 
         Returns:
@@ -85,6 +87,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             kms_key_id=kms_key_id,
             global_secondary_indexes=global_secondary_indexes,
             local_secondary_indexes=local_secondary_indexes,
+            vector_indexes=vector_indexes,
             wait=wait,
         )
 
@@ -155,6 +158,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
         kms_key_id: str | None = None,
         global_secondary_indexes: list[dict[str, Any]] | None = None,
         local_secondary_indexes: list[dict[str, Any]] | None = None,
+        vector_indexes: list[dict[str, Any]] | None = None,
         wait: bool = False,
     ) -> None:
         """Create a new DynamoDB table. Blocks until complete.
@@ -171,6 +175,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             kms_key_id: KMS key ARN (required for CUSTOMER_MANAGED).
             global_secondary_indexes: List of GSI definitions.
             local_secondary_indexes: List of LSI definitions.
+            vector_indexes: List of vector index definitions.
             wait: If True, wait for table to become active.
 
         Example:
@@ -189,6 +194,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             kms_key_id=kms_key_id,
             global_secondary_indexes=global_secondary_indexes,
             local_secondary_indexes=local_secondary_indexes,
+            vector_indexes=vector_indexes,
             wait=wait,
         )
 

--- a/python/pydynox/client/_table.py
+++ b/python/pydynox/client/_table.py
@@ -50,6 +50,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
         local_secondary_indexes: list[dict[str, Any]] | None = None,
         vector_indexes: list[dict[str, Any]] | None = None,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> Coroutine[Any, Any, None]:
         """Create a new DynamoDB table. Returns an awaitable.
 
@@ -67,6 +68,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             local_secondary_indexes: List of LSI definitions.
             vector_indexes: List of vector index definitions.
             wait: If True, wait for table to become active.
+            timeout_seconds: Maximum wait time for the table and vector indexes.
 
         Returns:
             Awaitable that completes when table is created.
@@ -89,6 +91,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             local_secondary_indexes=local_secondary_indexes,
             vector_indexes=vector_indexes,
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
     def table_exists(self, table_name: str) -> Coroutine[Any, Any, bool]:
@@ -160,6 +163,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
         local_secondary_indexes: list[dict[str, Any]] | None = None,
         vector_indexes: list[dict[str, Any]] | None = None,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None:
         """Create a new DynamoDB table. Blocks until complete.
 
@@ -177,6 +181,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             local_secondary_indexes: List of LSI definitions.
             vector_indexes: List of vector index definitions.
             wait: If True, wait for table to become active.
+            timeout_seconds: Maximum wait time for the table and vector indexes.
 
         Example:
             client.sync_create_table("users", partition_key=("pk", "S"))
@@ -196,6 +201,7 @@ class TableOperations(_MixinBase):  # pragma: no cover
             local_secondary_indexes=local_secondary_indexes,
             vector_indexes=vector_indexes,
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
     def sync_table_exists(self, table_name: str) -> bool:

--- a/python/pydynox/client/_vector.py
+++ b/python/pydynox/client/_vector.py
@@ -99,10 +99,11 @@ class VectorOperations(_MixinBase):  # pragma: no cover
         definition: dict[str, Any],
         *,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> Coroutine[Any, Any, None]:
         _log_debug("create_vector_index", f'Creating vector index on "{table}"')
         return self._client.create_vector_index(  # type: ignore[attr-defined, no-any-return]
-            table, definition, wait=wait
+            table, definition, wait=wait, timeout_seconds=timeout_seconds
         )
 
     def sync_create_vector_index(
@@ -111,10 +112,11 @@ class VectorOperations(_MixinBase):  # pragma: no cover
         definition: dict[str, Any],
         *,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None:
         _log_debug("sync_create_vector_index", f'Creating vector index on "{table}"')
         self._client.sync_create_vector_index(  # type: ignore[attr-defined]
-            table, definition, wait=wait
+            table, definition, wait=wait, timeout_seconds=timeout_seconds
         )
 
     def delete_vector_index(
@@ -123,10 +125,11 @@ class VectorOperations(_MixinBase):  # pragma: no cover
         index_name: str,
         *,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> Coroutine[Any, Any, None]:
         _log_debug("delete_vector_index", f'Deleting vector index "{index_name}"')
         return self._client.delete_vector_index(  # type: ignore[attr-defined, no-any-return]
-            table, index_name, wait=wait
+            table, index_name, wait=wait, timeout_seconds=timeout_seconds
         )
 
     def sync_delete_vector_index(
@@ -135,10 +138,11 @@ class VectorOperations(_MixinBase):  # pragma: no cover
         index_name: str,
         *,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None:
         _log_debug("sync_delete_vector_index", f'Deleting vector index "{index_name}"')
         self._client.sync_delete_vector_index(  # type: ignore[attr-defined]
-            table, index_name, wait=wait
+            table, index_name, wait=wait, timeout_seconds=timeout_seconds
         )
 
     def describe_vector_index(

--- a/python/pydynox/client/_vector.py
+++ b/python/pydynox/client/_vector.py
@@ -1,0 +1,160 @@
+"""Vector search and vector index operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydynox._internal._logging import _log_debug
+from pydynox._internal._tracing import add_response_attributes, trace_operation
+from pydynox._internal._vector import VectorMatch, VectorSearchResult
+from pydynox.client._typing import _MixinBase
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Coroutine
+
+
+def _convert_search_result(value: dict[str, Any]) -> VectorSearchResult[dict[str, Any]]:
+    matches = [VectorMatch(item=match["item"], score=match["score"]) for match in value["matches"]]
+    return VectorSearchResult(matches, value["metrics"])
+
+
+class VectorOperations(_MixinBase):  # pragma: no cover
+    """DynamoDB vector operations."""
+
+    async def search_vectors(
+        self,
+        table: str,
+        index_name: str,
+        vector: list[float],
+        *,
+        top_k: int = 10,
+        search_condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        projection_expression: str | None = None,
+    ) -> VectorSearchResult[dict[str, Any]]:
+        _log_debug("search_vectors", f'Searching vector index "{index_name}"')
+        with trace_operation("search_vectors", table, self.get_region()) as span:
+            value = await self._client.search_vectors(  # type: ignore[attr-defined]
+                table,
+                index_name,
+                vector,
+                top_k=top_k,
+                search_condition_expression=search_condition_expression,
+                expression_attribute_names=expression_attribute_names,
+                expression_attribute_values=expression_attribute_values,
+                projection_expression=projection_expression,
+            )
+            result = _convert_search_result(value)
+            if span is not None:
+                span.set_attribute("aws.dynamodb.vector_index", index_name)
+            add_response_attributes(
+                span,
+                request_id=result.metrics.request_id,
+                vector_search_bytes=result.metrics.vector_search_bytes,
+                returned_rows=len(result),
+            )
+        self._record_metrics(result.metrics, "vector_search")
+        return result
+
+    def sync_search_vectors(
+        self,
+        table: str,
+        index_name: str,
+        vector: list[float],
+        *,
+        top_k: int = 10,
+        search_condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        projection_expression: str | None = None,
+    ) -> VectorSearchResult[dict[str, Any]]:
+        _log_debug("sync_search_vectors", f'Searching vector index "{index_name}"')
+        with trace_operation("search_vectors", table, self.get_region()) as span:
+            value = self._client.sync_search_vectors(  # type: ignore[attr-defined]
+                table,
+                index_name,
+                vector,
+                top_k=top_k,
+                search_condition_expression=search_condition_expression,
+                expression_attribute_names=expression_attribute_names,
+                expression_attribute_values=expression_attribute_values,
+                projection_expression=projection_expression,
+            )
+            result = _convert_search_result(value)
+            if span is not None:
+                span.set_attribute("aws.dynamodb.vector_index", index_name)
+            add_response_attributes(
+                span,
+                request_id=result.metrics.request_id,
+                vector_search_bytes=result.metrics.vector_search_bytes,
+                returned_rows=len(result),
+            )
+        self._record_metrics(result.metrics, "vector_search")
+        return result
+
+    def create_vector_index(
+        self,
+        table: str,
+        definition: dict[str, Any],
+        *,
+        wait: bool = False,
+    ) -> Coroutine[Any, Any, None]:
+        _log_debug("create_vector_index", f'Creating vector index on "{table}"')
+        return self._client.create_vector_index(  # type: ignore[attr-defined, no-any-return]
+            table, definition, wait=wait
+        )
+
+    def sync_create_vector_index(
+        self,
+        table: str,
+        definition: dict[str, Any],
+        *,
+        wait: bool = False,
+    ) -> None:
+        _log_debug("sync_create_vector_index", f'Creating vector index on "{table}"')
+        self._client.sync_create_vector_index(  # type: ignore[attr-defined]
+            table, definition, wait=wait
+        )
+
+    def delete_vector_index(
+        self,
+        table: str,
+        index_name: str,
+        *,
+        wait: bool = False,
+    ) -> Coroutine[Any, Any, None]:
+        _log_debug("delete_vector_index", f'Deleting vector index "{index_name}"')
+        return self._client.delete_vector_index(  # type: ignore[attr-defined, no-any-return]
+            table, index_name, wait=wait
+        )
+
+    def sync_delete_vector_index(
+        self,
+        table: str,
+        index_name: str,
+        *,
+        wait: bool = False,
+    ) -> None:
+        _log_debug("sync_delete_vector_index", f'Deleting vector index "{index_name}"')
+        self._client.sync_delete_vector_index(  # type: ignore[attr-defined]
+            table, index_name, wait=wait
+        )
+
+    def describe_vector_index(
+        self,
+        table: str,
+        index_name: str,
+    ) -> Coroutine[Any, Any, dict[str, Any]]:
+        return self._client.describe_vector_index(  # type: ignore[attr-defined, no-any-return]
+            table, index_name
+        )
+
+    def sync_describe_vector_index(
+        self,
+        table: str,
+        index_name: str,
+    ) -> dict[str, Any]:
+        return self._client.sync_describe_vector_index(  # type: ignore[attr-defined, no-any-return]
+            table, index_name
+        )

--- a/python/pydynox/indexes.py
+++ b/python/pydynox/indexes.py
@@ -40,5 +40,20 @@ Example:
 """
 
 from pydynox._internal._indexes import GlobalSecondaryIndex, LocalSecondaryIndex
+from pydynox._internal._vector import (
+    VectorDistance,
+    VectorIndex,
+    VectorIndexInfo,
+    VectorMatch,
+    VectorSearchResult,
+)
 
-__all__ = ["GlobalSecondaryIndex", "LocalSecondaryIndex"]
+__all__ = [
+    "GlobalSecondaryIndex",
+    "LocalSecondaryIndex",
+    "VectorDistance",
+    "VectorIndex",
+    "VectorIndexInfo",
+    "VectorMatch",
+    "VectorSearchResult",
+]

--- a/python/pydynox/model.py
+++ b/python/pydynox/model.py
@@ -1245,7 +1245,7 @@ class Model(ModelBase, metaclass=ModelMeta):
         """Create the DynamoDB table for this model. Async.
 
         Uses the model's schema to build the table definition, including
-        hash key, range key, GSIs, and LSIs defined on the model.
+        hash key, range key, GSIs, LSIs, and vector indexes defined on the model.
 
         Args:
             billing_mode: "PAY_PER_REQUEST" (default) or "PROVISIONED".
@@ -1291,6 +1291,14 @@ class Model(ModelBase, metaclass=ModelMeta):
         if cls._local_indexes:
             lsis = [idx.to_create_table_definition(cls) for idx in cls._local_indexes.values()]
 
+        vector_indexes = None
+        if cls._vector_indexes:
+            if billing_mode != "PAY_PER_REQUEST":
+                raise ValueError("Vector indexes require PAY_PER_REQUEST billing mode")
+            vector_indexes = [
+                idx.to_create_table_definition(cls) for idx in cls._vector_indexes.values()
+            ]
+
         await client.create_table(
             table,
             partition_key=partition_key,
@@ -1303,6 +1311,7 @@ class Model(ModelBase, metaclass=ModelMeta):
             kms_key_id=kms_key_id,
             global_secondary_indexes=gsis,
             local_secondary_indexes=lsis,
+            vector_indexes=vector_indexes,
             wait=wait,
         )
 
@@ -1351,7 +1360,7 @@ class Model(ModelBase, metaclass=ModelMeta):
         """Create the DynamoDB table for this model. Sync (blocks).
 
         Uses the model's schema to build the table definition, including
-        hash key, range key, GSIs, and LSIs defined on the model.
+        hash key, range key, GSIs, LSIs, and vector indexes defined on the model.
 
         Args:
             billing_mode: "PAY_PER_REQUEST" (default) or "PROVISIONED".
@@ -1397,6 +1406,14 @@ class Model(ModelBase, metaclass=ModelMeta):
         if cls._local_indexes:
             lsis = [idx.to_create_table_definition(cls) for idx in cls._local_indexes.values()]
 
+        vector_indexes = None
+        if cls._vector_indexes:
+            if billing_mode != "PAY_PER_REQUEST":
+                raise ValueError("Vector indexes require PAY_PER_REQUEST billing mode")
+            vector_indexes = [
+                idx.to_create_table_definition(cls) for idx in cls._vector_indexes.values()
+            ]
+
         client.sync_create_table(
             table,
             partition_key=partition_key,
@@ -1409,6 +1426,7 @@ class Model(ModelBase, metaclass=ModelMeta):
             kms_key_id=kms_key_id,
             global_secondary_indexes=gsis,
             local_secondary_indexes=lsis,
+            vector_indexes=vector_indexes,
             wait=wait,
         )
 

--- a/python/pydynox/model.py
+++ b/python/pydynox/model.py
@@ -1241,6 +1241,7 @@ class Model(ModelBase, metaclass=ModelMeta):
         encryption: str | None = None,
         kms_key_id: str | None = None,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None:
         """Create the DynamoDB table for this model. Async.
 
@@ -1255,6 +1256,7 @@ class Model(ModelBase, metaclass=ModelMeta):
             encryption: "AWS_OWNED", "AWS_MANAGED", or "CUSTOMER_MANAGED".
             kms_key_id: KMS key ARN (required for CUSTOMER_MANAGED).
             wait: If True, wait for table to become active.
+            timeout_seconds: Maximum wait time for the table and vector indexes.
 
         Raises:
             ValueError: If model has no partition_key defined.
@@ -1313,6 +1315,7 @@ class Model(ModelBase, metaclass=ModelMeta):
             local_secondary_indexes=lsis,
             vector_indexes=vector_indexes,
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
     @classmethod
@@ -1356,6 +1359,7 @@ class Model(ModelBase, metaclass=ModelMeta):
         encryption: str | None = None,
         kms_key_id: str | None = None,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None:
         """Create the DynamoDB table for this model. Sync (blocks).
 
@@ -1370,6 +1374,7 @@ class Model(ModelBase, metaclass=ModelMeta):
             encryption: "AWS_OWNED", "AWS_MANAGED", or "CUSTOMER_MANAGED".
             kms_key_id: KMS key ARN (required for CUSTOMER_MANAGED).
             wait: If True, wait for table to become active.
+            timeout_seconds: Maximum wait time for the table and vector indexes.
 
         Raises:
             ValueError: If model has no partition_key defined.
@@ -1428,6 +1433,7 @@ class Model(ModelBase, metaclass=ModelMeta):
             local_secondary_indexes=lsis,
             vector_indexes=vector_indexes,
             wait=wait,
+            timeout_seconds=timeout_seconds,
         )
 
     @classmethod

--- a/python/pydynox/pydynox_core.pyi
+++ b/python/pydynox/pydynox_core.pyi
@@ -162,6 +162,7 @@ class DynamoDBClient:
         local_secondary_indexes: list[dict[str, Any]] | None = None,
         vector_indexes: list[dict[str, Any]] | None = None,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None: ...
     def table_exists(self, table_name: str) -> bool: ...
     def delete_table(self, table_name: str) -> None: ...
@@ -197,24 +198,28 @@ class DynamoDBClient:
         table: str,
         definition: dict[str, Any],
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> Coroutine[Any, Any, None]: ...
     def sync_create_vector_index(
         self,
         table: str,
         definition: dict[str, Any],
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None: ...
     def delete_vector_index(
         self,
         table: str,
         index_name: str,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> Coroutine[Any, Any, None]: ...
     def sync_delete_vector_index(
         self,
         table: str,
         index_name: str,
         wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None: ...
     def describe_vector_index(
         self,

--- a/python/pydynox/pydynox_core.pyi
+++ b/python/pydynox/pydynox_core.pyi
@@ -13,6 +13,8 @@ class OperationMetrics:
     request_id: str | None
     items_count: int | None
     scanned_count: int | None
+    vector_search_bytes: float | None
+    vector_write_bytes: float | None
 
     def __init__(self, duration_ms: float = 0.0) -> None: ...
 
@@ -157,6 +159,8 @@ class DynamoDBClient:
         encryption: str | None = None,
         kms_key_id: str | None = None,
         global_secondary_indexes: list[dict[str, Any]] | None = None,
+        local_secondary_indexes: list[dict[str, Any]] | None = None,
+        vector_indexes: list[dict[str, Any]] | None = None,
         wait: bool = False,
     ) -> None: ...
     def table_exists(self, table_name: str) -> bool: ...
@@ -166,6 +170,62 @@ class DynamoDBClient:
         table_name: str,
         timeout_seconds: int | None = None,
     ) -> None: ...
+    def search_vectors(
+        self,
+        table: str,
+        index_name: str,
+        vector: list[float],
+        top_k: int = 10,
+        search_condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        projection_expression: str | None = None,
+    ) -> Coroutine[Any, Any, dict[str, Any]]: ...
+    def sync_search_vectors(
+        self,
+        table: str,
+        index_name: str,
+        vector: list[float],
+        top_k: int = 10,
+        search_condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        projection_expression: str | None = None,
+    ) -> dict[str, Any]: ...
+    def create_vector_index(
+        self,
+        table: str,
+        definition: dict[str, Any],
+        wait: bool = False,
+    ) -> Coroutine[Any, Any, None]: ...
+    def sync_create_vector_index(
+        self,
+        table: str,
+        definition: dict[str, Any],
+        wait: bool = False,
+    ) -> None: ...
+    def delete_vector_index(
+        self,
+        table: str,
+        index_name: str,
+        wait: bool = False,
+    ) -> Coroutine[Any, Any, None]: ...
+    def sync_delete_vector_index(
+        self,
+        table: str,
+        index_name: str,
+        wait: bool = False,
+    ) -> None: ...
+    def describe_vector_index(
+        self,
+        table: str,
+        index_name: str,
+    ) -> Coroutine[Any, Any, dict[str, Any]]: ...
+    def sync_describe_vector_index(
+        self,
+        table: str,
+        index_name: str,
+    ) -> dict[str, Any]: ...
 
     # Async methods
     def async_get_item(

--- a/python/pydynox/testing/memory.py
+++ b/python/pydynox/testing/memory.py
@@ -298,7 +298,6 @@ class MemoryClient:
         self._last_metrics: FakeMetrics | None = None
         self._total_metrics = FakeTotalMetrics()
         self._vector_index_definitions: dict[tuple[str, str], dict[str, Any]] = {}
-        self._deleted_vector_indexes: set[tuple[str, str]] = set()
         # For compatibility with code that accesses _client directly
         self._client = self
 
@@ -306,6 +305,10 @@ class MemoryClient:
         if seed:
             for table_name, items in seed.items():
                 self._tables[table_name] = {}
+                self._table_schemas[table_name] = {
+                    "partition_key": "pk",
+                    "sort_key": "sk" if any("sk" in item for item in items) else "",
+                }
                 for item in items:
                     # Infer key from first item
                     key_str = self._make_key_string(item)
@@ -419,7 +422,6 @@ class MemoryClient:
         after: dict[str, Any] | None,
     ) -> float | None:
         """Calculate vector bytes affected by a write."""
-        self._discover_vector_indexes(table)
         total = 0
         found = False
         for (index_table, _), definition in self._vector_index_definitions.items():
@@ -967,36 +969,8 @@ class MemoryClient:
 
     # ========== VECTOR SEARCH ==========
 
-    @staticmethod
-    def _model_classes() -> Iterator[type[Model]]:
-        pending = list(Model.__subclasses__())
-        while pending:
-            model = pending.pop()
-            pending.extend(model.__subclasses__())
-            yield model
-
-    def _discover_vector_indexes(self, table: str) -> None:
-        for model in self._model_classes():
-            config = getattr(model, "model_config", None)
-            if config is None or config.table != table:
-                continue
-            for index in getattr(model, "_vector_indexes", {}).values():
-                key = (table, index.index_name)
-                if key not in self._deleted_vector_indexes:
-                    self._vector_index_definitions.setdefault(
-                        key, index.to_create_table_definition(model)
-                    )
-
     def _find_vector_index(self, table: str, index_name: str) -> dict[str, Any]:
         key = (table, index_name)
-        if key in self._deleted_vector_indexes:
-            raise ValueError(f"Vector index '{index_name}' not found on table '{table}'")
-
-        stored = self._vector_index_definitions.get(key)
-        if stored is not None:
-            return stored
-
-        self._discover_vector_indexes(table)
         stored = self._vector_index_definitions.get(key)
         if stored is not None:
             return stored
@@ -1005,7 +979,6 @@ class MemoryClient:
 
     def _vector_projection(
         self,
-        table: str,
         item: dict[str, Any],
         definition: dict[str, Any],
     ) -> dict[str, Any]:
@@ -1013,15 +986,12 @@ class MemoryClient:
         if projection == "ALL":
             return copy.deepcopy(item)
 
-        selected: set[str] = set()
-        for model in self._model_classes():
-            config = getattr(model, "model_config", None)
-            if config is None or config.table != table:
-                continue
-            for key_name in (model._partition_key, model._sort_key):
-                if key_name is not None:
-                    selected.add(model._py_to_dynamo.get(key_name, key_name))
-            break
+        selected = set(definition.get("table_key_attributes") or [])
+        selected.add(definition["vector_attribute"])
+        partition_key = definition.get("partition_key")
+        if partition_key is not None:
+            selected.add(partition_key)
+        selected.update(definition.get("inline_filters") or [])
 
         if projection == "INCLUDE":
             selected.update(definition.get("non_key_attributes") or [])
@@ -1083,7 +1053,7 @@ class MemoryClient:
                 continue
 
             score = self._vector_score(vector, stored, definition["distance_function"])
-            projected = self._vector_projection(table, item, definition)
+            projected = self._vector_projection(item, definition)
             if projection_expression:
                 names = expression_attribute_names or {}
                 requested = [
@@ -1091,6 +1061,8 @@ class MemoryClient:
                     for name in projection_expression.split(",")
                 ]
                 projected = {name: projected[name] for name in requested if name in projected}
+            else:
+                projected.pop(vector_attribute, None)
             matches.append(VectorMatch(item=projected, score=score))
 
         reverse = definition["distance_function"] == "DOT_PRODUCT"
@@ -1217,10 +1189,27 @@ class MemoryClient:
         """Create an in-memory table."""
         if table not in self._tables:
             self._tables[table] = {}
+        partition_key = kwargs.get("partition_key")
+        sort_key = kwargs.get("sort_key")
+        self._table_schemas[table] = {
+            "partition_key": partition_key[0] if partition_key else "pk",
+            "sort_key": sort_key[0] if sort_key else "",
+        }
         for definition in kwargs.get("vector_indexes") or []:
             key = (table, definition["index_name"])
-            self._deleted_vector_indexes.discard(key)
-            self._vector_index_definitions[key] = copy.deepcopy(definition)
+            stored = copy.deepcopy(definition)
+            stored.setdefault(
+                "table_key_attributes",
+                [
+                    name
+                    for name in [
+                        self._table_schemas[table]["partition_key"],
+                        self._table_schemas[table]["sort_key"],
+                    ]
+                    if name
+                ],
+            )
+            self._vector_index_definitions[key] = stored
 
     async def create_table(self, table: str, **kwargs: Any) -> None:
         self._do_create_table(table, **kwargs)
@@ -1229,28 +1218,67 @@ class MemoryClient:
         self._do_create_table(table, **kwargs)
 
     async def create_vector_index(
-        self, table: str, definition: dict[str, Any], wait: bool = False
+        self,
+        table: str,
+        definition: dict[str, Any],
+        wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None:
-        key = (table, definition["index_name"])
-        self._deleted_vector_indexes.discard(key)
-        self._vector_index_definitions[key] = copy.deepcopy(definition)
+        self._do_create_vector_index(table, definition)
 
     def sync_create_vector_index(
-        self, table: str, definition: dict[str, Any], wait: bool = False
+        self,
+        table: str,
+        definition: dict[str, Any],
+        wait: bool = False,
+        timeout_seconds: int | None = None,
     ) -> None:
+        self._do_create_vector_index(table, definition)
+
+    def _do_create_vector_index(self, table: str, definition: dict[str, Any]) -> None:
+        if table not in self._table_schemas:
+            raise ValueError(f"Table '{table}' does not exist")
         key = (table, definition["index_name"])
-        self._deleted_vector_indexes.discard(key)
-        self._vector_index_definitions[key] = copy.deepcopy(definition)
+        if key in self._vector_index_definitions:
+            raise ValueError(
+                f"Vector index '{definition['index_name']}' already exists on table '{table}'"
+            )
+        stored = copy.deepcopy(definition)
+        stored.setdefault(
+            "table_key_attributes",
+            [
+                name
+                for name in [
+                    self._table_schemas[table]["partition_key"],
+                    self._table_schemas[table]["sort_key"],
+                ]
+                if name
+            ],
+        )
+        self._vector_index_definitions[key] = stored
 
-    async def delete_vector_index(self, table: str, index_name: str, wait: bool = False) -> None:
-        key = (table, index_name)
-        self._vector_index_definitions.pop(key, None)
-        self._deleted_vector_indexes.add(key)
+    async def delete_vector_index(
+        self,
+        table: str,
+        index_name: str,
+        wait: bool = False,
+        timeout_seconds: int | None = None,
+    ) -> None:
+        self._do_delete_vector_index(table, index_name)
 
-    def sync_delete_vector_index(self, table: str, index_name: str, wait: bool = False) -> None:
+    def sync_delete_vector_index(
+        self,
+        table: str,
+        index_name: str,
+        wait: bool = False,
+        timeout_seconds: int | None = None,
+    ) -> None:
+        self._do_delete_vector_index(table, index_name)
+
+    def _do_delete_vector_index(self, table: str, index_name: str) -> None:
         key = (table, index_name)
-        self._vector_index_definitions.pop(key, None)
-        self._deleted_vector_indexes.add(key)
+        if self._vector_index_definitions.pop(key, None) is None:
+            raise ValueError(f"Vector index '{index_name}' not found on table '{table}'")
 
     def _describe_vector_index(self, table: str, index_name: str) -> dict[str, Any]:
         definition = self._find_vector_index(table, index_name)
@@ -1277,11 +1305,9 @@ class MemoryClient:
     def delete_table(self, table: str) -> None:
         """Delete a table."""
         self._tables.pop(table, None)
+        self._table_schemas.pop(table, None)
         self._vector_index_definitions = {
             key: value for key, value in self._vector_index_definitions.items() if key[0] != table
-        }
-        self._deleted_vector_indexes = {
-            key for key in self._deleted_vector_indexes if key[0] != table
         }
 
     # ========== HELPERS ==========

--- a/python/pydynox/testing/memory.py
+++ b/python/pydynox/testing/memory.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import copy
+import math
 import re
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Iterator, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterator, TypeVar, cast
 
 from pydynox.config import clear_default_client, get_default_client, set_default_client
 from pydynox.exceptions import ConditionalCheckFailedException
 from pydynox.model import Model
+
+if TYPE_CHECKING:
+    from pydynox._internal._metrics import OperationMetrics
 
 
 def _split_top_level(clause: str) -> list[str]:
@@ -92,6 +96,8 @@ class FakeMetrics:
     scanned_count: int = 0
     count: int = 0
     items_count: int = 0
+    vector_search_bytes: float | None = None
+    vector_write_bytes: float | None = None
 
 
 @dataclass
@@ -291,6 +297,8 @@ class MemoryClient:
         self._diagnostics = None
         self._last_metrics: FakeMetrics | None = None
         self._total_metrics = FakeTotalMetrics()
+        self._vector_index_definitions: dict[tuple[str, str], dict[str, Any]] = {}
+        self._deleted_vector_indexes: set[tuple[str, str]] = set()
         # For compatibility with code that accesses _client directly
         self._client = self
 
@@ -404,6 +412,28 @@ class MemoryClient:
         self._last_metrics = metrics
         self._total_metrics.add(metrics, operation)
 
+    def _vector_write_bytes(
+        self,
+        table: str,
+        before: dict[str, Any] | None,
+        after: dict[str, Any] | None,
+    ) -> float | None:
+        """Calculate vector bytes affected by a write."""
+        self._discover_vector_indexes(table)
+        total = 0
+        found = False
+        for (index_table, _), definition in self._vector_index_definitions.items():
+            if index_table != table:
+                continue
+            attribute = definition["vector_attribute"]
+            vector = (after or {}).get(attribute)
+            if vector is None:
+                vector = (before or {}).get(attribute)
+            if vector is not None:
+                total += len(vector) * 4
+                found = True
+        return float(total) if found else None
+
     # ========== CRUD (internal sync implementations) ==========
 
     def _do_put_item(
@@ -431,8 +461,10 @@ class MemoryClient:
             ):
                 raise ConditionalCheckFailedException("Condition check failed")
 
+        existing = tbl.get(key_str)
         tbl[key_str] = copy.deepcopy(item)
         metrics = self._make_metrics(start, wcu=1)
+        metrics.vector_write_bytes = self._vector_write_bytes(table, existing, item)
         self._record_metrics(metrics, "put")
         return metrics
 
@@ -474,8 +506,9 @@ class MemoryClient:
             ):
                 raise ConditionalCheckFailedException("Condition check failed")
 
-        tbl.pop(key_str, None)
+        existing = tbl.pop(key_str, None)
         metrics = self._make_metrics(start, wcu=1)
+        metrics.vector_write_bytes = self._vector_write_bytes(table, existing, None)
         self._record_metrics(metrics, "delete")
         return metrics
 
@@ -495,6 +528,7 @@ class MemoryClient:
         key_str = self._make_key_string(key)
 
         existing = tbl.get(key_str)
+        before = copy.deepcopy(existing)
 
         # Check condition if provided
         if condition_expression:
@@ -524,6 +558,7 @@ class MemoryClient:
             )
 
         metrics = self._make_metrics(start, wcu=1)
+        metrics.vector_write_bytes = self._vector_write_bytes(table, before, existing)
         self._record_metrics(metrics, "update")
         return metrics
 
@@ -930,6 +965,188 @@ class MemoryClient:
             "metrics": self._make_metrics(start, rcu=len(tbl) * 0.5),
         }
 
+    # ========== VECTOR SEARCH ==========
+
+    @staticmethod
+    def _model_classes() -> Iterator[type[Model]]:
+        pending = list(Model.__subclasses__())
+        while pending:
+            model = pending.pop()
+            pending.extend(model.__subclasses__())
+            yield model
+
+    def _discover_vector_indexes(self, table: str) -> None:
+        for model in self._model_classes():
+            config = getattr(model, "model_config", None)
+            if config is None or config.table != table:
+                continue
+            for index in getattr(model, "_vector_indexes", {}).values():
+                key = (table, index.index_name)
+                if key not in self._deleted_vector_indexes:
+                    self._vector_index_definitions.setdefault(
+                        key, index.to_create_table_definition(model)
+                    )
+
+    def _find_vector_index(self, table: str, index_name: str) -> dict[str, Any]:
+        key = (table, index_name)
+        if key in self._deleted_vector_indexes:
+            raise ValueError(f"Vector index '{index_name}' not found on table '{table}'")
+
+        stored = self._vector_index_definitions.get(key)
+        if stored is not None:
+            return stored
+
+        self._discover_vector_indexes(table)
+        stored = self._vector_index_definitions.get(key)
+        if stored is not None:
+            return stored
+
+        raise ValueError(f"Vector index '{index_name}' not found on table '{table}'")
+
+    def _vector_projection(
+        self,
+        table: str,
+        item: dict[str, Any],
+        definition: dict[str, Any],
+    ) -> dict[str, Any]:
+        projection = definition.get("projection", "ALL")
+        if projection == "ALL":
+            return copy.deepcopy(item)
+
+        selected: set[str] = set()
+        for model in self._model_classes():
+            config = getattr(model, "model_config", None)
+            if config is None or config.table != table:
+                continue
+            for key_name in (model._partition_key, model._sort_key):
+                if key_name is not None:
+                    selected.add(model._py_to_dynamo.get(key_name, key_name))
+            break
+
+        if projection == "INCLUDE":
+            selected.update(definition.get("non_key_attributes") or [])
+        return {name: copy.deepcopy(item[name]) for name in selected if name in item}
+
+    @staticmethod
+    def _vector_score(left: list[float], right: list[float], distance: str) -> float:
+        if len(left) != len(right):
+            raise ValueError(
+                f"Search vector has {len(left)} dimensions, stored vector has {len(right)}"
+            )
+
+        dot = sum(a * b for a, b in zip(left, right))
+        if distance == "DOT_PRODUCT":
+            return dot
+        if distance == "EUCLIDEAN":
+            return math.sqrt(sum((a - b) ** 2 for a, b in zip(left, right)))
+
+        left_norm = math.sqrt(sum(value * value for value in left))
+        right_norm = math.sqrt(sum(value * value for value in right))
+        if left_norm == 0 or right_norm == 0:
+            raise ValueError("Cosine distance requires non-zero vectors")
+        return 1.0 - (dot / (left_norm * right_norm))
+
+    def _do_search_vectors(
+        self,
+        table: str,
+        index_name: str,
+        vector: list[float],
+        top_k: int = 10,
+        search_condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        projection_expression: str | None = None,
+    ) -> Any:
+        from pydynox._internal._vector import VectorMatch, VectorSearchResult
+
+        if not 1 <= top_k <= 100:
+            raise ValueError("top_k must be between 1 and 100")
+
+        definition = self._find_vector_index(table, index_name)
+        dimensions = definition["dimensions"]
+        if len(vector) != dimensions:
+            raise ValueError(f"Search vector requires {dimensions} dimensions, got {len(vector)}")
+
+        start = time.time()
+        matches: list[VectorMatch[dict[str, Any]]] = []
+        vector_attribute = definition["vector_attribute"]
+        for item in self._get_table(table).values():
+            stored = item.get(vector_attribute)
+            if stored is None:
+                continue
+            if search_condition_expression and not self._check_condition(
+                item,
+                search_condition_expression,
+                expression_attribute_names,
+                expression_attribute_values,
+            ):
+                continue
+
+            score = self._vector_score(vector, stored, definition["distance_function"])
+            projected = self._vector_projection(table, item, definition)
+            if projection_expression:
+                names = expression_attribute_names or {}
+                requested = [
+                    names.get(name.strip(), name.strip())
+                    for name in projection_expression.split(",")
+                ]
+                projected = {name: projected[name] for name in requested if name in projected}
+            matches.append(VectorMatch(item=projected, score=score))
+
+        reverse = definition["distance_function"] == "DOT_PRODUCT"
+        matches.sort(key=lambda match: match.score, reverse=reverse)
+        matches = matches[:top_k]
+
+        metrics = self._make_metrics(start)
+        metrics.items_count = len(matches)
+        metrics.vector_search_bytes = float(len(vector) * 4)
+        self._record_metrics(metrics, "vector_search")
+        return VectorSearchResult(matches, cast("OperationMetrics", metrics))
+
+    async def search_vectors(
+        self,
+        table: str,
+        index_name: str,
+        vector: list[float],
+        top_k: int = 10,
+        search_condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        projection_expression: str | None = None,
+    ) -> Any:
+        return self._do_search_vectors(
+            table,
+            index_name,
+            vector,
+            top_k,
+            search_condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            projection_expression,
+        )
+
+    def sync_search_vectors(
+        self,
+        table: str,
+        index_name: str,
+        vector: list[float],
+        top_k: int = 10,
+        search_condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        projection_expression: str | None = None,
+    ) -> Any:
+        return self._do_search_vectors(
+            table,
+            index_name,
+            vector,
+            top_k,
+            search_condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            projection_expression,
+        )
+
     # ========== BATCH ==========
 
     def batch_get_item(
@@ -996,14 +1213,76 @@ class MemoryClient:
     # Alias for async-first API (sync version has sync_ prefix)
     sync_table_exists = table_exists
 
-    def create_table(self, table: str, **kwargs: Any) -> None:
-        """Create a table (just initializes empty dict)."""
+    def _do_create_table(self, table: str, **kwargs: Any) -> None:
+        """Create an in-memory table."""
         if table not in self._tables:
             self._tables[table] = {}
+        for definition in kwargs.get("vector_indexes") or []:
+            key = (table, definition["index_name"])
+            self._deleted_vector_indexes.discard(key)
+            self._vector_index_definitions[key] = copy.deepcopy(definition)
+
+    async def create_table(self, table: str, **kwargs: Any) -> None:
+        self._do_create_table(table, **kwargs)
+
+    def sync_create_table(self, table: str, **kwargs: Any) -> None:
+        self._do_create_table(table, **kwargs)
+
+    async def create_vector_index(
+        self, table: str, definition: dict[str, Any], wait: bool = False
+    ) -> None:
+        key = (table, definition["index_name"])
+        self._deleted_vector_indexes.discard(key)
+        self._vector_index_definitions[key] = copy.deepcopy(definition)
+
+    def sync_create_vector_index(
+        self, table: str, definition: dict[str, Any], wait: bool = False
+    ) -> None:
+        key = (table, definition["index_name"])
+        self._deleted_vector_indexes.discard(key)
+        self._vector_index_definitions[key] = copy.deepcopy(definition)
+
+    async def delete_vector_index(self, table: str, index_name: str, wait: bool = False) -> None:
+        key = (table, index_name)
+        self._vector_index_definitions.pop(key, None)
+        self._deleted_vector_indexes.add(key)
+
+    def sync_delete_vector_index(self, table: str, index_name: str, wait: bool = False) -> None:
+        key = (table, index_name)
+        self._vector_index_definitions.pop(key, None)
+        self._deleted_vector_indexes.add(key)
+
+    def _describe_vector_index(self, table: str, index_name: str) -> dict[str, Any]:
+        definition = self._find_vector_index(table, index_name)
+        item_count = sum(
+            1 for item in self._get_table(table).values() if definition["vector_attribute"] in item
+        )
+        return {
+            "index_name": index_name,
+            "status": "ACTIVE",
+            "backfilling": False,
+            "item_count": item_count,
+            "size_bytes": None,
+            "index_arn": None,
+            "dimensions": definition["dimensions"],
+            "distance": definition["distance_function"],
+        }
+
+    async def describe_vector_index(self, table: str, index_name: str) -> dict[str, Any]:
+        return self._describe_vector_index(table, index_name)
+
+    def sync_describe_vector_index(self, table: str, index_name: str) -> dict[str, Any]:
+        return self._describe_vector_index(table, index_name)
 
     def delete_table(self, table: str) -> None:
         """Delete a table."""
         self._tables.pop(table, None)
+        self._vector_index_definitions = {
+            key: value for key, value in self._vector_index_definitions.items() if key[0] != table
+        }
+        self._deleted_vector_indexes = {
+            key for key in self._deleted_vector_indexes if key[0] != table
+        }
 
     # ========== HELPERS ==========
 

--- a/src/basic_operations/delete.rs
+++ b/src/basic_operations/delete.rs
@@ -15,7 +15,7 @@ use crate::conversions::{
     attribute_values_to_py_dict, extract_string_map, py_dict_to_attribute_values,
 };
 use crate::errors::map_sdk_error_with_item;
-use crate::metrics::OperationMetrics;
+use crate::metrics::{OperationMetrics, vector_write_bytes};
 
 /// Prepared delete_item data.
 pub struct PreparedDeleteItem {
@@ -133,6 +133,7 @@ pub async fn execute_delete_item(
     match result {
         Ok(output) => {
             let consumed_wcu = output.consumed_capacity().and_then(|c| c.capacity_units());
+            let vector_write_bytes = vector_write_bytes(output.consumed_capacity());
 
             let attributes = if has_return_values {
                 output.attributes().cloned()
@@ -141,7 +142,8 @@ pub async fn execute_delete_item(
             };
 
             Ok(DeleteItemResult {
-                metrics: OperationMetrics::with_capacity(duration_ms, None, consumed_wcu, None),
+                metrics: OperationMetrics::with_capacity(duration_ms, None, consumed_wcu, None)
+                    .with_vector_capacity(None, vector_write_bytes),
                 attributes,
             })
         }

--- a/src/basic_operations/delete.rs
+++ b/src/basic_operations/delete.rs
@@ -104,7 +104,7 @@ pub async fn execute_delete_item(
         .delete_item()
         .table_name(&prepared.table)
         .set_key(Some(prepared.key))
-        .return_consumed_capacity(ReturnConsumedCapacity::Total);
+        .return_consumed_capacity(ReturnConsumedCapacity::Indexes);
 
     if let Some(condition) = prepared.condition_expression {
         request = request.condition_expression(condition);

--- a/src/basic_operations/put.rs
+++ b/src/basic_operations/put.rs
@@ -102,7 +102,7 @@ pub async fn execute_put_item(
         .put_item()
         .table_name(&prepared.table)
         .set_item(Some(prepared.item))
-        .return_consumed_capacity(ReturnConsumedCapacity::Total);
+        .return_consumed_capacity(ReturnConsumedCapacity::Indexes);
 
     if let Some(condition) = prepared.condition_expression {
         request = request.condition_expression(condition);

--- a/src/basic_operations/put.rs
+++ b/src/basic_operations/put.rs
@@ -15,7 +15,7 @@ use crate::conversions::{
     attribute_values_to_py_dict, extract_string_map, py_dict_to_attribute_values,
 };
 use crate::errors::map_sdk_error_with_item;
-use crate::metrics::OperationMetrics;
+use crate::metrics::{OperationMetrics, vector_write_bytes};
 
 /// Prepared put_item data (converted from Python).
 pub struct PreparedPutItem {
@@ -131,6 +131,7 @@ pub async fn execute_put_item(
     match result {
         Ok(output) => {
             let consumed_wcu = output.consumed_capacity().and_then(|c| c.capacity_units());
+            let vector_write_bytes = vector_write_bytes(output.consumed_capacity());
 
             let attributes = if has_return_values {
                 output.attributes().cloned()
@@ -139,7 +140,8 @@ pub async fn execute_put_item(
             };
 
             Ok(PutItemResult {
-                metrics: OperationMetrics::with_capacity(duration_ms, None, consumed_wcu, None),
+                metrics: OperationMetrics::with_capacity(duration_ms, None, consumed_wcu, None)
+                    .with_vector_capacity(None, vector_write_bytes),
                 attributes,
             })
         }

--- a/src/basic_operations/update_op.rs
+++ b/src/basic_operations/update_op.rs
@@ -15,7 +15,7 @@ use crate::conversions::{
     attribute_values_to_py_dict, py_dict_to_attribute_values, py_to_attribute_value_direct,
 };
 use crate::errors::map_sdk_error_with_item;
-use crate::metrics::OperationMetrics;
+use crate::metrics::{OperationMetrics, vector_write_bytes};
 
 /// Prepared update_item data (converted from Python).
 pub struct PreparedUpdateItem {
@@ -166,6 +166,7 @@ pub async fn execute_update_item(
     match result {
         Ok(output) => {
             let consumed_wcu = output.consumed_capacity().and_then(|c| c.capacity_units());
+            let vector_write_bytes = vector_write_bytes(output.consumed_capacity());
 
             let attributes = if has_return_values {
                 output.attributes().cloned()
@@ -174,7 +175,8 @@ pub async fn execute_update_item(
             };
 
             Ok(UpdateItemResult {
-                metrics: OperationMetrics::with_capacity(duration_ms, None, consumed_wcu, None),
+                metrics: OperationMetrics::with_capacity(duration_ms, None, consumed_wcu, None)
+                    .with_vector_capacity(None, vector_write_bytes),
                 attributes,
             })
         }

--- a/src/basic_operations/update_op.rs
+++ b/src/basic_operations/update_op.rs
@@ -137,7 +137,7 @@ pub async fn execute_update_item(
         .table_name(&prepared.table)
         .set_key(Some(prepared.key))
         .update_expression(prepared.update_expression)
-        .return_consumed_capacity(ReturnConsumedCapacity::Total);
+        .return_consumed_capacity(ReturnConsumedCapacity::Indexes);
 
     if let Some(condition) = prepared.condition_expression {
         request = request.condition_expression(condition);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -21,6 +21,7 @@ mod partiql_ops;
 mod query_ops;
 mod table_ops;
 mod transaction_ops;
+mod vector_ops;
 
 use aws_sdk_dynamodb::Client;
 use aws_sdk_kms::Client as KmsClient;

--- a/src/client/table_ops.rs
+++ b/src/client/table_ops.rs
@@ -6,7 +6,7 @@ use crate::table_operations;
 #[pymethods]
 impl DynamoDBClient {
     /// Sync version of create_table. Blocks until complete.
-    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, wait=false))]
+    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, vector_indexes=None, wait=false))]
     #[allow(clippy::too_many_arguments)]
     pub fn sync_create_table(
         &self,
@@ -22,6 +22,7 @@ impl DynamoDBClient {
         kms_key_id: Option<&str>,
         global_secondary_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         local_secondary_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
+        vector_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         wait: bool,
     ) -> PyResult<()> {
         let (range_key_name, range_key_type) = match range_key {
@@ -36,6 +37,11 @@ impl DynamoDBClient {
 
         let lsis = match local_secondary_indexes {
             Some(list) => Some(table_operations::parse_lsi_definitions(py, list)?),
+            None => None,
+        };
+
+        let vector_indexes = match vector_indexes {
+            Some(list) => Some(table_operations::parse_vector_index_definitions(list)?),
             None => None,
         };
 
@@ -55,6 +61,7 @@ impl DynamoDBClient {
             kms_key_id,
             gsis,
             lsis,
+            vector_indexes,
             wait,
         )
     }
@@ -85,7 +92,7 @@ impl DynamoDBClient {
     }
 
     /// Create a new DynamoDB table. Returns a Python awaitable.
-    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, wait=false))]
+    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, vector_indexes=None, wait=false))]
     #[allow(clippy::too_many_arguments)]
     pub fn create_table<'py>(
         &self,
@@ -101,6 +108,7 @@ impl DynamoDBClient {
         kms_key_id: Option<&str>,
         global_secondary_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         local_secondary_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
+        vector_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         wait: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let (range_key_name, range_key_type) = match range_key {
@@ -115,6 +123,11 @@ impl DynamoDBClient {
 
         let lsis = match local_secondary_indexes {
             Some(list) => Some(table_operations::parse_lsi_definitions(py, list)?),
+            None => None,
+        };
+
+        let vector_indexes = match vector_indexes {
+            Some(list) => Some(table_operations::parse_vector_index_definitions(list)?),
             None => None,
         };
 
@@ -134,6 +147,7 @@ impl DynamoDBClient {
             kms_key_id,
             gsis,
             lsis,
+            vector_indexes,
             wait,
         )
     }

--- a/src/client/table_ops.rs
+++ b/src/client/table_ops.rs
@@ -6,7 +6,7 @@ use crate::table_operations;
 #[pymethods]
 impl DynamoDBClient {
     /// Sync version of create_table. Blocks until complete.
-    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, vector_indexes=None, wait=false))]
+    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, vector_indexes=None, wait=false, timeout_seconds=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn sync_create_table(
         &self,
@@ -24,6 +24,7 @@ impl DynamoDBClient {
         local_secondary_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         vector_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         wait: bool,
+        timeout_seconds: Option<u64>,
     ) -> PyResult<()> {
         let (range_key_name, range_key_type) = match range_key {
             Some((name, typ)) => (Some(name), Some(typ)),
@@ -46,6 +47,7 @@ impl DynamoDBClient {
         };
 
         table_operations::sync_create_table(
+            py,
             &self.client,
             &self.runtime,
             table_name,
@@ -63,6 +65,7 @@ impl DynamoDBClient {
             lsis,
             vector_indexes,
             wait,
+            timeout_seconds,
         )
     }
 
@@ -92,7 +95,7 @@ impl DynamoDBClient {
     }
 
     /// Create a new DynamoDB table. Returns a Python awaitable.
-    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, vector_indexes=None, wait=false))]
+    #[pyo3(signature = (table_name, hash_key, range_key=None, billing_mode="PAY_PER_REQUEST", read_capacity=None, write_capacity=None, table_class=None, encryption=None, kms_key_id=None, global_secondary_indexes=None, local_secondary_indexes=None, vector_indexes=None, wait=false, timeout_seconds=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn create_table<'py>(
         &self,
@@ -110,6 +113,7 @@ impl DynamoDBClient {
         local_secondary_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         vector_indexes: Option<&Bound<'_, pyo3::types::PyList>>,
         wait: bool,
+        timeout_seconds: Option<u64>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let (range_key_name, range_key_type) = match range_key {
             Some((name, typ)) => (Some(name), Some(typ)),
@@ -149,6 +153,7 @@ impl DynamoDBClient {
             lsis,
             vector_indexes,
             wait,
+            timeout_seconds,
         )
     }
 

--- a/src/client/vector_ops.rs
+++ b/src/client/vector_ops.rs
@@ -64,24 +64,33 @@ impl DynamoDBClient {
         )
     }
 
-    #[pyo3(signature = (table, definition, wait=false))]
+    #[pyo3(signature = (table, definition, wait=false, timeout_seconds=None))]
     pub fn create_vector_index<'py>(
         &self,
         py: Python<'py>,
         table: &str,
         definition: &Bound<'_, PyDict>,
         wait: bool,
+        timeout_seconds: Option<u64>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        table_operations::create_vector_index(py, self.client.clone(), table, definition, wait)
+        table_operations::create_vector_index(
+            py,
+            self.client.clone(),
+            table,
+            definition,
+            wait,
+            timeout_seconds,
+        )
     }
 
-    #[pyo3(signature = (table, definition, wait=false))]
+    #[pyo3(signature = (table, definition, wait=false, timeout_seconds=None))]
     pub fn sync_create_vector_index(
         &self,
         py: Python<'_>,
         table: &str,
         definition: &Bound<'_, PyDict>,
         wait: bool,
+        timeout_seconds: Option<u64>,
     ) -> PyResult<()> {
         table_operations::sync_create_vector_index(
             py,
@@ -90,27 +99,37 @@ impl DynamoDBClient {
             table,
             definition,
             wait,
+            timeout_seconds,
         )
     }
 
-    #[pyo3(signature = (table, index_name, wait=false))]
+    #[pyo3(signature = (table, index_name, wait=false, timeout_seconds=None))]
     pub fn delete_vector_index<'py>(
         &self,
         py: Python<'py>,
         table: &str,
         index_name: &str,
         wait: bool,
+        timeout_seconds: Option<u64>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        table_operations::delete_vector_index(py, self.client.clone(), table, index_name, wait)
+        table_operations::delete_vector_index(
+            py,
+            self.client.clone(),
+            table,
+            index_name,
+            wait,
+            timeout_seconds,
+        )
     }
 
-    #[pyo3(signature = (table, index_name, wait=false))]
+    #[pyo3(signature = (table, index_name, wait=false, timeout_seconds=None))]
     pub fn sync_delete_vector_index(
         &self,
         py: Python<'_>,
         table: &str,
         index_name: &str,
         wait: bool,
+        timeout_seconds: Option<u64>,
     ) -> PyResult<()> {
         table_operations::sync_delete_vector_index(
             py,
@@ -119,6 +138,7 @@ impl DynamoDBClient {
             table,
             index_name,
             wait,
+            timeout_seconds,
         )
     }
 

--- a/src/client/vector_ops.rs
+++ b/src/client/vector_ops.rs
@@ -1,0 +1,148 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use super::DynamoDBClient;
+use crate::table_operations;
+use crate::vector_operations;
+
+#[pymethods]
+impl DynamoDBClient {
+    #[pyo3(signature = (table, index_name, vector, top_k=10, search_condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, projection_expression=None))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn search_vectors<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        index_name: &str,
+        vector: Vec<f64>,
+        top_k: i32,
+        search_condition_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        projection_expression: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        vector_operations::search_vectors(
+            py,
+            self.client.clone(),
+            table,
+            index_name,
+            vector,
+            top_k,
+            search_condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            projection_expression,
+        )
+    }
+
+    #[pyo3(signature = (table, index_name, vector, top_k=10, search_condition_expression=None, expression_attribute_names=None, expression_attribute_values=None, projection_expression=None))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn sync_search_vectors(
+        &self,
+        py: Python<'_>,
+        table: &str,
+        index_name: &str,
+        vector: Vec<f64>,
+        top_k: i32,
+        search_condition_expression: Option<String>,
+        expression_attribute_names: Option<&Bound<'_, PyDict>>,
+        expression_attribute_values: Option<&Bound<'_, PyDict>>,
+        projection_expression: Option<String>,
+    ) -> PyResult<Py<PyAny>> {
+        vector_operations::sync_search_vectors(
+            py,
+            &self.client,
+            &self.runtime,
+            table,
+            index_name,
+            vector,
+            top_k,
+            search_condition_expression,
+            expression_attribute_names,
+            expression_attribute_values,
+            projection_expression,
+        )
+    }
+
+    #[pyo3(signature = (table, definition, wait=false))]
+    pub fn create_vector_index<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        definition: &Bound<'_, PyDict>,
+        wait: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        table_operations::create_vector_index(py, self.client.clone(), table, definition, wait)
+    }
+
+    #[pyo3(signature = (table, definition, wait=false))]
+    pub fn sync_create_vector_index(
+        &self,
+        py: Python<'_>,
+        table: &str,
+        definition: &Bound<'_, PyDict>,
+        wait: bool,
+    ) -> PyResult<()> {
+        table_operations::sync_create_vector_index(
+            py,
+            &self.client,
+            &self.runtime,
+            table,
+            definition,
+            wait,
+        )
+    }
+
+    #[pyo3(signature = (table, index_name, wait=false))]
+    pub fn delete_vector_index<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        index_name: &str,
+        wait: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        table_operations::delete_vector_index(py, self.client.clone(), table, index_name, wait)
+    }
+
+    #[pyo3(signature = (table, index_name, wait=false))]
+    pub fn sync_delete_vector_index(
+        &self,
+        py: Python<'_>,
+        table: &str,
+        index_name: &str,
+        wait: bool,
+    ) -> PyResult<()> {
+        table_operations::sync_delete_vector_index(
+            py,
+            &self.client,
+            &self.runtime,
+            table,
+            index_name,
+            wait,
+        )
+    }
+
+    pub fn describe_vector_index<'py>(
+        &self,
+        py: Python<'py>,
+        table: &str,
+        index_name: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        table_operations::describe_vector_index(py, self.client.clone(), table, index_name)
+    }
+
+    pub fn sync_describe_vector_index(
+        &self,
+        py: Python<'_>,
+        table: &str,
+        index_name: &str,
+    ) -> PyResult<Py<PyAny>> {
+        table_operations::sync_describe_vector_index(
+            py,
+            &self.client,
+            &self.runtime,
+            table,
+            index_name,
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod serialization;
 mod table_operations;
 mod tracing;
 mod transaction_operations;
+mod vector_operations;
 
 use client::DynamoDBClient;
 use rate_limiter::{AdaptiveRate, FixedRate, RateLimitMetrics};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,6 +3,7 @@
 //! This module provides metrics from DynamoDB operations including
 //! duration, consumed capacity, and request IDs.
 
+use aws_sdk_dynamodb::types::ConsumedCapacity;
 use pyo3::prelude::*;
 
 /// Metrics returned from DynamoDB operations.
@@ -36,6 +37,14 @@ pub struct OperationMetrics {
     /// Number of items scanned before filtering.
     #[pyo3(get)]
     pub scanned_count: Option<usize>,
+
+    /// Vector search request bytes consumed.
+    #[pyo3(get)]
+    pub vector_search_bytes: Option<f64>,
+
+    /// Vector write request bytes consumed.
+    #[pyo3(get)]
+    pub vector_write_bytes: Option<f64>,
 }
 
 #[pymethods]
@@ -62,6 +71,12 @@ impl OperationMetrics {
         if let Some(count) = self.items_count {
             parts.push(format!("items={}", count));
         }
+        if let Some(bytes) = self.vector_search_bytes {
+            parts.push(format!("vector_search_bytes={:.0}", bytes));
+        }
+        if let Some(bytes) = self.vector_write_bytes {
+            parts.push(format!("vector_write_bytes={:.0}", bytes));
+        }
         if let Some(ref req_id) = self.request_id {
             // Truncate request_id for readability
             let short_id = if req_id.len() > 8 {
@@ -74,6 +89,19 @@ impl OperationMetrics {
 
         format!("OperationMetrics({})", parts.join(", "))
     }
+}
+
+/// Sum vector write request bytes across all vector indexes.
+pub fn vector_write_bytes(capacity: Option<&ConsumedCapacity>) -> Option<f64> {
+    let total = capacity
+        .and_then(|value| value.vector_indexes())
+        .map(|indexes| {
+            indexes
+                .values()
+                .filter_map(|value| value.vector_write_request_bytes())
+                .sum::<f64>()
+        })?;
+    Some(total)
 }
 
 impl OperationMetrics {
@@ -91,6 +119,8 @@ impl OperationMetrics {
             request_id,
             items_count: None,
             scanned_count: None,
+            vector_search_bytes: None,
+            vector_write_bytes: None,
         }
     }
 
@@ -103,6 +133,17 @@ impl OperationMetrics {
     /// Set scanned count (for query/scan).
     pub fn with_scanned_count(mut self, count: usize) -> Self {
         self.scanned_count = Some(count);
+        self
+    }
+
+    /// Set vector capacity metrics.
+    pub fn with_vector_capacity(
+        mut self,
+        search_bytes: Option<f64>,
+        write_bytes: Option<f64>,
+    ) -> Self {
+        self.vector_search_bytes = search_bytes;
+        self.vector_write_bytes = write_bytes;
         self
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -93,15 +93,16 @@ impl OperationMetrics {
 
 /// Sum vector write request bytes across all vector indexes.
 pub fn vector_write_bytes(capacity: Option<&ConsumedCapacity>) -> Option<f64> {
-    let total = capacity
-        .and_then(|value| value.vector_indexes())
-        .map(|indexes| {
-            indexes
-                .values()
-                .filter_map(|value| value.vector_write_request_bytes())
-                .sum::<f64>()
-        })?;
-    Some(total)
+    let indexes = capacity.and_then(|value| value.vector_indexes())?;
+    if indexes.is_empty() {
+        return None;
+    }
+    Some(
+        indexes
+            .values()
+            .filter_map(|value| value.vector_write_request_bytes())
+            .sum(),
+    )
 }
 
 impl OperationMetrics {

--- a/src/table_operations/create.rs
+++ b/src/table_operations/create.rs
@@ -13,8 +13,11 @@ use tokio::runtime::Runtime;
 
 use super::gsi::GsiDefinition;
 use super::lsi::LsiDefinition;
-use super::vector_index::{VectorIndexDefinition, build_vector_index, wait_for_vector_index};
-use super::wait::{execute_wait_for_table_active, sync_wait_for_table_active};
+use super::vector_index::{
+    VectorIndexDefinition, build_vector_attribute_definitions, build_vector_index,
+    wait_for_vector_index,
+};
+use super::wait::execute_wait_for_table_active;
 use crate::errors::{ValidationException, map_sdk_error};
 
 /// Prepared create table request (converted before async).
@@ -32,6 +35,7 @@ pub struct PreparedCreateTable {
     pub vector_index_list: Vec<AwsVectorIndex>,
     pub vector_index_names: Vec<String>,
     pub wait: bool,
+    pub timeout_seconds: Option<u64>,
 }
 
 /// Prepare create table request - validates and builds all AWS types.
@@ -52,6 +56,7 @@ pub fn prepare_create_table(
     lsis: Option<Vec<LsiDefinition>>,
     vector_indexes: Option<Vec<VectorIndexDefinition>>,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<PreparedCreateTable> {
     let hash_attr_type = parse_attribute_type(hash_key_type)?;
 
@@ -248,6 +253,25 @@ pub fn prepare_create_table(
             ));
         }
         for definition in definitions {
+            for attribute in build_vector_attribute_definitions(&definition)? {
+                let name = attribute.attribute_name().to_string();
+                if let Some(existing) = attribute_definitions
+                    .iter()
+                    .find(|existing| existing.attribute_name() == name)
+                {
+                    if existing.attribute_type() != attribute.attribute_type() {
+                        return Err(ValidationException::new_err(format!(
+                            "Attribute '{}' has conflicting DynamoDB types '{}' and '{}'",
+                            name,
+                            existing.attribute_type().as_str(),
+                            attribute.attribute_type().as_str()
+                        )));
+                    }
+                } else {
+                    defined_attrs.insert(name);
+                    attribute_definitions.push(attribute);
+                }
+            }
             vector_index_names.push(definition.index_name.clone());
             vector_index_list.push(build_vector_index(&definition)?);
         }
@@ -277,6 +301,7 @@ pub fn prepare_create_table(
         vector_index_list,
         vector_index_names,
         wait,
+        timeout_seconds,
     })
 }
 
@@ -331,9 +356,21 @@ pub async fn execute_create_table(client: Client, prepared: PreparedCreateTable)
 
     // Wait for table to become active if requested
     if prepared.wait {
-        execute_wait_for_table_active(client.clone(), &prepared.table_name, None).await?;
+        execute_wait_for_table_active(
+            client.clone(),
+            &prepared.table_name,
+            prepared.timeout_seconds,
+        )
+        .await?;
         for index_name in prepared.vector_index_names {
-            wait_for_vector_index(&client, &prepared.table_name, &index_name, true).await?;
+            wait_for_vector_index(
+                &client,
+                &prepared.table_name,
+                &index_name,
+                true,
+                prepared.timeout_seconds,
+            )
+            .await?;
         }
     }
 
@@ -360,6 +397,7 @@ pub fn create_table<'py>(
     lsis: Option<Vec<LsiDefinition>>,
     vector_indexes: Option<Vec<VectorIndexDefinition>>,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let prepared = prepare_create_table(
         table_name,
@@ -377,6 +415,7 @@ pub fn create_table<'py>(
         lsis,
         vector_indexes,
         wait,
+        timeout_seconds,
     )?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
@@ -387,6 +426,7 @@ pub fn create_table<'py>(
 /// Sync create_table - blocks until complete.
 #[allow(clippy::too_many_arguments)]
 pub fn sync_create_table(
+    py: Python<'_>,
     client: &Client,
     runtime: &Arc<Runtime>,
     table_name: &str,
@@ -404,6 +444,7 @@ pub fn sync_create_table(
     lsis: Option<Vec<LsiDefinition>>,
     vector_indexes: Option<Vec<VectorIndexDefinition>>,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<()> {
     let prepared = prepare_create_table(
         table_name,
@@ -420,29 +461,12 @@ pub fn sync_create_table(
         gsis,
         lsis,
         vector_indexes,
-        false, // Don't wait in the async part
+        wait,
+        timeout_seconds,
     )?;
 
     let client_clone = client.clone();
-    let table_name_owned = table_name.to_string();
-    let vector_index_names = prepared.vector_index_names.clone();
-
-    runtime.block_on(async { execute_create_table(client_clone, prepared).await })?;
-
-    // Wait for table to become active if requested (sync version)
-    if wait {
-        sync_wait_for_table_active(client, runtime, &table_name_owned, None)?;
-        for index_name in vector_index_names {
-            runtime.block_on(wait_for_vector_index(
-                client,
-                &table_name_owned,
-                &index_name,
-                true,
-            ))?;
-        }
-    }
-
-    Ok(())
+    py.detach(|| runtime.block_on(execute_create_table(client_clone, prepared)))
 }
 
 /// Build projection for GSI/LSI.

--- a/src/table_operations/create.rs
+++ b/src/table_operations/create.rs
@@ -4,7 +4,7 @@ use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, BillingMode, GlobalSecondaryIndex, KeySchemaElement, KeyType,
     LocalSecondaryIndex, Projection, ProjectionType, ScalarAttributeType, SseSpecification,
-    SseType, TableClass,
+    SseType, TableClass, VectorIndex as AwsVectorIndex,
 };
 use pyo3::prelude::*;
 use std::collections::HashSet;
@@ -13,6 +13,7 @@ use tokio::runtime::Runtime;
 
 use super::gsi::GsiDefinition;
 use super::lsi::LsiDefinition;
+use super::vector_index::{VectorIndexDefinition, build_vector_index, wait_for_vector_index};
 use super::wait::{execute_wait_for_table_active, sync_wait_for_table_active};
 use crate::errors::{ValidationException, map_sdk_error};
 
@@ -28,6 +29,8 @@ pub struct PreparedCreateTable {
     pub sse_spec: Option<SseSpecification>,
     pub gsi_list: Vec<GlobalSecondaryIndex>,
     pub lsi_list: Vec<LocalSecondaryIndex>,
+    pub vector_index_list: Vec<AwsVectorIndex>,
+    pub vector_index_names: Vec<String>,
     pub wait: bool,
 }
 
@@ -47,6 +50,7 @@ pub fn prepare_create_table(
     kms_key_id: Option<&str>,
     gsis: Option<Vec<GsiDefinition>>,
     lsis: Option<Vec<LsiDefinition>>,
+    vector_indexes: Option<Vec<VectorIndexDefinition>>,
     wait: bool,
 ) -> PyResult<PreparedCreateTable> {
     let hash_attr_type = parse_attribute_type(hash_key_type)?;
@@ -235,6 +239,20 @@ pub fn prepare_create_table(
 
     let billing = parse_billing_mode(billing_mode)?;
 
+    let mut vector_index_list = Vec::new();
+    let mut vector_index_names = Vec::new();
+    if let Some(definitions) = vector_indexes {
+        if billing != BillingMode::PayPerRequest {
+            return Err(ValidationException::new_err(
+                "Vector indexes require PAY_PER_REQUEST billing mode",
+            ));
+        }
+        for definition in definitions {
+            vector_index_names.push(definition.index_name.clone());
+            vector_index_list.push(build_vector_index(&definition)?);
+        }
+    }
+
     let tc = match table_class {
         Some(tc) => Some(parse_table_class(tc)?),
         None => None,
@@ -256,6 +274,8 @@ pub fn prepare_create_table(
         sse_spec,
         gsi_list,
         lsi_list,
+        vector_index_list,
+        vector_index_names,
         wait,
     })
 }
@@ -275,6 +295,10 @@ pub async fn execute_create_table(client: Client, prepared: PreparedCreateTable)
 
     if !prepared.lsi_list.is_empty() {
         request = request.set_local_secondary_indexes(Some(prepared.lsi_list));
+    }
+
+    if !prepared.vector_index_list.is_empty() {
+        request = request.set_vector_indexes(Some(prepared.vector_index_list));
     }
 
     if prepared.billing == BillingMode::Provisioned {
@@ -307,7 +331,10 @@ pub async fn execute_create_table(client: Client, prepared: PreparedCreateTable)
 
     // Wait for table to become active if requested
     if prepared.wait {
-        execute_wait_for_table_active(client, &prepared.table_name, None).await?;
+        execute_wait_for_table_active(client.clone(), &prepared.table_name, None).await?;
+        for index_name in prepared.vector_index_names {
+            wait_for_vector_index(&client, &prepared.table_name, &index_name, true).await?;
+        }
     }
 
     Ok(())
@@ -331,6 +358,7 @@ pub fn create_table<'py>(
     kms_key_id: Option<&str>,
     gsis: Option<Vec<GsiDefinition>>,
     lsis: Option<Vec<LsiDefinition>>,
+    vector_indexes: Option<Vec<VectorIndexDefinition>>,
     wait: bool,
 ) -> PyResult<Bound<'py, PyAny>> {
     let prepared = prepare_create_table(
@@ -347,6 +375,7 @@ pub fn create_table<'py>(
         kms_key_id,
         gsis,
         lsis,
+        vector_indexes,
         wait,
     )?;
 
@@ -373,6 +402,7 @@ pub fn sync_create_table(
     kms_key_id: Option<&str>,
     gsis: Option<Vec<GsiDefinition>>,
     lsis: Option<Vec<LsiDefinition>>,
+    vector_indexes: Option<Vec<VectorIndexDefinition>>,
     wait: bool,
 ) -> PyResult<()> {
     let prepared = prepare_create_table(
@@ -389,17 +419,27 @@ pub fn sync_create_table(
         kms_key_id,
         gsis,
         lsis,
+        vector_indexes,
         false, // Don't wait in the async part
     )?;
 
     let client_clone = client.clone();
     let table_name_owned = table_name.to_string();
+    let vector_index_names = prepared.vector_index_names.clone();
 
     runtime.block_on(async { execute_create_table(client_clone, prepared).await })?;
 
     // Wait for table to become active if requested (sync version)
     if wait {
         sync_wait_for_table_active(client, runtime, &table_name_owned, None)?;
+        for index_name in vector_index_names {
+            runtime.block_on(wait_for_vector_index(
+                client,
+                &table_name_owned,
+                &index_name,
+                true,
+            ))?;
+        }
     }
 
     Ok(())

--- a/src/table_operations/mod.rs
+++ b/src/table_operations/mod.rs
@@ -21,20 +21,26 @@ mod delete;
 mod exists;
 mod gsi;
 mod lsi;
+mod vector_index;
 mod wait;
 
 // Re-export sync operations (with sync_ prefix)
 pub use create::sync_create_table;
 pub use delete::sync_delete_table;
 pub use exists::sync_table_exists;
+pub use vector_index::{
+    sync_create_vector_index, sync_delete_vector_index, sync_describe_vector_index,
+};
 pub use wait::sync_wait_for_table_active;
 
 // Re-export async operations (no prefix - default)
 pub use create::create_table;
 pub use delete::delete_table;
 pub use exists::table_exists;
+pub use vector_index::{create_vector_index, delete_vector_index, describe_vector_index};
 pub use wait::wait_for_table_active;
 
 // Re-export GSI/LSI parsing (unchanged)
 pub use gsi::parse_gsi_definitions;
 pub use lsi::parse_lsi_definitions;
+pub use vector_index::parse_vector_index_definitions;

--- a/src/table_operations/vector_index.rs
+++ b/src/table_operations/vector_index.rs
@@ -2,12 +2,14 @@
 
 use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::types::{
-    CreateVectorIndexAction, DeleteVectorIndexAction, Projection, ProjectionType,
-    SearchSchemaElement, SearchSchemaElementType, VectorAttributeDefinition,
-    VectorDistanceFunction, VectorIndex, VectorIndexDescription, VectorIndexUpdate,
+    AttributeDefinition, CreateVectorIndexAction, DeleteVectorIndexAction, Projection,
+    ProjectionType, ScalarAttributeType, SearchSchemaElement, SearchSchemaElementType,
+    VectorAttributeDefinition, VectorDistanceFunction, VectorIndex, VectorIndexDescription,
+    VectorIndexUpdate,
 };
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
@@ -22,6 +24,7 @@ pub struct VectorIndexDefinition {
     pub distance_function: String,
     pub partition_key: Option<String>,
     pub inline_filters: Vec<String>,
+    pub attribute_definitions: Vec<(String, String)>,
     pub projection: String,
     pub non_key_attributes: Option<Vec<String>>,
 }
@@ -121,6 +124,48 @@ pub fn parse_vector_index_definition(
         ));
     }
 
+    let attribute_definitions: Vec<(String, String)> = definition
+        .get_item("attribute_definitions")?
+        .map(|value| value.extract())
+        .transpose()?
+        .unwrap_or_default();
+    let search_schema_names: HashSet<&String> =
+        partition_key.iter().chain(inline_filters.iter()).collect();
+    let mut defined_types = HashMap::new();
+    for (name, attr_type) in &attribute_definitions {
+        if name.is_empty() {
+            return Err(ValidationException::new_err(
+                "Vector search schema attribute name cannot be empty",
+            ));
+        }
+        parse_search_attribute_type(attr_type)?;
+        if !search_schema_names.contains(name) {
+            return Err(ValidationException::new_err(format!(
+                "Attribute definition '{}' is not used by the vector search schema",
+                name
+            )));
+        }
+        if let Some(previous) = defined_types.insert(name, attr_type) {
+            let detail = if previous == attr_type {
+                "is duplicated"
+            } else {
+                "has conflicting types"
+            };
+            return Err(ValidationException::new_err(format!(
+                "Vector search schema attribute '{}' {}",
+                name, detail
+            )));
+        }
+    }
+    for name in partition_key.iter().chain(inline_filters.iter()) {
+        if !defined_types.contains_key(name) {
+            return Err(ValidationException::new_err(format!(
+                "Vector search schema attribute '{}' is missing from attribute_definitions",
+                name
+            )));
+        }
+    }
+
     let projection = definition
         .get_item("projection")?
         .map(|value| value.extract())
@@ -138,6 +183,7 @@ pub fn parse_vector_index_definition(
         distance_function,
         partition_key,
         inline_filters,
+        attribute_definitions,
         projection,
         non_key_attributes,
     })
@@ -149,6 +195,41 @@ pub fn parse_vector_index_definitions(
     definitions
         .iter()
         .map(|item| parse_vector_index_definition(item.cast::<PyDict>()?))
+        .collect()
+}
+
+fn parse_search_attribute_type(value: &str) -> PyResult<ScalarAttributeType> {
+    match value {
+        "S" => Ok(ScalarAttributeType::S),
+        "N" => Ok(ScalarAttributeType::N),
+        "B" => Ok(ScalarAttributeType::B),
+        _ => Err(ValidationException::new_err(format!(
+            "Invalid vector search schema attribute type '{}'. Must be S, N, or B",
+            value
+        ))),
+    }
+}
+
+pub fn build_vector_attribute_definitions(
+    definition: &VectorIndexDefinition,
+) -> PyResult<Vec<AttributeDefinition>> {
+    let mut seen = HashSet::new();
+    definition
+        .attribute_definitions
+        .iter()
+        .filter(|(name, _)| seen.insert(name.clone()))
+        .map(|(name, attr_type)| {
+            AttributeDefinition::builder()
+                .attribute_name(name)
+                .attribute_type(parse_search_attribute_type(attr_type)?)
+                .build()
+                .map_err(|error| {
+                    ValidationException::new_err(format!(
+                        "Invalid vector search schema attribute: {}",
+                        error
+                    ))
+                })
+        })
         .collect()
 }
 
@@ -291,10 +372,12 @@ pub(crate) async fn wait_for_vector_index(
     table: &str,
     index_name: &str,
     present: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<()> {
     let start = Instant::now();
+    let timeout = Duration::from_secs(timeout_seconds.unwrap_or(900));
     loop {
-        if start.elapsed() > Duration::from_secs(900) {
+        if start.elapsed() > timeout {
             return Err(PyErr::new::<pyo3::exceptions::PyTimeoutError, _>(format!(
                 "Timeout waiting for vector index '{}'",
                 index_name
@@ -321,20 +404,74 @@ async fn execute_create_vector_index(
     table: String,
     definition: VectorIndexDefinition,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<()> {
     let index_name = definition.index_name.clone();
+    let existing = client
+        .describe_table()
+        .table_name(&table)
+        .send()
+        .await
+        .map_err(|error| map_sdk_error(error, Some(&table)))?;
+    let existing_types: HashMap<String, String> = existing
+        .table()
+        .map(|description| {
+            description
+                .attribute_definitions()
+                .iter()
+                .map(|attribute| {
+                    (
+                        attribute.attribute_name().to_string(),
+                        attribute.attribute_type().as_str().to_string(),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut new_definitions = Vec::new();
+    let mut seen_definitions = HashSet::new();
+    for (name, attr_type) in &definition.attribute_definitions {
+        if !seen_definitions.insert(name) {
+            continue;
+        }
+        if let Some(existing_type) = existing_types.get(name) {
+            if existing_type != attr_type {
+                return Err(ValidationException::new_err(format!(
+                    "Vector search schema attribute '{}' already exists with type '{}', not '{}'",
+                    name, existing_type, attr_type
+                )));
+            }
+        } else {
+            new_definitions.push(
+                AttributeDefinition::builder()
+                    .attribute_name(name)
+                    .attribute_type(parse_search_attribute_type(attr_type)?)
+                    .build()
+                    .map_err(|error| {
+                        ValidationException::new_err(format!(
+                            "Invalid vector search schema attribute: {}",
+                            error
+                        ))
+                    })?,
+            );
+        }
+    }
     let update = VectorIndexUpdate::builder()
         .create(build_create_action(&definition)?)
         .build();
-    client
+    let mut request = client
         .update_table()
         .table_name(&table)
-        .vector_index_updates(update)
+        .vector_index_updates(update);
+    if !new_definitions.is_empty() {
+        request = request.set_attribute_definitions(Some(new_definitions));
+    }
+    request
         .send()
         .await
         .map_err(|error| map_sdk_error(error, Some(&table)))?;
     if wait {
-        wait_for_vector_index(&client, &table, &index_name, true).await?;
+        wait_for_vector_index(&client, &table, &index_name, true, timeout_seconds).await?;
     }
     Ok(())
 }
@@ -344,6 +481,7 @@ async fn execute_delete_vector_index(
     table: String,
     index_name: String,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<()> {
     let action = DeleteVectorIndexAction::builder()
         .index_name(&index_name)
@@ -360,7 +498,7 @@ async fn execute_delete_vector_index(
         .await
         .map_err(|error| map_sdk_error(error, Some(&table)))?;
     if wait {
-        wait_for_vector_index(&client, &table, &index_name, false).await?;
+        wait_for_vector_index(&client, &table, &index_name, false, timeout_seconds).await?;
     }
     Ok(())
 }
@@ -384,11 +522,12 @@ pub fn create_vector_index<'py>(
     table: &str,
     definition: &Bound<'_, PyDict>,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let definition = parse_vector_index_definition(definition)?;
     let table = table.to_string();
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        execute_create_vector_index(client, table, definition, wait).await
+        execute_create_vector_index(client, table, definition, wait, timeout_seconds).await
     })
 }
 
@@ -399,11 +538,20 @@ pub fn sync_create_vector_index(
     table: &str,
     definition: &Bound<'_, PyDict>,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<()> {
     let definition = parse_vector_index_definition(definition)?;
     let table = table.to_string();
     let client = client.clone();
-    py.detach(|| runtime.block_on(execute_create_vector_index(client, table, definition, wait)))
+    py.detach(|| {
+        runtime.block_on(execute_create_vector_index(
+            client,
+            table,
+            definition,
+            wait,
+            timeout_seconds,
+        ))
+    })
 }
 
 pub fn delete_vector_index<'py>(
@@ -412,11 +560,12 @@ pub fn delete_vector_index<'py>(
     table: &str,
     index_name: &str,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let table = table.to_string();
     let index_name = index_name.to_string();
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        execute_delete_vector_index(client, table, index_name, wait).await
+        execute_delete_vector_index(client, table, index_name, wait, timeout_seconds).await
     })
 }
 
@@ -427,11 +576,20 @@ pub fn sync_delete_vector_index(
     table: &str,
     index_name: &str,
     wait: bool,
+    timeout_seconds: Option<u64>,
 ) -> PyResult<()> {
     let client = client.clone();
     let table = table.to_string();
     let index_name = index_name.to_string();
-    py.detach(|| runtime.block_on(execute_delete_vector_index(client, table, index_name, wait)))
+    py.detach(|| {
+        runtime.block_on(execute_delete_vector_index(
+            client,
+            table,
+            index_name,
+            wait,
+            timeout_seconds,
+        ))
+    })
 }
 
 pub fn describe_vector_index<'py>(

--- a/src/table_operations/vector_index.rs
+++ b/src/table_operations/vector_index.rs
@@ -1,0 +1,474 @@
+//! Vector index definitions and lifecycle operations.
+
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::types::{
+    CreateVectorIndexAction, DeleteVectorIndexAction, Projection, ProjectionType,
+    SearchSchemaElement, SearchSchemaElementType, VectorAttributeDefinition,
+    VectorDistanceFunction, VectorIndex, VectorIndexDescription, VectorIndexUpdate,
+};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::runtime::Runtime;
+
+use crate::errors::{ValidationException, map_sdk_error};
+
+#[derive(Clone, Debug)]
+pub struct VectorIndexDefinition {
+    pub index_name: String,
+    pub vector_attribute: String,
+    pub dimensions: i64,
+    pub distance_function: String,
+    pub partition_key: Option<String>,
+    pub inline_filters: Vec<String>,
+    pub projection: String,
+    pub non_key_attributes: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug)]
+struct VectorIndexInfo {
+    index_name: String,
+    status: Option<String>,
+    backfilling: Option<bool>,
+    item_count: Option<i64>,
+    size_bytes: Option<i64>,
+    index_arn: Option<String>,
+    dimensions: Option<i64>,
+    distance: Option<String>,
+}
+
+fn required_string(dict: &Bound<'_, PyDict>, field: &str) -> PyResult<String> {
+    dict.get_item(field)?
+        .ok_or_else(|| ValidationException::new_err(format!("Vector index missing '{}'", field)))?
+        .extract()
+}
+
+fn required_i64(dict: &Bound<'_, PyDict>, field: &str) -> PyResult<i64> {
+    dict.get_item(field)?
+        .ok_or_else(|| ValidationException::new_err(format!("Vector index missing '{}'", field)))?
+        .extract()
+}
+
+pub fn parse_vector_index_definition(
+    definition: &Bound<'_, PyDict>,
+) -> PyResult<VectorIndexDefinition> {
+    let index_name = required_string(definition, "index_name")?;
+    let vector_attribute = required_string(definition, "vector_attribute")?;
+    if index_name.is_empty() {
+        return Err(ValidationException::new_err(
+            "Vector index name cannot be empty",
+        ));
+    }
+    if vector_attribute.is_empty() {
+        return Err(ValidationException::new_err(
+            "Vector attribute name cannot be empty",
+        ));
+    }
+    let dimensions = required_i64(definition, "dimensions")?;
+    if !(1..=4096).contains(&dimensions) {
+        return Err(ValidationException::new_err(
+            "Vector index dimensions must be between 1 and 4096",
+        ));
+    }
+
+    let distance_function = required_string(definition, "distance_function")?;
+    VectorDistanceFunction::try_parse(&distance_function).map_err(|_| {
+        ValidationException::new_err(format!(
+            "Invalid vector distance function '{}'",
+            distance_function
+        ))
+    })?;
+
+    let partition_key = definition
+        .get_item("partition_key")?
+        .map(|value| value.extract())
+        .transpose()?;
+    let inline_filters: Vec<String> = definition
+        .get_item("inline_filters")?
+        .map(|value| value.extract())
+        .transpose()?
+        .unwrap_or_default();
+    if inline_filters.len() > 18 {
+        return Err(ValidationException::new_err(
+            "Vector indexes support at most 18 inline filters",
+        ));
+    }
+    let unique_filters = inline_filters
+        .iter()
+        .collect::<std::collections::HashSet<_>>();
+    if unique_filters.len() != inline_filters.len() {
+        return Err(ValidationException::new_err(
+            "Vector index contains duplicate inline filters",
+        ));
+    }
+    if partition_key.as_ref() == Some(&vector_attribute) {
+        return Err(ValidationException::new_err(
+            "Vector attribute cannot also be the vector partition key",
+        ));
+    }
+    if inline_filters.contains(&vector_attribute) {
+        return Err(ValidationException::new_err(
+            "Vector attribute cannot also be an inline filter",
+        ));
+    }
+    if partition_key
+        .as_ref()
+        .is_some_and(|key| inline_filters.contains(key))
+    {
+        return Err(ValidationException::new_err(
+            "Vector partition key cannot also be an inline filter",
+        ));
+    }
+
+    let projection = definition
+        .get_item("projection")?
+        .map(|value| value.extract())
+        .transpose()?
+        .unwrap_or_else(|| "ALL".to_string());
+    let non_key_attributes = definition
+        .get_item("non_key_attributes")?
+        .map(|value| value.extract())
+        .transpose()?;
+
+    Ok(VectorIndexDefinition {
+        index_name,
+        vector_attribute,
+        dimensions,
+        distance_function,
+        partition_key,
+        inline_filters,
+        projection,
+        non_key_attributes,
+    })
+}
+
+pub fn parse_vector_index_definitions(
+    definitions: &Bound<'_, PyList>,
+) -> PyResult<Vec<VectorIndexDefinition>> {
+    definitions
+        .iter()
+        .map(|item| parse_vector_index_definition(item.cast::<PyDict>()?))
+        .collect()
+}
+
+fn build_projection(definition: &VectorIndexDefinition) -> PyResult<Projection> {
+    match definition.projection.as_str() {
+        "ALL" => Ok(Projection::builder()
+            .projection_type(ProjectionType::All)
+            .build()),
+        "KEYS_ONLY" => Ok(Projection::builder()
+            .projection_type(ProjectionType::KeysOnly)
+            .build()),
+        "INCLUDE" => {
+            let attributes = definition.non_key_attributes.clone().ok_or_else(|| {
+                ValidationException::new_err(
+                    "non_key_attributes required when vector projection is 'INCLUDE'",
+                )
+            })?;
+            if attributes.is_empty() {
+                return Err(ValidationException::new_err(
+                    "non_key_attributes cannot be empty for vector projection 'INCLUDE'",
+                ));
+            }
+            Ok(Projection::builder()
+                .projection_type(ProjectionType::Include)
+                .set_non_key_attributes(Some(attributes))
+                .build())
+        }
+        value => Err(ValidationException::new_err(format!(
+            "Invalid vector projection '{}'",
+            value
+        ))),
+    }
+}
+
+fn build_search_schema(definition: &VectorIndexDefinition) -> PyResult<Vec<SearchSchemaElement>> {
+    let mut schema = Vec::new();
+    if let Some(partition_key) = &definition.partition_key {
+        schema.push(
+            SearchSchemaElement::builder()
+                .attribute_name(partition_key)
+                .search_schema_element_type(SearchSchemaElementType::Hash)
+                .build()
+                .map_err(|error| {
+                    ValidationException::new_err(format!("Invalid vector partition key: {}", error))
+                })?,
+        );
+    }
+    for filter in &definition.inline_filters {
+        schema.push(
+            SearchSchemaElement::builder()
+                .attribute_name(filter)
+                .search_schema_element_type(SearchSchemaElementType::InlineFilter)
+                .build()
+                .map_err(|error| {
+                    ValidationException::new_err(format!("Invalid vector inline filter: {}", error))
+                })?,
+        );
+    }
+    Ok(schema)
+}
+
+fn build_vector_attribute(
+    definition: &VectorIndexDefinition,
+) -> PyResult<VectorAttributeDefinition> {
+    VectorAttributeDefinition::builder()
+        .attribute_name(&definition.vector_attribute)
+        .build()
+        .map_err(|error| {
+            ValidationException::new_err(format!("Invalid vector attribute: {}", error))
+        })
+}
+
+pub fn build_vector_index(definition: &VectorIndexDefinition) -> PyResult<VectorIndex> {
+    VectorIndex::builder()
+        .index_name(&definition.index_name)
+        .vector_attribute(build_vector_attribute(definition)?)
+        .set_search_schema(Some(build_search_schema(definition)?))
+        .projection(build_projection(definition)?)
+        .dimensions(definition.dimensions)
+        .distance_function(VectorDistanceFunction::from(
+            definition.distance_function.as_str(),
+        ))
+        .build()
+        .map_err(|error| ValidationException::new_err(format!("Invalid vector index: {}", error)))
+}
+
+fn build_create_action(definition: &VectorIndexDefinition) -> PyResult<CreateVectorIndexAction> {
+    CreateVectorIndexAction::builder()
+        .index_name(&definition.index_name)
+        .vector_attribute(build_vector_attribute(definition)?)
+        .set_search_schema(Some(build_search_schema(definition)?))
+        .projection(build_projection(definition)?)
+        .dimensions(definition.dimensions)
+        .distance_function(VectorDistanceFunction::from(
+            definition.distance_function.as_str(),
+        ))
+        .build()
+        .map_err(|error| ValidationException::new_err(format!("Invalid vector index: {}", error)))
+}
+
+fn info_from_description(description: &VectorIndexDescription) -> VectorIndexInfo {
+    VectorIndexInfo {
+        index_name: description.index_name().unwrap_or_default().to_string(),
+        status: description
+            .index_status()
+            .map(|status| status.as_str().to_string()),
+        backfilling: description.backfilling(),
+        item_count: description.item_count(),
+        size_bytes: description.index_size_bytes(),
+        index_arn: description.index_arn().map(str::to_string),
+        dimensions: description.dimensions(),
+        distance: description
+            .distance_function()
+            .map(|distance| distance.as_str().to_string()),
+    }
+}
+
+async fn execute_describe_vector_index(
+    client: &Client,
+    table: &str,
+    index_name: &str,
+) -> PyResult<Option<VectorIndexInfo>> {
+    let response = client
+        .describe_table()
+        .table_name(table)
+        .send()
+        .await
+        .map_err(|error| map_sdk_error(error, Some(table)))?;
+    Ok(response.table().and_then(|description| {
+        description
+            .vector_indexes()
+            .iter()
+            .find(|index| index.index_name() == Some(index_name))
+            .map(info_from_description)
+    }))
+}
+
+pub(crate) async fn wait_for_vector_index(
+    client: &Client,
+    table: &str,
+    index_name: &str,
+    present: bool,
+) -> PyResult<()> {
+    let start = Instant::now();
+    loop {
+        if start.elapsed() > Duration::from_secs(900) {
+            return Err(PyErr::new::<pyo3::exceptions::PyTimeoutError, _>(format!(
+                "Timeout waiting for vector index '{}'",
+                index_name
+            )));
+        }
+
+        let info = execute_describe_vector_index(client, table, index_name).await?;
+        if present {
+            if info.as_ref().is_some_and(|value| {
+                value.status.as_deref() == Some("ACTIVE") && value.backfilling != Some(true)
+            }) {
+                return Ok(());
+            }
+        } else if info.is_none() {
+            return Ok(());
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+async fn execute_create_vector_index(
+    client: Client,
+    table: String,
+    definition: VectorIndexDefinition,
+    wait: bool,
+) -> PyResult<()> {
+    let index_name = definition.index_name.clone();
+    let update = VectorIndexUpdate::builder()
+        .create(build_create_action(&definition)?)
+        .build();
+    client
+        .update_table()
+        .table_name(&table)
+        .vector_index_updates(update)
+        .send()
+        .await
+        .map_err(|error| map_sdk_error(error, Some(&table)))?;
+    if wait {
+        wait_for_vector_index(&client, &table, &index_name, true).await?;
+    }
+    Ok(())
+}
+
+async fn execute_delete_vector_index(
+    client: Client,
+    table: String,
+    index_name: String,
+    wait: bool,
+) -> PyResult<()> {
+    let action = DeleteVectorIndexAction::builder()
+        .index_name(&index_name)
+        .build()
+        .map_err(|error| {
+            ValidationException::new_err(format!("Invalid vector index: {}", error))
+        })?;
+    let update = VectorIndexUpdate::builder().delete(action).build();
+    client
+        .update_table()
+        .table_name(&table)
+        .vector_index_updates(update)
+        .send()
+        .await
+        .map_err(|error| map_sdk_error(error, Some(&table)))?;
+    if wait {
+        wait_for_vector_index(&client, &table, &index_name, false).await?;
+    }
+    Ok(())
+}
+
+fn info_to_python(py: Python<'_>, info: VectorIndexInfo) -> PyResult<Py<PyAny>> {
+    let value = PyDict::new(py);
+    value.set_item("index_name", info.index_name)?;
+    value.set_item("status", info.status)?;
+    value.set_item("backfilling", info.backfilling)?;
+    value.set_item("item_count", info.item_count)?;
+    value.set_item("size_bytes", info.size_bytes)?;
+    value.set_item("index_arn", info.index_arn)?;
+    value.set_item("dimensions", info.dimensions)?;
+    value.set_item("distance", info.distance)?;
+    Ok(value.into_any().unbind())
+}
+
+pub fn create_vector_index<'py>(
+    py: Python<'py>,
+    client: Client,
+    table: &str,
+    definition: &Bound<'_, PyDict>,
+    wait: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    let definition = parse_vector_index_definition(definition)?;
+    let table = table.to_string();
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        execute_create_vector_index(client, table, definition, wait).await
+    })
+}
+
+pub fn sync_create_vector_index(
+    py: Python<'_>,
+    client: &Client,
+    runtime: &Arc<Runtime>,
+    table: &str,
+    definition: &Bound<'_, PyDict>,
+    wait: bool,
+) -> PyResult<()> {
+    let definition = parse_vector_index_definition(definition)?;
+    let table = table.to_string();
+    let client = client.clone();
+    py.detach(|| runtime.block_on(execute_create_vector_index(client, table, definition, wait)))
+}
+
+pub fn delete_vector_index<'py>(
+    py: Python<'py>,
+    client: Client,
+    table: &str,
+    index_name: &str,
+    wait: bool,
+) -> PyResult<Bound<'py, PyAny>> {
+    let table = table.to_string();
+    let index_name = index_name.to_string();
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        execute_delete_vector_index(client, table, index_name, wait).await
+    })
+}
+
+pub fn sync_delete_vector_index(
+    py: Python<'_>,
+    client: &Client,
+    runtime: &Arc<Runtime>,
+    table: &str,
+    index_name: &str,
+    wait: bool,
+) -> PyResult<()> {
+    let client = client.clone();
+    let table = table.to_string();
+    let index_name = index_name.to_string();
+    py.detach(|| runtime.block_on(execute_delete_vector_index(client, table, index_name, wait)))
+}
+
+pub fn describe_vector_index<'py>(
+    py: Python<'py>,
+    client: Client,
+    table: &str,
+    index_name: &str,
+) -> PyResult<Bound<'py, PyAny>> {
+    let table = table.to_string();
+    let index_name = index_name.to_string();
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let info = execute_describe_vector_index(&client, &table, &index_name)
+            .await?
+            .ok_or_else(|| {
+                ValidationException::new_err(format!(
+                    "Vector index '{}' not found on table '{}'",
+                    index_name, table
+                ))
+            })?;
+        Python::attach(|py| info_to_python(py, info))
+    })
+}
+
+pub fn sync_describe_vector_index(
+    py: Python<'_>,
+    client: &Client,
+    runtime: &Arc<Runtime>,
+    table: &str,
+    index_name: &str,
+) -> PyResult<Py<PyAny>> {
+    let info =
+        py.detach(|| runtime.block_on(execute_describe_vector_index(client, table, index_name)))?;
+    let info = info.ok_or_else(|| {
+        ValidationException::new_err(format!(
+            "Vector index '{}' not found on table '{}'",
+            index_name, table
+        ))
+    })?;
+    info_to_python(py, info)
+}

--- a/src/vector_operations/mod.rs
+++ b/src/vector_operations/mod.rs
@@ -1,0 +1,5 @@
+//! DynamoDB vector operations.
+
+mod search;
+
+pub use search::{search_vectors, sync_search_vectors};

--- a/src/vector_operations/search.rs
+++ b/src/vector_operations/search.rs
@@ -1,0 +1,241 @@
+//! SearchVectors operation.
+
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::types::{AttributeValue, ReturnConsumedCapacity};
+use aws_types::request_id::RequestId;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::runtime::Runtime;
+
+use crate::conversions::{
+    attribute_values_to_py_dict, extract_string_map, py_dict_to_attribute_values,
+};
+use crate::errors::map_sdk_error;
+use crate::metrics::OperationMetrics;
+
+pub struct PreparedSearchVectors {
+    table: String,
+    index_name: String,
+    vector: Vec<AttributeValue>,
+    top_k: i32,
+    search_condition_expression: Option<String>,
+    expression_attribute_names: Option<HashMap<String, String>>,
+    expression_attribute_values: Option<HashMap<String, AttributeValue>>,
+    projection_expression: Option<String>,
+}
+
+struct RawVectorMatch {
+    item: HashMap<String, AttributeValue>,
+    score: f64,
+}
+
+struct RawVectorSearchResult {
+    matches: Vec<RawVectorMatch>,
+    metrics: OperationMetrics,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_search_vectors(
+    py: Python<'_>,
+    table: &str,
+    index_name: &str,
+    vector: Vec<f64>,
+    top_k: i32,
+    search_condition_expression: Option<String>,
+    expression_attribute_names: Option<&Bound<'_, PyDict>>,
+    expression_attribute_values: Option<&Bound<'_, PyDict>>,
+    projection_expression: Option<String>,
+) -> PyResult<PreparedSearchVectors> {
+    if !(1..=100).contains(&top_k) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "top_k must be between 1 and 100",
+        ));
+    }
+    if vector.is_empty() || vector.len() > 4096 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "vector must contain between 1 and 4096 dimensions",
+        ));
+    }
+
+    let mut search_vector = Vec::with_capacity(vector.len());
+    for (index, value) in vector.into_iter().enumerate() {
+        if !value.is_finite() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "vector contains a non-finite value at index {}",
+                index
+            )));
+        }
+        let value = value as f32;
+        if !value.is_finite() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "vector contains a value outside float32 range at index {}",
+                index
+            )));
+        }
+        search_vector.push(AttributeValue::N(value.to_string()));
+    }
+
+    let names = extract_string_map(expression_attribute_names)?;
+    let values = match expression_attribute_values {
+        Some(dict) => Some(py_dict_to_attribute_values(py, dict)?),
+        None => None,
+    };
+
+    Ok(PreparedSearchVectors {
+        table: table.to_string(),
+        index_name: index_name.to_string(),
+        vector: search_vector,
+        top_k,
+        search_condition_expression,
+        expression_attribute_names: names,
+        expression_attribute_values: values,
+        projection_expression,
+    })
+}
+
+async fn execute_search_vectors(
+    client: Client,
+    prepared: PreparedSearchVectors,
+) -> Result<
+    RawVectorSearchResult,
+    (
+        aws_sdk_dynamodb::error::SdkError<
+            aws_sdk_dynamodb::operation::search_vectors::SearchVectorsError,
+        >,
+        String,
+    ),
+> {
+    let mut request = client
+        .search_vectors()
+        .table_name(&prepared.table)
+        .index_name(prepared.index_name)
+        .set_search_vector(Some(prepared.vector))
+        .top_k(prepared.top_k)
+        .return_consumed_capacity(ReturnConsumedCapacity::Total);
+
+    if let Some(expression) = prepared.search_condition_expression {
+        request = request.search_condition_expression(expression);
+    }
+    if let Some(names) = prepared.expression_attribute_names {
+        request = request.set_expression_attribute_names(Some(names));
+    }
+    if let Some(values) = prepared.expression_attribute_values {
+        request = request.set_expression_attribute_values(Some(values));
+    }
+    if let Some(projection) = prepared.projection_expression {
+        request = request.projection_expression(projection);
+    }
+
+    let start = Instant::now();
+    let result = request.send().await;
+    let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    match result {
+        Ok(output) => {
+            let request_id = output.request_id().map(str::to_string);
+            let search_bytes = output
+                .consumed_capacity()
+                .and_then(|capacity| capacity.vector_search_request_bytes());
+            let matches = output
+                .search_results
+                .unwrap_or_default()
+                .into_iter()
+                .map(|result| RawVectorMatch {
+                    item: result.item.unwrap_or_default(),
+                    score: result.score,
+                })
+                .collect::<Vec<_>>();
+            let metrics = OperationMetrics::with_capacity(duration_ms, None, None, request_id)
+                .with_items_count(matches.len())
+                .with_vector_capacity(search_bytes, None);
+
+            Ok(RawVectorSearchResult { matches, metrics })
+        }
+        Err(error) => Err((error, prepared.table)),
+    }
+}
+
+fn raw_to_python(py: Python<'_>, raw: RawVectorSearchResult) -> PyResult<Py<PyAny>> {
+    let result = PyDict::new(py);
+    let matches = PyList::empty(py);
+
+    for vector_match in raw.matches {
+        let value = PyDict::new(py);
+        value.set_item("item", attribute_values_to_py_dict(py, vector_match.item)?)?;
+        value.set_item("score", vector_match.score)?;
+        matches.append(value)?;
+    }
+
+    result.set_item("matches", matches)?;
+    result.set_item("metrics", raw.metrics)?;
+    Ok(result.into_any().unbind())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn sync_search_vectors(
+    py: Python<'_>,
+    client: &Client,
+    runtime: &Arc<Runtime>,
+    table: &str,
+    index_name: &str,
+    vector: Vec<f64>,
+    top_k: i32,
+    search_condition_expression: Option<String>,
+    expression_attribute_names: Option<&Bound<'_, PyDict>>,
+    expression_attribute_values: Option<&Bound<'_, PyDict>>,
+    projection_expression: Option<String>,
+) -> PyResult<Py<PyAny>> {
+    let prepared = prepare_search_vectors(
+        py,
+        table,
+        index_name,
+        vector,
+        top_k,
+        search_condition_expression,
+        expression_attribute_names,
+        expression_attribute_values,
+        projection_expression,
+    )?;
+    let result = py.detach(|| runtime.block_on(execute_search_vectors(client.clone(), prepared)));
+
+    match result {
+        Ok(raw) => raw_to_python(py, raw),
+        Err((error, table)) => Err(map_sdk_error(error, Some(&table))),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn search_vectors<'py>(
+    py: Python<'py>,
+    client: Client,
+    table: &str,
+    index_name: &str,
+    vector: Vec<f64>,
+    top_k: i32,
+    search_condition_expression: Option<String>,
+    expression_attribute_names: Option<&Bound<'_, PyDict>>,
+    expression_attribute_values: Option<&Bound<'_, PyDict>>,
+    projection_expression: Option<String>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let prepared = prepare_search_vectors(
+        py,
+        table,
+        index_name,
+        vector,
+        top_k,
+        search_condition_expression,
+        expression_attribute_names,
+        expression_attribute_values,
+        projection_expression,
+    )?;
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        match execute_search_vectors(client, prepared).await {
+            Ok(raw) => Python::attach(|py| raw_to_python(py, raw)),
+            Err((error, table)) => Err(map_sdk_error(error, Some(&table))),
+        }
+    })
+}

--- a/tests/memory/test_vector_memory.py
+++ b/tests/memory/test_vector_memory.py
@@ -54,6 +54,7 @@ class EuclideanDocument(Model):
 
 def test_sync_vector_search_orders_by_cosine_distance() -> None:
     with MemoryBackend():
+        Product.sync_create_table()
         Product(
             pk="1",
             tenant_id="TENANT#1",
@@ -79,7 +80,7 @@ def test_sync_vector_search_orders_by_cosine_distance() -> None:
 
 def test_vector_write_metrics() -> None:
     with MemoryBackend():
-        Product.semantic.sync_create()
+        Product.sync_create_table()
         product = Product(
             pk="1",
             tenant_id="TENANT#1",
@@ -106,6 +107,7 @@ async def test_async_table_creation_registers_vector_index() -> None:
 @pytest.mark.asyncio
 async def test_async_vector_search_applies_inline_filter() -> None:
     with MemoryBackend():
+        await Product.create_table()
         await Product(
             pk="book",
             tenant_id="TENANT#1",
@@ -130,6 +132,7 @@ async def test_async_vector_search_applies_inline_filter() -> None:
 
 def test_vector_search_can_return_dicts() -> None:
     with MemoryBackend():
+        Product.sync_create_table()
         Product(
             pk="1",
             tenant_id="TENANT#1",
@@ -144,10 +147,30 @@ def test_vector_search_can_return_dicts() -> None:
         )
 
         assert matches[0].item["pk"] == "1"
+        assert "embedding" not in matches[0].item
+
+
+def test_model_vector_search_explicitly_requests_vector_attribute() -> None:
+    with MemoryBackend():
+        Product.sync_create_table()
+        Product(
+            pk="1",
+            tenant_id="TENANT#1",
+            category="books",
+            embedding=[1.0, 0.0],
+        ).sync_save()
+
+        matches = Product.semantic.sync_search(
+            [1.0, 0.0],
+            partition_key="TENANT#1",
+        )
+
+        assert matches[0].item.embedding == [1.0, 0.0]
 
 
 def test_dot_product_search_orders_highest_score_first() -> None:
     with MemoryBackend():
+        DotProductDocument.sync_create_table()
         DotProductDocument(pk="1", embedding=[1.0, 0.0]).sync_save()
         DotProductDocument(pk="2", embedding=[2.0, 0.0]).sync_save()
 
@@ -158,6 +181,7 @@ def test_dot_product_search_orders_highest_score_first() -> None:
 
 def test_euclidean_search_applies_top_k_and_projection() -> None:
     with MemoryBackend():
+        EuclideanDocument.sync_create_table()
         EuclideanDocument(
             pk="1",
             title="Closest",
@@ -180,8 +204,27 @@ def test_euclidean_search_applies_top_k_and_projection() -> None:
         assert matches[0].item == {"pk": "1", "title": "Closest"}
 
 
+def test_include_projection_can_build_partial_model() -> None:
+    with MemoryBackend():
+        EuclideanDocument.sync_create_table()
+        EuclideanDocument(
+            pk="1",
+            title="Closest",
+            hidden="secret",
+            embedding=[1.0, 0.0],
+        ).sync_save()
+
+        matches = EuclideanDocument.semantic.sync_search([1.0, 0.0])
+
+        assert matches[0].item.pk == "1"
+        assert matches[0].item.title == "Closest"
+        assert matches[0].item.embedding == [1.0, 0.0]
+        assert matches[0].item.hidden is None
+
+
 def test_empty_vector_index_returns_no_matches() -> None:
     with MemoryBackend():
+        DotProductDocument.sync_create_table()
         matches = DotProductDocument.semantic.sync_search([1.0, 0.0])
 
         assert matches == []
@@ -190,10 +233,42 @@ def test_empty_vector_index_returns_no_matches() -> None:
 
 def test_vector_index_lifecycle_in_memory() -> None:
     with MemoryBackend():
+        Product._get_client().sync_create_table(
+            "vector-products",
+            partition_key=("pk", "S"),
+        )
         Product.semantic.sync_create(wait=True)
         info = Product.semantic.sync_describe()
         assert info.status == "ACTIVE"
         assert info.dimensions == 2
+        with pytest.raises(ValueError, match="already exists"):
+            Product.semantic.sync_create()
         Product.semantic.sync_delete(wait=True)
+        with pytest.raises(ValueError, match="not found"):
+            Product.semantic.sync_describe()
+        with pytest.raises(ValueError, match="not found"):
+            Product.semantic.sync_delete()
+
+
+def test_vector_index_creation_requires_table() -> None:
+    with MemoryBackend():
+        with pytest.raises(ValueError, match="does not exist"):
+            Product.semantic.sync_create()
+
+
+def test_vector_index_is_not_auto_discovered() -> None:
+    with MemoryBackend():
+        Product._get_client().sync_create_table(
+            "vector-products",
+            partition_key=("pk", "S"),
+        )
+
+        with pytest.raises(ValueError, match="not found"):
+            Product.semantic.sync_search(
+                [1.0, 0.0],
+                partition_key="TENANT#1",
+                as_dict=True,
+            )
+
         with pytest.raises(ValueError, match="not found"):
             Product.semantic.sync_describe()

--- a/tests/memory/test_vector_memory.py
+++ b/tests/memory/test_vector_memory.py
@@ -1,0 +1,199 @@
+"""Vector search tests for MemoryBackend."""
+
+import pytest
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute, VectorAttribute
+from pydynox.indexes import VectorDistance, VectorIndex
+from pydynox.testing import MemoryBackend
+
+
+class Product(Model):
+    model_config = ModelConfig(table="vector-products")
+
+    pk = StringAttribute(partition_key=True)
+    tenant_id = StringAttribute()
+    category = StringAttribute()
+    embedding = VectorAttribute(dimensions=2)
+
+    semantic = VectorIndex(
+        index_name="semantic-index",
+        vector_attribute="embedding",
+        partition_key="tenant_id",
+        inline_filters=["category"],
+    )
+
+
+class DotProductDocument(Model):
+    model_config = ModelConfig(table="dot-documents")
+
+    pk = StringAttribute(partition_key=True)
+    embedding = VectorAttribute(dimensions=2)
+
+    semantic = VectorIndex(
+        index_name="dot-index",
+        vector_attribute="embedding",
+        distance=VectorDistance.DOT_PRODUCT,
+    )
+
+
+class EuclideanDocument(Model):
+    model_config = ModelConfig(table="euclidean-documents")
+
+    pk = StringAttribute(partition_key=True)
+    title = StringAttribute()
+    hidden = StringAttribute()
+    embedding = VectorAttribute(dimensions=2)
+
+    semantic = VectorIndex(
+        index_name="euclidean-index",
+        vector_attribute="embedding",
+        distance=VectorDistance.EUCLIDEAN,
+        projection=["title"],
+    )
+
+
+def test_sync_vector_search_orders_by_cosine_distance() -> None:
+    with MemoryBackend():
+        Product(
+            pk="1",
+            tenant_id="TENANT#1",
+            category="books",
+            embedding=[1.0, 0.0],
+        ).sync_save()
+        Product(
+            pk="2",
+            tenant_id="TENANT#1",
+            category="books",
+            embedding=[0.0, 1.0],
+        ).sync_save()
+
+        matches = Product.semantic.sync_search(
+            [0.9, 0.1],
+            partition_key="TENANT#1",
+        )
+
+        assert [match.item.pk for match in matches] == ["1", "2"]
+        assert matches.metrics.items_count == 2
+        assert matches.metrics.vector_search_bytes == 8.0
+
+
+def test_vector_write_metrics() -> None:
+    with MemoryBackend():
+        Product.semantic.sync_create()
+        product = Product(
+            pk="1",
+            tenant_id="TENANT#1",
+            category="books",
+            embedding=[1.0, 0.0],
+        )
+
+        product.sync_save()
+
+        assert Product._get_client().get_last_metrics().vector_write_bytes == 8.0
+
+
+@pytest.mark.asyncio
+async def test_async_table_creation_registers_vector_index() -> None:
+    with MemoryBackend():
+        await Product.create_table(wait=True)
+
+        info = await Product.semantic.describe()
+
+        assert info.status == "ACTIVE"
+        assert info.dimensions == 2
+
+
+@pytest.mark.asyncio
+async def test_async_vector_search_applies_inline_filter() -> None:
+    with MemoryBackend():
+        await Product(
+            pk="book",
+            tenant_id="TENANT#1",
+            category="books",
+            embedding=[1.0, 0.0],
+        ).save()
+        await Product(
+            pk="music",
+            tenant_id="TENANT#1",
+            category="music",
+            embedding=[1.0, 0.0],
+        ).save()
+
+        matches = await Product.semantic.search(
+            [1.0, 0.0],
+            partition_key="TENANT#1",
+            where=Product.category == "books",
+        )
+
+        assert [match.item.pk for match in matches] == ["book"]
+
+
+def test_vector_search_can_return_dicts() -> None:
+    with MemoryBackend():
+        Product(
+            pk="1",
+            tenant_id="TENANT#1",
+            category="books",
+            embedding=[1.0, 0.0],
+        ).sync_save()
+
+        matches = Product.semantic.sync_search(
+            [1.0, 0.0],
+            partition_key="TENANT#1",
+            as_dict=True,
+        )
+
+        assert matches[0].item["pk"] == "1"
+
+
+def test_dot_product_search_orders_highest_score_first() -> None:
+    with MemoryBackend():
+        DotProductDocument(pk="1", embedding=[1.0, 0.0]).sync_save()
+        DotProductDocument(pk="2", embedding=[2.0, 0.0]).sync_save()
+
+        matches = DotProductDocument.semantic.sync_search([1.0, 0.0])
+
+        assert [match.item.pk for match in matches] == ["2", "1"]
+
+
+def test_euclidean_search_applies_top_k_and_projection() -> None:
+    with MemoryBackend():
+        EuclideanDocument(
+            pk="1",
+            title="Closest",
+            hidden="secret",
+            embedding=[1.0, 0.0],
+        ).sync_save()
+        EuclideanDocument(
+            pk="2",
+            title="Farthest",
+            hidden="secret",
+            embedding=[3.0, 0.0],
+        ).sync_save()
+
+        matches = EuclideanDocument.semantic.sync_search(
+            [0.9, 0.0],
+            top_k=1,
+            as_dict=True,
+        )
+
+        assert matches[0].item == {"pk": "1", "title": "Closest"}
+
+
+def test_empty_vector_index_returns_no_matches() -> None:
+    with MemoryBackend():
+        matches = DotProductDocument.semantic.sync_search([1.0, 0.0])
+
+        assert matches == []
+        assert matches.metrics.items_count == 0
+
+
+def test_vector_index_lifecycle_in_memory() -> None:
+    with MemoryBackend():
+        Product.semantic.sync_create(wait=True)
+        info = Product.semantic.sync_describe()
+        assert info.status == "ACTIVE"
+        assert info.dimensions == 2
+        Product.semantic.sync_delete(wait=True)
+        with pytest.raises(ValueError, match="not found"):
+            Product.semantic.sync_describe()

--- a/tests/unit/test_model_table.py
+++ b/tests/unit/test_model_table.py
@@ -87,6 +87,7 @@ def test_sync_create_table_basic(mock_client: MagicMock) -> None:
         local_secondary_indexes=None,
         vector_indexes=None,
         wait=False,
+        timeout_seconds=None,
     )
 
 
@@ -157,6 +158,7 @@ def test_sync_create_table_with_options(mock_client: MagicMock) -> None:
             encryption="CUSTOMER_MANAGED",
             kms_key_id="arn:aws:kms:us-east-1:123456789012:key/abc",
             wait=True,
+            timeout_seconds=300,
         )
 
     # THEN all options should be passed
@@ -174,6 +176,7 @@ def test_sync_create_table_with_options(mock_client: MagicMock) -> None:
         local_secondary_indexes=None,
         vector_indexes=None,
         wait=True,
+        timeout_seconds=300,
     )
 
 

--- a/tests/unit/test_model_table.py
+++ b/tests/unit/test_model_table.py
@@ -85,6 +85,7 @@ def test_sync_create_table_basic(mock_client: MagicMock) -> None:
         kms_key_id=None,
         global_secondary_indexes=None,
         local_secondary_indexes=None,
+        vector_indexes=None,
         wait=False,
     )
 
@@ -171,6 +172,7 @@ def test_sync_create_table_with_options(mock_client: MagicMock) -> None:
         kms_key_id="arn:aws:kms:us-east-1:123456789012:key/abc",
         global_secondary_indexes=None,
         local_secondary_indexes=None,
+        vector_indexes=None,
         wait=True,
     )
 

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -124,6 +124,7 @@ def test_enable_tracing_with_config():
         pytest.param("batch_get", "BatchGetItem", id="batch_get"),
         pytest.param("transact_write", "TransactWriteItems", id="transact_write"),
         pytest.param("transact_get", "TransactGetItems", id="transact_get"),
+        pytest.param("search_vectors", "SearchVectors", id="search_vectors"),
     ],
 )
 def test_get_operation_name(operation: str, expected: str):
@@ -325,12 +326,18 @@ def test_add_response_attributes():
         consumed_rcu=1.5,
         consumed_wcu=2.0,
         request_id="ABC123",
+        vector_search_bytes=4096.0,
+        vector_write_bytes=1024.0,
+        returned_rows=10,
     )
 
     # THEN attributes are set on the span
     mock_span.set_attribute.assert_any_call("aws.dynamodb.consumed_capacity.read", 1.5)
     mock_span.set_attribute.assert_any_call("aws.dynamodb.consumed_capacity.write", 2.0)
     mock_span.set_attribute.assert_any_call("aws.request_id", "ABC123")
+    mock_span.set_attribute.assert_any_call("aws.dynamodb.vector_search_bytes", 4096.0)
+    mock_span.set_attribute.assert_any_call("aws.dynamodb.vector_write_bytes", 1024.0)
+    mock_span.set_attribute.assert_any_call("db.response.returned_rows", 10)
 
 
 def test_add_response_attributes_disabled():

--- a/tests/unit/test_vector_attribute.py
+++ b/tests/unit/test_vector_attribute.py
@@ -1,0 +1,57 @@
+"""Unit tests for VectorAttribute."""
+
+import math
+
+import pytest
+from pydynox import Model, ModelConfig
+from pydynox.attributes import StringAttribute, VectorAttribute
+
+
+class Document(Model):
+    model_config = ModelConfig(table="documents")
+
+    pk = StringAttribute(partition_key=True)
+    embedding = VectorAttribute(dimensions=3, alias="emb")
+
+
+def test_vector_attribute_validates_dimensions() -> None:
+    with pytest.raises(ValueError, match="between 1 and 4096"):
+        VectorAttribute(dimensions=0)
+
+    with pytest.raises(ValueError, match="between 1 and 4096"):
+        VectorAttribute(dimensions=4097)
+
+
+def test_vector_attribute_normalizes_float32() -> None:
+    document = Document(pk="DOC#1", embedding=[1, 0.2, -3.5])
+
+    assert document.embedding is not None
+    assert document.embedding[0] == 1.0
+    assert document.to_dict()["emb"] == document.embedding
+
+
+def test_vector_attribute_rejects_wrong_dimension_count() -> None:
+    with pytest.raises(ValueError, match="requires 3 dimensions, got 2"):
+        Document(pk="DOC#1", embedding=[1.0, 2.0])
+
+
+@pytest.mark.parametrize("value", [True, "1", None])
+def test_vector_attribute_rejects_non_numeric_values(value: object) -> None:
+    with pytest.raises(TypeError, match="requires numeric values"):
+        Document(pk="DOC#1", embedding=[1.0, value, 3.0])
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_vector_attribute_rejects_non_finite_values(value: float) -> None:
+    with pytest.raises(ValueError, match="non-finite"):
+        Document(pk="DOC#1", embedding=[1.0, value, 3.0])
+
+
+def test_vector_attribute_accepts_tolist_objects() -> None:
+    class ArrayLike:
+        def tolist(self) -> list[float]:
+            return [1.0, 2.0, 3.0]
+
+    document = Document(pk="DOC#1", embedding=ArrayLike())  # type: ignore[arg-type]
+
+    assert document.embedding == [1.0, 2.0, 3.0]

--- a/tests/unit/test_vector_index.py
+++ b/tests/unit/test_vector_index.py
@@ -1,11 +1,20 @@
 """Unit tests for VectorIndex."""
 
-from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+from enum import Enum
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pydynox import DynamoDBClient, Model, ModelConfig
-from pydynox.attributes import StringAttribute, VectorAttribute
-from pydynox.indexes import VectorDistance, VectorIndex
+from pydynox import DynamoDBClient, Model, ModelConfig, pydynox_core
+from pydynox.attributes import (
+    BooleanAttribute,
+    DatetimeAttribute,
+    EnumAttribute,
+    StringAttribute,
+    VectorAttribute,
+)
+from pydynox.exceptions import ValidationException
+from pydynox.indexes import VectorDistance, VectorIndex, VectorMatch, VectorSearchResult
 
 
 class Product(Model):
@@ -38,11 +47,33 @@ def test_vector_index_create_table_definition_uses_aliases() -> None:
         "vector_attribute": "emb",
         "dimensions": 3,
         "distance_function": "COSINE",
+        "attribute_definitions": [("tenant", "S"), ("cat", "S")],
+        "table_key_attributes": ["pk"],
         "partition_key": "tenant",
         "inline_filters": ["cat"],
         "projection": "INCLUDE",
         "non_key_attributes": ["name", "cat"],
     }
+
+
+def test_client_definition_requires_search_schema_attribute_types() -> None:
+    client = pydynox_core.DynamoDBClient(
+        region="us-east-1",
+        access_key="testing",
+        secret_key="testing",
+    )
+    with pytest.raises(ValidationException, match="missing from attribute_definitions"):
+        client.create_vector_index(
+            "products",
+            {
+                "index_name": "semantic-index",
+                "vector_attribute": "embedding",
+                "dimensions": 3,
+                "distance_function": "COSINE",
+                "partition_key": "tenant_id",
+                "projection": "ALL",
+            },
+        )
 
 
 def test_vector_index_requires_vector_attribute() -> None:
@@ -56,6 +87,144 @@ def test_vector_index_requires_vector_attribute() -> None:
                 index_name="semantic-index",
                 vector_attribute="embedding",
             )
+
+
+def test_vector_index_validates_constructor_arguments() -> None:
+    with pytest.raises(ValueError, match="index_name is required"):
+        VectorIndex(index_name="", vector_attribute="embedding")
+    with pytest.raises(ValueError, match="vector_attribute is required"):
+        VectorIndex(index_name="semantic-index", vector_attribute="")
+    with pytest.raises(ValueError, match="at most 18 inline filters"):
+        VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+            inline_filters=[f"filter_{index}" for index in range(19)],
+        )
+    with pytest.raises(ValueError, match="duplicate inline filters"):
+        VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+            inline_filters=["category", "category"],
+        )
+    with pytest.raises(ValueError, match="both partition key and inline filter"):
+        VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+            partition_key="tenant",
+            inline_filters=["tenant"],
+        )
+    with pytest.raises(ValueError, match="projection must be"):
+        VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+            projection="INVALID",
+        )
+
+
+def test_unbound_vector_index_rejects_model_operations() -> None:
+    index = VectorIndex(index_name="semantic-index", vector_attribute="embedding")
+    with pytest.raises(RuntimeError, match="not bound to a model"):
+        index.sync_search([1.0, 0.0])
+
+
+def test_vector_index_validates_referenced_attributes() -> None:
+    with pytest.raises(ValueError, match="unknown attribute 'missing'"):
+
+        class UnknownVector(Model):
+            model_config = ModelConfig(table="unknown-vector")
+            pk = StringAttribute(partition_key=True)
+            semantic = VectorIndex(
+                index_name="semantic-index",
+                vector_attribute="missing",
+            )
+
+    with pytest.raises(ValueError, match="cannot use its vector attribute as the partition key"):
+
+        class VectorPartition(Model):
+            model_config = ModelConfig(table="vector-partition")
+            pk = StringAttribute(partition_key=True)
+            embedding = VectorAttribute(dimensions=3)
+            semantic = VectorIndex(
+                index_name="semantic-index",
+                vector_attribute="embedding",
+                partition_key="embedding",
+            )
+
+    with pytest.raises(ValueError, match="cannot use its vector attribute as an inline filter"):
+
+        class VectorFilter(Model):
+            model_config = ModelConfig(table="vector-filter")
+            pk = StringAttribute(partition_key=True)
+            embedding = VectorAttribute(dimensions=3)
+            semantic = VectorIndex(
+                index_name="semantic-index",
+                vector_attribute="embedding",
+                inline_filters=["embedding"],
+            )
+
+    with pytest.raises(ValueError, match="unknown attribute 'missing'"):
+
+        class UnknownProjection(Model):
+            model_config = ModelConfig(table="unknown-projection")
+            pk = StringAttribute(partition_key=True)
+            embedding = VectorAttribute(dimensions=3)
+            semantic = VectorIndex(
+                index_name="semantic-index",
+                vector_attribute="embedding",
+                projection=["missing"],
+            )
+
+
+def test_vector_index_requires_scalar_search_schema_attributes() -> None:
+    with pytest.raises(ValueError, match="must use scalar DynamoDB type"):
+
+        class Invalid(Model):
+            model_config = ModelConfig(table="invalid-filter")
+            pk = StringAttribute(partition_key=True)
+            filter_flag = BooleanAttribute()
+            embedding = VectorAttribute(dimensions=3)
+            semantic = VectorIndex(
+                index_name="semantic-index",
+                vector_attribute="embedding",
+                inline_filters=["filter_flag"],
+            )
+
+
+def test_inherited_vector_index_is_bound_independently() -> None:
+    class BaseProduct(Model):
+        model_config = ModelConfig(table="base-products")
+        pk = StringAttribute(partition_key=True)
+        embedding = VectorAttribute(dimensions=3)
+        semantic = VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+        )
+
+    class ChildProduct(BaseProduct):
+        model_config = ModelConfig(table="child-products")
+
+    assert BaseProduct.semantic is not ChildProduct.semantic
+    assert BaseProduct.semantic._model_class is BaseProduct
+    assert ChildProduct.semantic._model_class is ChildProduct
+
+
+def test_inherited_vector_index_can_be_shadowed() -> None:
+    class BaseProduct(Model):
+        model_config = ModelConfig(table="base-products-shadowed")
+        pk = StringAttribute(partition_key=True)
+        embedding = VectorAttribute(dimensions=3)
+        semantic = VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+        )
+
+    class ChildProduct(BaseProduct):
+        model_config = ModelConfig(table="child-products-shadowed")
+        semantic = None
+
+    assert "semantic" not in ChildProduct._vector_indexes
+    assert ChildProduct.semantic is None
+    assert BaseProduct.semantic._model_class is BaseProduct
 
 
 def test_vector_index_rejects_invalid_projection() -> None:
@@ -85,6 +254,21 @@ def test_vector_index_validates_top_k_and_partition_key() -> None:
             top_k=0,
         )
 
+    class GlobalProduct(Model):
+        model_config = ModelConfig(table="global-products")
+        pk = StringAttribute(partition_key=True)
+        embedding = VectorAttribute(dimensions=3)
+        semantic = VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+        )
+
+    with pytest.raises(ValueError, match="does not define a partition key"):
+        GlobalProduct.semantic.sync_search(
+            [1.0, 0.0, 0.0],
+            partition_key="unexpected",
+        )
+
 
 def test_vector_index_validates_inline_filters() -> None:
     with pytest.raises(ValueError, match="equality comparisons joined by AND"):
@@ -103,17 +287,100 @@ def test_vector_index_validates_inline_filters() -> None:
 
 
 def test_vector_index_builds_partition_and_filter_expression() -> None:
-    vector, expression, names, values = Product.semantic._prepare_search(
+    vector, expression, names, values, projection = Product.semantic._prepare_search(
         [1.0, 0.0, 0.0],
         "TENANT#1",
         Product.category == "books",
         5,
+        as_dict=True,
     )
 
     assert vector == [1.0, 0.0, 0.0]
     assert expression == "#vector_pk = :vector_pk AND #n1 = :v1"
     assert names == {"#vector_pk": "tenant", "#n1": "cat"}
     assert values == {":vector_pk": "TENANT#1", ":v1": "books"}
+    assert projection is None
+
+
+def test_vector_index_serializes_multiple_inline_filters() -> None:
+    vector, expression, names, values, _ = Product.semantic._prepare_search(
+        [1.0, 0.0, 0.0],
+        "TENANT#1",
+        (Product.category == "books") & (Product.category == "reference"),
+        5,
+        as_dict=True,
+    )
+
+    assert vector == [1.0, 0.0, 0.0]
+    assert expression == "#vector_pk = :vector_pk AND (#n1 = :v1 AND #n1 = :v2)"
+    assert names == {"#vector_pk": "tenant", "#n1": "cat"}
+    assert values == {
+        ":vector_pk": "TENANT#1",
+        ":v1": "books",
+        ":v2": "reference",
+    }
+
+
+def test_model_search_builds_explicit_projection() -> None:
+    _, _, names, _, projection = Product.semantic._prepare_search(
+        [1.0, 0.0, 0.0],
+        "TENANT#1",
+        None,
+        5,
+    )
+
+    assert names is not None
+    assert projection is not None
+    projected_names = {names[placeholder] for placeholder in projection.split(", ")}
+    assert projected_names == {"pk", "tenant", "cat", "name", "emb"}
+
+
+def test_vector_index_serializes_partition_and_filter_values() -> None:
+    class Segment(Enum):
+        PREMIUM = "premium"
+
+    class Event(Model):
+        model_config = ModelConfig(table="events")
+        pk = StringAttribute(partition_key=True)
+        occurred_at = DatetimeAttribute()
+        segment = EnumAttribute(Segment)
+        embedding = VectorAttribute(dimensions=2)
+        semantic = VectorIndex(
+            index_name="event-index",
+            vector_attribute="embedding",
+            partition_key="occurred_at",
+            inline_filters=["segment"],
+        )
+
+    occurred_at = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
+    _, _, _, values, _ = Event.semantic._prepare_search(
+        [1.0, 0.0],
+        occurred_at,
+        Event.segment == Segment.PREMIUM,
+        5,
+        as_dict=True,
+    )
+
+    assert values == {
+        ":vector_pk": "2026-08-29T12:00:00+00:00",
+        ":v1": "premium",
+    }
+
+
+def test_vector_index_rejects_model_result_when_required_attributes_are_unavailable() -> None:
+    class Document(Model):
+        model_config = ModelConfig(table="required-documents")
+        pk = StringAttribute(partition_key=True)
+        title = StringAttribute(required=True)
+        embedding = VectorAttribute(dimensions=2)
+        semantic = VectorIndex(
+            index_name="document-index",
+            vector_attribute="embedding",
+            projection="KEYS_ONLY",
+        )
+
+    with pytest.raises(ValueError, match="required model attributes: title"):
+        Document.semantic.sync_search([1.0, 0.0])
 
 
 def test_model_create_table_includes_vector_indexes() -> None:
@@ -123,6 +390,83 @@ def test_model_create_table_includes_vector_indexes() -> None:
 
     kwargs = client.sync_create_table.call_args.kwargs
     assert kwargs["vector_indexes"] == [Product.semantic.to_create_table_definition(Product)]
+    assert kwargs["timeout_seconds"] is None
+
+
+def test_vector_index_lifecycle_forwards_timeout() -> None:
+    client = MagicMock(spec=DynamoDBClient)
+    with patch.object(Product, "_get_client", return_value=client):
+        Product.semantic.sync_create(wait=True, timeout_seconds=42)
+        Product.semantic.sync_delete(wait=True, timeout_seconds=21)
+
+    client.sync_create_vector_index.assert_called_once_with(
+        "products",
+        Product.semantic.to_create_table_definition(Product),
+        wait=True,
+        timeout_seconds=42,
+    )
+    client.sync_delete_vector_index.assert_called_once_with(
+        "products",
+        "semantic-index",
+        wait=True,
+        timeout_seconds=21,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_vector_search_and_lifecycle() -> None:
+    client = MagicMock(spec=DynamoDBClient)
+    client.create_vector_index = AsyncMock()
+    client.describe_vector_index = AsyncMock()
+    client.delete_vector_index = AsyncMock()
+    metrics = pydynox_core.OperationMetrics()
+    client.search_vectors.return_value = VectorSearchResult(
+        [
+            VectorMatch(
+                item={
+                    "pk": "PRODUCT#1",
+                    "tenant": "TENANT#1",
+                    "cat": "books",
+                    "name": "Book",
+                    "emb": [1.0, 0.0, 0.0],
+                },
+                score=0.1,
+            )
+        ],
+        metrics,
+    )
+    client.describe_vector_index.return_value = {
+        "index_name": "semantic-index",
+        "status": "ACTIVE",
+        "backfilling": False,
+        "item_count": 1,
+        "size_bytes": 12,
+        "index_arn": "arn:index",
+        "dimensions": 3,
+        "distance": "COSINE",
+    }
+
+    with patch.object(Product, "_get_client", return_value=client):
+        matches = await Product.semantic.search(
+            [1.0, 0.0, 0.0],
+            partition_key="TENANT#1",
+        )
+        await Product.semantic.create(wait=True, timeout_seconds=42)
+        info = await Product.semantic.describe()
+        await Product.semantic.delete(wait=True, timeout_seconds=21)
+
+    assert matches[0].item.pk == "PRODUCT#1"
+    assert matches.metrics is metrics
+    assert info.status == "ACTIVE"
+    assert info.distance is VectorDistance.COSINE
+    client.create_vector_index.assert_awaited_once()
+    client.describe_vector_index.assert_awaited_once_with("products", "semantic-index")
+    client.delete_vector_index.assert_awaited_once_with(
+        "products",
+        "semantic-index",
+        wait=True,
+        timeout_seconds=21,
+    )
 
 
 def test_model_rejects_provisioned_vector_table() -> None:

--- a/tests/unit/test_vector_index.py
+++ b/tests/unit/test_vector_index.py
@@ -1,0 +1,132 @@
+"""Unit tests for VectorIndex."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydynox import DynamoDBClient, Model, ModelConfig
+from pydynox.attributes import StringAttribute, VectorAttribute
+from pydynox.indexes import VectorDistance, VectorIndex
+
+
+class Product(Model):
+    model_config = ModelConfig(table="products")
+
+    pk = StringAttribute(partition_key=True)
+    tenant_id = StringAttribute(alias="tenant")
+    category = StringAttribute(alias="cat")
+    name = StringAttribute()
+    embedding = VectorAttribute(dimensions=3, alias="emb")
+
+    semantic = VectorIndex(
+        index_name="semantic-index",
+        vector_attribute="embedding",
+        distance=VectorDistance.COSINE,
+        partition_key="tenant_id",
+        inline_filters=["category"],
+        projection=["name", "category"],
+    )
+
+
+def test_vector_index_is_collected_and_bound() -> None:
+    assert Product._vector_indexes["semantic"] is Product.semantic
+    assert Product.semantic._model_class is Product
+
+
+def test_vector_index_create_table_definition_uses_aliases() -> None:
+    assert Product.semantic.to_create_table_definition(Product) == {
+        "index_name": "semantic-index",
+        "vector_attribute": "emb",
+        "dimensions": 3,
+        "distance_function": "COSINE",
+        "partition_key": "tenant",
+        "inline_filters": ["cat"],
+        "projection": "INCLUDE",
+        "non_key_attributes": ["name", "cat"],
+    }
+
+
+def test_vector_index_requires_vector_attribute() -> None:
+    with pytest.raises(ValueError, match="must be a VectorAttribute"):
+
+        class Invalid(Model):
+            model_config = ModelConfig(table="invalid")
+            pk = StringAttribute(partition_key=True)
+            embedding = StringAttribute()
+            semantic = VectorIndex(
+                index_name="semantic-index",
+                vector_attribute="embedding",
+            )
+
+
+def test_vector_index_rejects_invalid_projection() -> None:
+    with pytest.raises(ValueError, match="cannot be empty"):
+        VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+            projection=[],
+        )
+
+    with pytest.raises(ValueError, match="duplicate projection attributes"):
+        VectorIndex(
+            index_name="semantic-index",
+            vector_attribute="embedding",
+            projection=["name", "name"],
+        )
+
+
+def test_vector_index_validates_top_k_and_partition_key() -> None:
+    with pytest.raises(ValueError, match="requires partition_key"):
+        Product.semantic.sync_search([1.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="top_k must be between 1 and 100"):
+        Product.semantic.sync_search(
+            [1.0, 0.0, 0.0],
+            partition_key="TENANT#1",
+            top_k=0,
+        )
+
+
+def test_vector_index_validates_inline_filters() -> None:
+    with pytest.raises(ValueError, match="equality comparisons joined by AND"):
+        Product.semantic.sync_search(
+            [1.0, 0.0, 0.0],
+            partition_key="TENANT#1",
+            where=Product.category.begins_with("book"),
+        )
+
+    with pytest.raises(ValueError, match="is not declared as an inline filter"):
+        Product.semantic.sync_search(
+            [1.0, 0.0, 0.0],
+            partition_key="TENANT#1",
+            where=Product.name == "Book",
+        )
+
+
+def test_vector_index_builds_partition_and_filter_expression() -> None:
+    vector, expression, names, values = Product.semantic._prepare_search(
+        [1.0, 0.0, 0.0],
+        "TENANT#1",
+        Product.category == "books",
+        5,
+    )
+
+    assert vector == [1.0, 0.0, 0.0]
+    assert expression == "#vector_pk = :vector_pk AND #n1 = :v1"
+    assert names == {"#vector_pk": "tenant", "#n1": "cat"}
+    assert values == {":vector_pk": "TENANT#1", ":v1": "books"}
+
+
+def test_model_create_table_includes_vector_indexes() -> None:
+    client = MagicMock(spec=DynamoDBClient)
+    with patch.object(Product, "_get_client", return_value=client):
+        Product.sync_create_table()
+
+    kwargs = client.sync_create_table.call_args.kwargs
+    assert kwargs["vector_indexes"] == [Product.semantic.to_create_table_definition(Product)]
+
+
+def test_model_rejects_provisioned_vector_table() -> None:
+    client = MagicMock(spec=DynamoDBClient)
+    with patch.object(Product, "_get_client", return_value=client):
+        with pytest.raises(ValueError, match="PAY_PER_REQUEST"):
+            Product.sync_create_table(billing_mode="PROVISIONED")

--- a/uv.lock
+++ b/uv.lock
@@ -830,7 +830,7 @@ wheels = [
 
 [[package]]
 name = "pydynox"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -830,7 +830,7 @@ wheels = [
 
 [[package]]
 name = "pydynox"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/zensical.toml
+++ b/zensical.toml
@@ -16,6 +16,7 @@ nav = [
         "guides/models.md",
         "guides/attributes.md",
         "guides/indexes.md",
+        "guides/vector-search.md",
         "guides/single-table.md",
         "guides/conditions.md",
         "guides/query.md",


### PR DESCRIPTION
## Summary

- add `VectorAttribute`, `VectorIndex`, and async/sync vector search
- support vector index creation, lifecycle, capacity metrics, and tracing
- add exact vector search to `MemoryBackend`, tests, and documentation

## Ecosystem demand

Vector search support is also being requested by users of other Python DynamoDB ORMs, including [PynamoDB #1305](https://github.com/pynamodb/PynamoDB/issues/1305). Adding it to pydynox addresses a broader ecosystem need rather than a project-specific use case.

## Validation

- Rust fmt, check, and Clippy
- Ruff and ty
- 840 unit/vector tests passed, 2 skipped
- documentation build

Closes #458